### PR TITLE
sdk: don't clobber $BUILD/bin

### DIFF
--- a/villagesql/CMakeLists.txt
+++ b/villagesql/CMakeLists.txt
@@ -130,7 +130,7 @@ set(STABLE_SDK_DIR "${CMAKE_CURRENT_SOURCE_DIR}/stable_sdk/v1")
 # Generate villagesql_config script with version substituted
 configure_file(
   "${STABLE_SDK_DIR}/bin/villagesql_config.in"
-  "${CMAKE_BINARY_DIR}/bin/villagesql_config"
+  "${CMAKE_BINARY_DIR}/sdk/villagesql_config"
   @ONLY
 )
 
@@ -149,7 +149,7 @@ add_custom_target(sdk ALL
 
   # Copy villagesql_config script and make executable
   COMMAND ${CMAKE_COMMAND} -E copy
-    "${CMAKE_BINARY_DIR}/bin/villagesql_config"
+    "${CMAKE_BINARY_DIR}/sdk/villagesql_config"
     "${SDK_STAGING_DIR}/bin/"
   COMMAND chmod +x "${SDK_STAGING_DIR}/bin/villagesql_config"
 


### PR DESCRIPTION
Commit: f9303935694 'Docker: create /server, which is meant to be demo-worthy container (#442)
' copied villagesql_config to $BUILD/bin, which forced the directory to be created, before copying the file to SDK directory.  This prevented $BUILD/bin from being linked to $BUILD/runtime_output_directory.

This switches to use $BUILD/sdk as a staging directory for the file.