### PR TITLE
Update README to reflect unqualified VDF function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,13 +262,13 @@ CREATE TABLE signals (
 -- Insert sample data
 INSERT INTO signals VALUES (1, '(3,4)'), (2, '(5,12)'), (3, '(-1,2)');
 
--- Query using custom functions (note: functions require extension prefix)
+-- Query using custom functions
 SELECT
   id,
   reading,
-  vsql_complex.complex_abs(reading) AS magnitude,
-  vsql_complex.complex_real(reading) AS real_part,
-  vsql_complex.complex_imag(reading) AS imag_part
+  complex_abs(reading) AS magnitude,
+  complex_real(reading) AS real_part,
+  complex_imag(reading) AS imag_part
 FROM signals;
 
 -- Clean up: Drop table first, then uninstall extension


### PR DESCRIPTION
Removed misleading comment about requiring extension prefix and updated examples to use unqualified function calls, consistent with PR #436 which adds support for unqualified VDF lookup.

VDFs can now be called without qualification (e.g., complex_abs()) as long as there is only one function with that name. Qualified calls (vsql_complex.complex_abs()) are still supported when needed for disambiguation.