### PR TITLE
vef: add SpecialVdfCall helper

### DIFF
--- a/villagesql/types/special_vdf_call.h
+++ b/villagesql/types/special_vdf_call.h
@@ -1,0 +1,241 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+// SpecialVdfCall<ResultTag, ArgTags...> wraps a VDF function descriptor for
+// repeated calls where the argument and result types are known at compile time.
+// The constructor validates the descriptor, stores the call context, and
+// pre-initializes the type/is_null fields of each input slot once. invoke()
+// updates only the per-call data fields and dispatches to the VDF.
+//
+// Non-overlapping: invoke() is non-const and modifies shared input state.
+// Multiple concurrent invoke() calls on the same object are not safe.
+//
+// Example (IntResult):
+//   SpecialVdfCall<IntResult, CustomArg, CustomArg> call(vdf_);
+//   auto r = call.invoke(BinarySlice{data1, len1}, BinarySlice{data2, len2});
+//   if (!r) LogVSQL(ERROR_LEVEL, "%s: %s", call.name(), call.error_msg());
+//
+// Example (BinaryResult, data in out param to reduce data copy):
+//   SpecialVdfCall<BinaryResult, IntArg> call(vdf_);
+//   auto r = call.invoke(buffer_size, out_buf, max_len);
+//   if (!r) snprintf(error_msg, VEF_MAX_ERROR_LEN, "%s", call.error_msg());
+
+#ifndef VILLAGESQL_TYPES_SPECIAL_VDF_CALL_H_
+#define VILLAGESQL_TYPES_SPECIAL_VDF_CALL_H_
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <optional>
+#include <type_traits>
+
+#include "sql_string.h"
+#include "villagesql/sdk/include/villagesql/abi/types.h"
+
+namespace villagesql {
+
+// Value types for SpecialVdfCall arguments that require both a pointer and a
+// length. Each accepts either a MySQL String (implicit conversion) or an
+// explicit raw pointer + length.
+struct StringSlice {
+  const char *data;
+  size_t len;
+  StringSlice(const char *d, size_t l) : data(d), len(l) {}
+  StringSlice(const String &s) : data(s.ptr()), len(s.length()) {}
+};
+
+struct BinarySlice {
+  const unsigned char *data;
+  size_t len;
+  BinarySlice(const unsigned char *d, size_t l) : data(d), len(l) {}
+  BinarySlice(const String &s)
+      : data(reinterpret_cast<const unsigned char *>(s.ptr())),
+        len(s.length()) {}
+};
+
+// Arg type tags for SpecialVdfCall. Each tag defines:
+//   cpp_t  — the C++ type passed to invoke() for this argument
+//   init() — called once in SpecialVdfCall's constructor to set type/is_null
+//   fill() — called per invoke() to update the per-call data fields
+struct IntArg {
+  using cpp_t = int64_t;
+  static void init(vef_invalue_t &v) {
+    v.type = VEF_TYPE_INT;
+    v.is_null = false;
+  }
+  static void fill(vef_invalue_t &v, int64_t val) { v.int_value = val; }
+};
+
+struct StringArg {
+  using cpp_t = StringSlice;
+  static void init(vef_invalue_t &v) {
+    v.type = VEF_TYPE_STRING;
+    v.is_null = false;
+  }
+  static void fill(vef_invalue_t &v, StringSlice s) {
+    v.str_len = s.len;
+    v.str_value = s.data;
+  }
+};
+
+struct CustomArg {
+  using cpp_t = BinarySlice;
+  static void init(vef_invalue_t &v) {
+    v.type = VEF_TYPE_CUSTOM;
+    v.is_null = false;
+  }
+  static void fill(vef_invalue_t &v, BinarySlice b) {
+    v.bin_len = b.len;
+    v.bin_value = b.data;
+  }
+};
+
+// Result type tags for SpecialVdfCall. The tag determines which invoke()
+// overload is available:
+//   IntResult    → invoke(args...)                    → std::optional<int64_t>
+//   StringResult → invoke(args..., char *, size_t)   → std::optional<size_t>
+//   BinaryResult → invoke(args..., uchar *, size_t)  → std::optional<size_t>
+struct IntResult {};
+struct StringResult {};
+struct BinaryResult {};
+
+template <typename ResultTag, typename... ArgTags>
+class SpecialVdfCall {
+ public:
+  static constexpr size_t kN = sizeof...(ArgTags);
+  static_assert(kN > 0, "SpecialVdfCall requires at least one argument");
+
+  explicit SpecialVdfCall(const vef_func_desc_t *fd) : fd_(fd) {
+    assert(fd != nullptr);
+    assert(fd->prerun == nullptr && fd->postrun == nullptr);
+    ctx_.protocol = fd->protocol;
+    init_types();
+    vdf_args_.user_data = nullptr;
+    vdf_args_.value_count = static_cast<unsigned int>(kN);
+    vdf_args_.values = inputs_;
+  }
+
+  // Not copyable: vdf_args_.values points into inputs_.
+  SpecialVdfCall(const SpecialVdfCall &) = delete;
+  SpecialVdfCall &operator=(const SpecialVdfCall &) = delete;
+
+  // Not movable: vdf_args_.values points into inputs_.
+  SpecialVdfCall(SpecialVdfCall &&) = delete;
+  SpecialVdfCall &operator=(SpecialVdfCall &&) = delete;
+
+  const char *name() const { return fd_->name; }
+  // Error message from the last invoke() call.
+  const char *error_msg() const { return error_msg_; }
+  // Alternate output buffer set by the VDF in the last StringResult invoke(),
+  // or nullptr if the VDF used the caller-provided buffer.
+  const char *alt_str_buf() const { return alt_str_buf_; }
+  // Alternate output buffer set by the VDF in the last BinaryResult invoke(),
+  // or nullptr if the VDF used the caller-provided buffer.
+  const unsigned char *alt_bin_buf() const { return alt_bin_buf_; }
+
+  // For IntResult: fills inputs, calls the VDF, returns the integer result.
+  // Returns nullopt on error; error message available via error_msg().
+  template <typename RT = ResultTag,
+            std::enable_if_t<std::is_same_v<RT, IntResult>, int> = 0>
+  std::optional<int64_t> invoke(typename ArgTags::cpp_t... args) {
+    unsigned int i = 0;
+    ((ArgTags::fill(inputs_[i++], args)), ...);
+    vef_vdf_result_t result = {};
+    result.error_msg = error_msg_;
+    result.type = VEF_RESULT_VALUE;
+    fd_->vdf(&ctx_, &vdf_args_, &result);
+    if (result.type != VEF_RESULT_VALUE) {
+      if (error_msg_[0] == '\0')
+        snprintf(error_msg_, VEF_MAX_ERROR_LEN,
+                 "VDF returned unexpected result type");
+      return std::nullopt;
+    }
+    return result.int_value;
+  }
+
+  // For StringResult: fills inputs, calls the VDF writing into out_buf.
+  // Returns the actual output length on success, nullopt on error.
+  // Error message available via error_msg(). If the VDF returned an alternate
+  // buffer, alt_str_buf() is non-null and holds the output instead.
+  template <typename RT = ResultTag,
+            std::enable_if_t<std::is_same_v<RT, StringResult>, int> = 0>
+  std::optional<size_t> invoke(typename ArgTags::cpp_t... args, char *out_buf,
+                               size_t max_len) {
+    unsigned int i = 0;
+    ((ArgTags::fill(inputs_[i++], args)), ...);
+    alt_str_buf_ = nullptr;
+    vef_vdf_result_t result = {};
+    result.error_msg = error_msg_;
+    result.type = VEF_RESULT_VALUE;
+    result.str_buf = out_buf;
+    result.max_str_len = max_len;
+    result.alt_str_buf = &alt_str_buf_;
+    fd_->vdf(&ctx_, &vdf_args_, &result);
+    if (result.type != VEF_RESULT_VALUE) {
+      if (error_msg_[0] == '\0')
+        snprintf(error_msg_, VEF_MAX_ERROR_LEN,
+                 "VDF returned unexpected result type");
+      return std::nullopt;
+    }
+    return result.actual_len;
+  }
+
+  // For BinaryResult: fills inputs, calls the VDF writing into out_buf.
+  // Returns the actual output length on success, nullopt on error.
+  // Error message available via error_msg(). If the VDF returned an alternate
+  // buffer, alt_bin_buf() is non-null and holds the output instead.
+  template <typename RT = ResultTag,
+            std::enable_if_t<std::is_same_v<RT, BinaryResult>, int> = 0>
+  std::optional<size_t> invoke(typename ArgTags::cpp_t... args,
+                               unsigned char *out_buf, size_t max_len) {
+    unsigned int i = 0;
+    ((ArgTags::fill(inputs_[i++], args)), ...);
+    alt_bin_buf_ = nullptr;
+    vef_vdf_result_t result = {};
+    result.error_msg = error_msg_;
+    result.type = VEF_RESULT_VALUE;
+    result.bin_buf = out_buf;
+    result.max_bin_len = max_len;
+    result.alt_bin_buf = &alt_bin_buf_;
+    fd_->vdf(&ctx_, &vdf_args_, &result);
+    if (result.type != VEF_RESULT_VALUE) {
+      if (error_msg_[0] == '\0')
+        snprintf(error_msg_, VEF_MAX_ERROR_LEN,
+                 "VDF returned unexpected result type");
+      return std::nullopt;
+    }
+    return result.actual_len;
+  }
+
+ private:
+  void init_types() {
+    unsigned int i = 0;
+    ((ArgTags::init(inputs_[i++])), ...);
+  }
+
+  const vef_func_desc_t *fd_;
+  vef_context_t ctx_{};
+  vef_invalue_t inputs_[kN]{};
+  vef_vdf_args_t vdf_args_{};
+  char error_msg_[VEF_MAX_ERROR_LEN]{};
+  char *alt_str_buf_{nullptr};
+  unsigned char *alt_bin_buf_{nullptr};
+};
+
+}  // namespace villagesql
+
+#endif  // VILLAGESQL_TYPES_SPECIAL_VDF_CALL_H_

--- a/villagesql/types/type_decoder.cc
+++ b/villagesql/types/type_decoder.cc
@@ -38,17 +38,7 @@ TypeDecoder::TypeDecoder(const TypeContext &tc, MEM_ROOT &mem_root)
 
   const DecodeOp &op = tc.descriptor()->decode_op();
   if (op.vdf() != nullptr) {
-    vdf_ = op.vdf();
-    assert(vdf_->prerun == nullptr && vdf_->postrun == nullptr);
-    ctx_.protocol = VEF_PROTOCOL_2;
-    input_[0].type = VEF_TYPE_CUSTOM;
-    input_[0].is_null = false;
-    vdf_args_.user_data = nullptr;
-    vdf_args_.value_count = 1;
-    vdf_args_.values = input_;
-    vdf_result_.error_msg = error_msg_;
-    vdf_result_.max_str_len = buffer_size_;
-    vdf_result_.alt_str_buf = &alt_str_buf_;
+    vdf_call_.emplace(op.vdf());
   } else {
     fn_ = op.fn();
   }
@@ -60,9 +50,6 @@ bool TypeDecoder::Init() {
     my_error(ER_OUTOFMEMORY, MYF(ME_FATALERROR), buffer_size_);
     return true;
   }
-  if (vdf_ != nullptr) {
-    vdf_result_.str_buf = buffer_;
-  }
   return false;
 }
 
@@ -70,31 +57,24 @@ bool TypeDecoder::decode(const uchar *data, size_t len, String *out,
                          bool &is_valid) {
   is_valid = true;
 
-  if (vdf_ != nullptr) {
-    input_[0].bin_len = len;
-    input_[0].bin_value = data;
-    vdf_result_.type = VEF_RESULT_VALUE;
-    vdf_result_.actual_len = 0;
-    alt_str_buf_ = nullptr;
-
-    vdf_->vdf(&ctx_, &vdf_args_, &vdf_result_);
-
-    if (vdf_result_.type != VEF_RESULT_VALUE) {
+  if (vdf_call_.has_value()) {
+    auto r = vdf_call_->invoke(BinarySlice{data, len}, buffer_, buffer_size_);
+    if (!r) {
       // TODO(villagesql-beta): log errors.
       is_valid = false;
       return true;
     }
 
-    if (alt_str_buf_ != nullptr) {
+    if (vdf_call_->alt_str_buf() != nullptr) {
       // TODO(villagesql-beta): support caller supplied buffers.
       return true;
     }
-    const size_t actual_len = vdf_result_.actual_len;
-    if (actual_len > buffer_size_) {
+
+    if (*r > buffer_size_) {
       return true;
     }
 
-    out->set(buffer_, actual_len, &my_charset_utf8mb4_bin);
+    out->set(buffer_, *r, &my_charset_utf8mb4_bin);
   } else {
     // TODO(villagesql-beta): remove raw func pointer
     assert(fn_ != nullptr);

--- a/villagesql/types/type_decoder.h
+++ b/villagesql/types/type_decoder.h
@@ -18,11 +18,13 @@
 #define VILLAGESQL_TYPES_TYPE_DECODER_H_
 
 #include <cstddef>
+#include <optional>
 
 #include "my_inttypes.h"
 #include "sql_string.h"
 #include "villagesql/schema/descriptor/type_context.h"
 #include "villagesql/sdk/include/villagesql/abi/types.h"
+#include "villagesql/types/special_vdf_call.h"
 
 struct MEM_ROOT;
 
@@ -74,17 +76,9 @@ class TypeDecoder {
   // fn_ path: function pointer (non-null when not using a VDF)
   vef_decode_func_t fn_{nullptr};
 
-  // VDF path: pre-filled call structures. Constant fields are set once in the
-  // constructor; only input_[0].bin_len, input_[0].bin_value,
-  // vdf_result_.type, vdf_result_.actual_len, and alt_str_buf_ are updated
-  // per decode() call.
-  const vef_func_desc_t *vdf_{nullptr};
-  vef_context_t ctx_{};
-  vef_invalue_t input_[1]{};
-  vef_vdf_args_t vdf_args_{};
-  vef_vdf_result_t vdf_result_{};
-  char error_msg_[VEF_MAX_ERROR_LEN]{};
-  char *alt_str_buf_{nullptr};
+  // VDF path: SpecialVdfCall owns ctx/inputs/vdf_args, error_msg, and alt_buf.
+  // The output buffer (buffer_) is passed per decode() call.
+  std::optional<SpecialVdfCall<StringResult, CustomArg>> vdf_call_{};
 };
 
 }  // namespace villagesql

--- a/villagesql/types/type_encoder.cc
+++ b/villagesql/types/type_encoder.cc
@@ -38,17 +38,7 @@ TypeEncoder::TypeEncoder(const TypeContext *tc, MEM_ROOT &mem_root)
 
   const EncodeOp &op = tc->descriptor()->encode_op();
   if (op.vdf() != nullptr) {
-    vdf_ = op.vdf();
-    assert(vdf_->prerun == nullptr && vdf_->postrun == nullptr);
-    ctx_.protocol = VEF_PROTOCOL_2;
-    input_[0].type = VEF_TYPE_STRING;
-    input_[0].is_null = false;
-    vdf_args_.user_data = nullptr;
-    vdf_args_.value_count = 1;
-    vdf_args_.values = input_;
-    vdf_result_.error_msg = error_msg_;
-    vdf_result_.max_bin_len = buffer_size_;
-    vdf_result_.alt_bin_buf = &alt_bin_buf_;
+    vdf_call_.emplace(op.vdf());
   } else {
     fn_ = op.fn();
   }
@@ -60,45 +50,36 @@ bool TypeEncoder::Init() {
     my_error(ER_OUTOFMEMORY, MYF(ME_FATALERROR), buffer_size_);
     return true;
   }
-  if (vdf_ != nullptr) {
-    vdf_result_.bin_buf = pointer_cast<uchar *>(buffer_);
-  }
   return false;
 }
 
 String *TypeEncoder::encode(const String &from, bool &is_valid) {
   is_valid = true;
 
-  if (vdf_ != nullptr) {
-    input_[0].str_len = from.length();
-    input_[0].str_value = from.ptr();
-    vdf_result_.type = VEF_RESULT_VALUE;
-    vdf_result_.actual_len = 0;
-    alt_bin_buf_ = nullptr;
-
-    vdf_->vdf(&ctx_, &vdf_args_, &vdf_result_);
-
-    if (vdf_result_.type != VEF_RESULT_VALUE) {
+  if (vdf_call_.has_value()) {
+    auto r =
+        vdf_call_->invoke(from, pointer_cast<uchar *>(buffer_), buffer_size_);
+    if (!r) {
       // TODO(villagesql-beta): log warnings for errors
       is_valid = false;
       return nullptr;
     }
 
-    if (alt_bin_buf_ != nullptr) {
-      // TODO(villagesql-beta): support the extension returning alternate buffers
+    if (vdf_call_->alt_bin_buf() != nullptr) {
+      // TODO(villagesql-beta): support the extension returning alternate
+      // buffers
       is_valid = false;
       return nullptr;
     }
 
     // TODO(villagesql-beta): report an error or warning when the VDF overruns
     // the buffer rather than silently returning invalid
-    const size_t actual_len = vdf_result_.actual_len;
-    if (actual_len > buffer_size_) {
+    if (*r > buffer_size_) {
       is_valid = false;
       return nullptr;
     }
 
-    result_.set(buffer_, actual_len, &my_charset_bin);
+    result_.set(buffer_, *r, &my_charset_bin);
   } else {
     // TODO(villagesql-beta): Remove suport for these raw functions
     assert(fn_ != nullptr);

--- a/villagesql/types/type_encoder.h
+++ b/villagesql/types/type_encoder.h
@@ -18,10 +18,12 @@
 #define VILLAGESQL_TYPES_TYPE_ENCODER_H_
 
 #include <cstddef>
+#include <optional>
 
 #include "sql_string.h"
 #include "villagesql/schema/descriptor/type_context.h"
 #include "villagesql/sdk/include/villagesql/abi/types.h"
+#include "villagesql/types/special_vdf_call.h"
 
 struct MEM_ROOT;
 
@@ -81,17 +83,9 @@ class TypeEncoder {
   // fn_ path: function pointer (non-null when not using a VDF)
   vef_encode_func_t fn_{nullptr};
 
-  // VDF path: pre-filled call structures. Constant fields are set once in the
-  // constructor; only input_[0].str_len, input_[0].str_value,
-  // vdf_result_.type, vdf_result_.actual_len, and alt_bin_buf_ are updated
-  // per encode() call.
-  const vef_func_desc_t *vdf_{nullptr};
-  vef_context_t ctx_{};
-  vef_invalue_t input_[1]{};
-  vef_vdf_args_t vdf_args_{};
-  vef_vdf_result_t vdf_result_{};
-  char error_msg_[VEF_MAX_ERROR_LEN]{};
-  unsigned char *alt_bin_buf_{nullptr};
+  // VDF path: SpecialVdfCall owns ctx/inputs/vdf_args, error_msg, and alt_buf.
+  // The output buffer (buffer_) is passed per encode() call.
+  std::optional<SpecialVdfCall<BinaryResult, StringArg>> vdf_call_{};
 };
 
 }  // namespace villagesql

--- a/villagesql/types/type_op.cc
+++ b/villagesql/types/type_op.cc
@@ -26,6 +26,7 @@
 #include "sql_string.h"
 #include "template_utils.h"
 #include "villagesql/include/error.h"
+#include "villagesql/types/special_vdf_call.h"
 
 namespace villagesql {
 
@@ -35,38 +36,14 @@ int CompareOp::invoke(const unsigned char *data1, size_t len1,
     return fn_(data1, len1, data2, len2);
   }
 
-  assert(vdf_ != nullptr);
-  const vef_func_desc_t *fd = vdf_;
-  assert(fd->prerun == nullptr && fd->postrun == nullptr);
-  vef_context_t ctx = {VEF_PROTOCOL_2};
-
-  vef_invalue_t inputs[2];
-  inputs[0].type = VEF_TYPE_CUSTOM;
-  inputs[0].is_null = false;
-  inputs[0].bin_len = len1;
-  inputs[0].bin_value = data1;
-  inputs[1].type = VEF_TYPE_CUSTOM;
-  inputs[1].is_null = false;
-  inputs[1].bin_len = len2;
-  inputs[1].bin_value = data2;
-
-  vef_vdf_args_t vdf_args = {nullptr, 2, inputs};
-
-  char error_msg[VEF_MAX_ERROR_LEN] = {};
-  vef_vdf_result_t vdf_result = {};
-  vdf_result.type = VEF_RESULT_VALUE;
-  vdf_result.error_msg = error_msg;
-  vdf_result.int_value = 0;
-
-  fd->vdf(&ctx, &vdf_args, &vdf_result);
-
-  if (vdf_result.type != VEF_RESULT_VALUE) {
-    LogVSQL(ERROR_LEVEL, "compare VDF '%s' returned error: %s", fd->name,
-            error_msg);
+  SpecialVdfCall<IntResult, CustomArg, CustomArg> call(vdf_);
+  auto result = call.invoke(BinarySlice{data1, len1}, BinarySlice{data2, len2});
+  if (!result) {
+    LogVSQL(ERROR_LEVEL, "compare VDF '%s' returned error: %s", call.name(),
+            call.error_msg());
     return 0;
   }
-
-  return static_cast<int>(vdf_result.int_value);
+  return static_cast<int>(*result);
 }
 
 size_t HashOp::invoke(const unsigned char *data, size_t len) const {
@@ -74,115 +51,47 @@ size_t HashOp::invoke(const unsigned char *data, size_t len) const {
     return fn_(data, len);
   }
 
-  assert(vdf_ != nullptr);
-  const vef_func_desc_t *fd = vdf_;
-  assert(fd->prerun == nullptr && fd->postrun == nullptr);
-  vef_context_t ctx = {VEF_PROTOCOL_2};
-
-  vef_invalue_t input[1];
-  input[0].type = VEF_TYPE_CUSTOM;
-  input[0].is_null = false;
-  input[0].bin_len = len;
-  input[0].bin_value = data;
-
-  vef_vdf_args_t vdf_args = {nullptr, 1, input};
-
-  char error_msg[VEF_MAX_ERROR_LEN] = {};
-  vef_vdf_result_t vdf_result = {};
-  vdf_result.type = VEF_RESULT_VALUE;
-  vdf_result.error_msg = error_msg;
-  vdf_result.int_value = 0;
-
-  fd->vdf(&ctx, &vdf_args, &vdf_result);
-
-  if (vdf_result.type != VEF_RESULT_VALUE) {
-    LogVSQL(ERROR_LEVEL, "hash VDF '%s' returned error: %s", fd->name,
-            error_msg);
+  SpecialVdfCall<IntResult, CustomArg> call(vdf_);
+  auto result = call.invoke(BinarySlice{data, len});
+  if (!result) {
+    LogVSQL(ERROR_LEVEL, "hash VDF '%s' returned error: %s", call.name(),
+            call.error_msg());
     return 0;
   }
-
-  return static_cast<size_t>(vdf_result.int_value);
+  return static_cast<size_t>(*result);
 }
 
 bool IntToParamsOp::invoke(int64_t value, std::string *result,
                            char *error_msg) const {
-  assert(vdf_ != nullptr);
-  const vef_func_desc_t *fd = vdf_;
-  assert(fd->prerun == nullptr && fd->postrun == nullptr);
-  vef_context_t ctx = {VEF_PROTOCOL_2};
-
-  vef_invalue_t input[1];
-  input[0].type = VEF_TYPE_INT;
-  input[0].is_null = false;
-  input[0].int_value = value;
-
-  vef_vdf_args_t vdf_args = {nullptr, 1, input};
-
   char str_buffer[VEF_MAX_TYPE_PARAMS_STRING_LEN];
-  char *alt_str_buf = nullptr;
-  vef_vdf_result_t vdf_result = {};
-  vdf_result.type = VEF_RESULT_VALUE;
-  vdf_result.error_msg = error_msg;
-  vdf_result.str_buf = str_buffer;
-  vdf_result.max_str_len = sizeof(str_buffer);
-  vdf_result.actual_len = 0;
-  vdf_result.alt_str_buf = &alt_str_buf;
-
-  fd->vdf(&ctx, &vdf_args, &vdf_result);
-
-  if (vdf_result.type == VEF_RESULT_ERROR) {
-    return true;
-  }
-  if (vdf_result.type != VEF_RESULT_VALUE) {
-    snprintf(error_msg, VEF_MAX_ERROR_LEN,
-             "int_to_params VDF returned unexpected result type");
+  SpecialVdfCall<StringResult, IntArg> call(vdf_);
+  auto r = call.invoke(value, str_buffer, sizeof(str_buffer));
+  if (!r) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN, "%s", call.error_msg());
     return true;
   }
 
-  const char *result_data = (alt_str_buf != nullptr) ? alt_str_buf : str_buffer;
-  *result = std::string(result_data, vdf_result.actual_len);
+  const char *result_data =
+      call.alt_str_buf() != nullptr ? call.alt_str_buf() : str_buffer;
+  *result = std::string(result_data, *r);
   return false;
 }
 
 bool ResolveParamsOp::invoke(const std::string &params_str,
                              ResolvedTypeParams *result,
                              char *error_msg) const {
-  assert(vdf_ != nullptr);
-  const vef_func_desc_t *fd = vdf_;
-  assert(fd->prerun == nullptr && fd->postrun == nullptr);
-  vef_context_t ctx = {VEF_PROTOCOL_2};
-
-  vef_invalue_t input[1];
-  input[0].type = VEF_TYPE_STRING;
-  input[0].is_null = false;
-  input[0].str_len = params_str.size();
-  input[0].str_value = params_str.c_str();
-
-  vef_vdf_args_t vdf_args = {nullptr, 1, input};
-
   char str_buffer[VEF_MAX_TYPE_PARAMS_STRING_LEN];
-  char *alt_str_buf = nullptr;
-  vef_vdf_result_t vdf_result = {};
-  vdf_result.type = VEF_RESULT_VALUE;
-  vdf_result.error_msg = error_msg;
-  vdf_result.str_buf = str_buffer;
-  vdf_result.max_str_len = sizeof(str_buffer);
-  vdf_result.actual_len = 0;
-  vdf_result.alt_str_buf = &alt_str_buf;
-
-  fd->vdf(&ctx, &vdf_args, &vdf_result);
-
-  if (vdf_result.type == VEF_RESULT_ERROR) {
-    return true;
-  }
-  if (vdf_result.type != VEF_RESULT_VALUE) {
-    snprintf(error_msg, VEF_MAX_ERROR_LEN,
-             "resolve_params VDF returned unexpected result type");
+  SpecialVdfCall<StringResult, StringArg> call(vdf_);
+  auto r = call.invoke(StringSlice{params_str.c_str(), params_str.size()},
+                       str_buffer, sizeof(str_buffer));
+  if (!r) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN, "%s", call.error_msg());
     return true;
   }
 
-  const char *result_data = (alt_str_buf != nullptr) ? alt_str_buf : str_buffer;
-  std::string output(result_data, vdf_result.actual_len);
+  const char *result_data =
+      call.alt_str_buf() != nullptr ? call.alt_str_buf() : str_buffer;
+  std::string output(result_data, *r);
 
   // Parse "persisted_length,max_decode_buffer_length"
   size_t comma = output.find(',');
@@ -212,37 +121,14 @@ bool ResolveParamsOp::invoke(const std::string &params_str,
 
 bool IntrinsicDefaultOp::invoke(int64_t buffer_size, unsigned char *buffer,
                                 size_t *length, char *error_msg) const {
-  assert(vdf_ != nullptr);
-  const vef_func_desc_t *fd = vdf_;
-  assert(fd->prerun == nullptr && fd->postrun == nullptr);
-  vef_context_t ctx = {VEF_PROTOCOL_2};
-
-  vef_invalue_t input[1];
-  input[0].type = VEF_TYPE_INT;
-  input[0].is_null = false;
-  input[0].int_value = buffer_size;
-
-  vef_vdf_args_t vdf_args = {nullptr, 1, input};
-
-  vef_vdf_result_t vdf_result = {};
-  vdf_result.type = VEF_RESULT_VALUE;
-  vdf_result.error_msg = error_msg;
-  vdf_result.bin_buf = buffer;
-  vdf_result.max_bin_len = static_cast<size_t>(buffer_size);
-  vdf_result.actual_len = 0;
-
-  fd->vdf(&ctx, &vdf_args, &vdf_result);
-
-  if (vdf_result.type == VEF_RESULT_ERROR) {
-    return true;
-  }
-  if (vdf_result.type != VEF_RESULT_VALUE) {
-    snprintf(error_msg, VEF_MAX_ERROR_LEN,
-             "intrinsic_default VDF returned unexpected result type");
+  SpecialVdfCall<BinaryResult, IntArg> call(vdf_);
+  auto r = call.invoke(buffer_size, buffer, static_cast<size_t>(buffer_size));
+  if (!r) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN, "%s", call.error_msg());
     return true;
   }
 
-  *length = vdf_result.actual_len;
+  *length = *r;
   return false;
 }
 


### PR DESCRIPTION
## Description

SpecialVdfCall is a helper class used to call "annointed" VDFs used for things like "encode", "decode", "hash", etc. where the API "signature" is know at build time.  It handles setting up the args, and will handle ABI compatibility in the future.


## Related Issue

N/A

## How was this tested?

Ran villagesql tests.

## Checklist

- [X] I have signed the CLA
- [X] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [X] I have added or updated tests as appropriate
- [X] My changes maintain compatibility with upstream MySQL 8.4
