### PR TITLE
dev_server: add release workflows

### DIFF
--- a/.github/workflows/release-dev-server.yml
+++ b/.github/workflows/release-dev-server.yml
@@ -1,0 +1,162 @@
+name: Release Dev Server
+
+# Triggered by version tags (e.g. 0.0.3, 0.0.3-dev) or manually.
+# Builds the dev-server package for all three target platforms, runs the
+# integration tests on each, then creates a GitHub Release with the tarballs.
+#
+# Runner requirements:
+#   - [self-hosted, linux, x86_64]    - existing CI runner
+#   - linux on arm64 (GitHub-hosted)  - Apple Silicon
+#   - macos-latest (GitHub-hosted)    - Apple Silicon
+
+on:
+  push:
+    tags:
+      - '[0-9]*.[0-9]*.[0-9]*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to build a release for (e.g. 0.0.3)'
+        required: true
+
+jobs:
+  build-package:
+    name: Build (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: [self-hosted, linux, x86_64]
+            platform: linux-x86_64
+            os: linux
+          - runner: ubuntu-24.04-arm
+            platform: linux-aarch64
+            os: linux
+          - runner: macos-latest
+            platform: macos-arm64
+            os: macos
+
+    env:
+      BUILD_DIR: ${{ github.workspace }}/build
+      OUTPUT_DIR: ${{ github.workspace }}/output
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          path: source
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Install dependencies (Linux)
+        if: matrix.os == 'linux'
+        run: sudo source/scripts/setup_linux_build_env.sh
+
+      - name: Install dependencies (macOS)
+        if: matrix.os == 'macos'
+        run: brew install openssl cmake
+
+      - name: Setup ccache
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ runner.os }}-${{ runner.arch }}-release-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-release
+            ${{ runner.os }}-${{ runner.arch }}-build
+          max-size: 2G
+          append-timestamp: false
+
+      - name: Cache Boost
+        uses: actions/cache@v4
+        with:
+          path: /tmp/boost
+          key: boost-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Build and package dev server
+        run: |
+          mkdir -p "$BUILD_DIR" "$OUTPUT_DIR"
+
+          EXTRA_FLAGS="-DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost"
+          EXTRA_FLAGS="$EXTRA_FLAGS -DCMAKE_C_COMPILER_LAUNCHER=ccache"
+          EXTRA_FLAGS="$EXTRA_FLAGS -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
+          if [ "${{ matrix.os }}" = "macos" ]; then
+            EXTRA_FLAGS="$EXTRA_FLAGS -DWITH_SSL=$(brew --prefix openssl)"
+          fi
+
+          BUILD_DIR="$BUILD_DIR" \
+          OUTPUT_DIR="$OUTPUT_DIR" \
+          CMAKE_EXTRA_FLAGS="$EXTRA_FLAGS" \
+            source/scripts/make_villagesql_dev_server.sh
+
+      - name: Run integration tests
+        run: |
+          TARBALL=$(ls "$OUTPUT_DIR"/*.tar.gz | head -1)
+          TEST_DIR=$(mktemp -d)
+          tar xzf "$TARBALL" -C "$TEST_DIR"
+          PACKAGE_DIR=$(echo "$TEST_DIR"/villagesql-dev-server-*)
+          source/villagesql/dev_server/tests/integration_test.sh "$PACKAGE_DIR"
+          rm -rf "$TEST_DIR"
+
+      - name: Upload package
+        uses: actions/upload-artifact@v4
+        with:
+          name: devserver-${{ matrix.platform }}
+          path: ${{ env.OUTPUT_DIR }}/*.tar.gz
+
+  create-release:
+    name: Create GitHub Release
+    needs: build-package
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Determine release tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download all packages
+        uses: actions/download-artifact@v4
+        with:
+          pattern: devserver-*
+          merge-multiple: true
+          path: packages/
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          cat > notes.md << 'EOF'
+          VillageSQL development server ${{ steps.tag.outputs.tag }}.
+
+          See QUICKSTART.md (included in each tarball) for setup instructions.
+
+          ## Platforms
+
+          | File | Platform |
+          |------|----------|
+          | `villagesql-dev-server-${{ steps.tag.outputs.tag }}-linux-x86_64.tar.gz` | Linux x86_64 |
+          | `villagesql-dev-server-${{ steps.tag.outputs.tag }}-linux-aarch64.tar.gz` | Linux arm64 |
+          | `villagesql-dev-server-${{ steps.tag.outputs.tag }}-macos-arm64.tar.gz` | macOS Apple Silicon |
+
+          ## Quick Start
+
+          ```bash
+          tar xzf villagesql-dev-server-${{ steps.tag.outputs.tag }}-<platform>.tar.gz
+          cd villagesql-dev-server-${{ steps.tag.outputs.tag }}-<platform>/
+          ./villagesql init
+          ./villagesql start
+          ./villagesql connect
+          ```
+          EOF
+
+          gh release create "${{ steps.tag.outputs.tag }}" packages/*.tar.gz \
+            --title "VillageSQL Dev Server ${{ steps.tag.outputs.tag }}" \
+            --notes-file notes.md

--- a/scripts/make_villagesql_dev_server.sh
+++ b/scripts/make_villagesql_dev_server.sh
@@ -83,6 +83,8 @@ fi
 
 # Get platform info
 PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')"
+# Use "macos" to match MySQL's naming convention (uname returns "darwin" on macOS)
+[[ "$PLATFORM" == "darwin" ]] && PLATFORM="macos"
 ARCH="$(uname -m)"
 
 PACKAGE_NAME="villagesql-dev-server-${VSQL_VERSION}-${PLATFORM}-${ARCH}"


### PR DESCRIPTION
## Description

Creates dev_server tgz for the three platforms:
* macOS on Apple Silicon
* linux on Arm64
* linux on intel

## Related Issue

#30 

## How was this tested?

Github Action will be tested in production

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
