### PR TITLE
vef: cleanup (Try)CompareCustomType

### DIFF
--- a/sql/sql_executor.cc
+++ b/sql/sql_executor.cc
@@ -3982,11 +3982,10 @@ static bool cmp_field_value(Field *field, ptrdiff_t diff) {
 
   // Use custom comparison function for custom types
   if (field->has_type_context()) {
-    if (auto result = villagesql::TryCompareCustomType(
-            *field->get_type_context(), field->data_ptr(), value1_length,
-            field->data_ptr() + diff, value2_length)) {
-      return *result != 0;
-    }
+    const auto result = villagesql::CompareCustomType(
+        *field->get_type_context(), field->data_ptr(), value1_length,
+        field->data_ptr() + diff, value2_length);
+    return result != 0;
   }
 
   // Trailing space can't be skipped and length is different

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -328,13 +328,8 @@ int CustomMemCompare(const Item *item, const uchar *data1, size_t len1,
   // Use custom comparison for custom types
   if (item != nullptr && item->has_type_context()) {
     auto *tc = item->get_type_context();
-    if (auto result = TryCompareCustomType(*tc, data1, len1, data2, len2)) {
-      // Handle reverse sort direction in this path only since the comparison
-      // function assumes ASC but memcmp relies on bits being flipped for DESC.
-      res = reverse ? -*result : *result;
-    } else {
-      res = memcmp(data1, data2, min_len);
-    }
+    auto result = CompareCustomType(*tc, data1, len1, data2, len2);
+    res = reverse ? -result : result;
   } else {
     res = memcmp(data1, data2, min_len);
   }

--- a/villagesql/types/util.h
+++ b/villagesql/types/util.h
@@ -140,10 +140,8 @@ extern bool InjectAndEncodeCustomType(Item *item, const TypeContext &tc);
 // Template version that works with both Item and Field types
 // Both Item and Field have has_type_context() and get_type_context() methods
 // Overload for TypeContext with binary data
-inline std::optional<int> TryCompareCustomType(const TypeContext &tc,
-                                               const uchar *data1, size_t len1,
-                                               const uchar *data2,
-                                               size_t len2) {
+inline int CompareCustomType(const TypeContext &tc, const uchar *data1,
+                             size_t len1, const uchar *data2, size_t len2) {
   assert(tc.descriptor());
   return tc.descriptor()->compare_op().invoke(data1, len1, data2, len2);
 }
@@ -156,8 +154,7 @@ std::optional<int> TryCompareCustomType(const T *obj, const uchar *data1,
     return std::nullopt;
   }
 
-  return TryCompareCustomType(*obj->get_type_context(), data1, len1, data2,
-                              len2);
+  return CompareCustomType(*obj->get_type_context(), data1, len1, data2, len2);
 }
 
 // Template overload for comparing two String objects with custom type context
@@ -168,7 +165,7 @@ std::optional<int> TryCompareCustomType(const T *obj, const String &str1,
     return std::nullopt;
   }
 
-  return TryCompareCustomType(
+  return CompareCustomType(
       *obj->get_type_context(), pointer_cast<const uchar *>(str1.ptr()),
       str1.length(), pointer_cast<const uchar *>(str2.ptr()), str2.length());
 }
@@ -181,7 +178,7 @@ inline std::optional<int> TryCompareCustomType(const TypeContext *tc,
     return std::nullopt;
   }
 
-  return TryCompareCustomType(
+  return CompareCustomType(
       *tc, pointer_cast<const uchar *>(str1.ptr()), str1.length(),
       pointer_cast<const uchar *>(str2.ptr()), str2.length());
 }


### PR DESCRIPTION
Drop "Try" from overload that always runs comparison
Return an int since it isn't optional
Remove dead branches