### PR TITLE
Column Storage: InnoDB storage ABI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -205,6 +205,7 @@ When adding VillageSQL features:
     - `TODO(villagesql-rebase):` - Check during MySQL version rebases
     - `TODO(villagesql-crash):` - Known crash
     - `TODO(villagesql-windows):` - Known problems with supporting Windows
+    - `TODO(villagesql-indexing):` - Related to indexing work
 - Avoid `/* */` style comments except for copyright headers
 - Do NOT use section separator comments (e.g., `// ===== Serialization =====`) - they're hard to maintain and add little value
 - Do NOT add explanatory comments on #include lines (e.g., `#include "my_sys.h" // my_ok, my_printf_error`) - they're hard to maintain

--- a/scripts/villint.sh
+++ b/scripts/villint.sh
@@ -164,6 +164,7 @@ ALLOWED_TODO_TAGS=(
   "villagesql-rebase"
   "villagesql-windows"
   "villagesql-blob"
+  "villagesql-indexing"
 )
 
 INVALID_TODO_TAGS_FOUND=0

--- a/storage/innobase/CMakeLists.txt
+++ b/storage/innobase/CMakeLists.txt
@@ -266,7 +266,8 @@ SET(INNOBASE_SOURCES
   ut/ut0ut.cc
   ut/ut0vec.cc
   ut/ut0wqueue.cc
-  villagesql/custom_column.cc)
+  villagesql/custom_column.cc
+  villagesql/storage_abi.cc)
 
 # https://gcc.gnu.org/bugzilla/show_bug.cgi?id=98753
 IF(MY_COMPILER_IS_GNU AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 11)

--- a/storage/innobase/villagesql/storage_abi.cc
+++ b/storage/innobase/villagesql/storage_abi.cc
@@ -1,0 +1,503 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+// C ABI implementation for InnoDB storage interface
+
+#include "villagesql/sdk/include/villagesql/abi/storage.h"
+
+#include <cstdio>
+#include <iterator>
+#include <new>
+
+#include "buf0buf.h"
+#include "fil0types.h"
+#include "fsp0fsp.h"
+#include "log0chkp.h"
+#include "mach0data.h"
+#include "mtr0log.h"
+#include "mtr0mtr.h"
+#include "page0page.h"
+#include "ut0dbg.h"
+
+// Lookup table mapping ABI latch types (VEF_STORAGE_PAGE_LATCH_*)
+// to corresponding InnoDB RW latch modes. ABI latch values are
+// contiguous integers starting at 0.
+static constexpr std::array<ulint, 4> kInnodbLatch{
+    RW_NO_LATCH,  // VEF_STORAGE_PAGE_LATCH_NONE
+    RW_S_LATCH,   // VEF_STORAGE_PAGE_LATCH_SHARED
+    RW_SX_LATCH,  // VEF_STORAGE_PAGE_LATCH_SHARED_EXCLUSIVE
+    RW_X_LATCH    // VEF_STORAGE_PAGE_LATCH_EXCLUSIVE
+};
+
+static ulint abi_to_innodb_latch(vef_storage_latch_t latch) {
+  const auto idx = static_cast<size_t>(latch);
+  if (latch < 0 || idx >= kInnodbLatch.size()) {
+    return RW_NO_LATCH;
+  }
+  return kInnodbLatch[idx];
+}
+
+// Mini-Transaction Interface Implementation
+
+extern "C" vef_storage_mtr_ref_t vef_storage_mtr_start(
+    void *buffer, uint32_t buffer_size, uint32_t *required_size,
+    uint32_t *required_alignment, char *error_msg, uint32_t error_msg_len) {
+  constexpr uint32_t mtr_size = sizeof(mtr_t);
+  constexpr uint32_t mtr_alignment = alignof(mtr_t);
+
+  if (required_size != nullptr) {
+    *required_size = mtr_size;
+  }
+
+  if (required_alignment != nullptr) {
+    *required_alignment = mtr_alignment;
+  }
+
+  if (buffer == nullptr) {
+    return nullptr;
+  }
+
+  if (buffer_size < mtr_size) {
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len,
+               "Buffer too small: need %u bytes, got %u", mtr_size,
+               buffer_size);
+    }
+    return nullptr;
+  }
+
+  // Check alignment
+  static_assert((mtr_alignment & (mtr_alignment - 1)) == 0,
+                "mtr_alignment must be power of two");
+
+  auto addr = reinterpret_cast<std::uintptr_t>(buffer);
+  if ((addr & (mtr_alignment - 1)) != 0) {
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len,
+               "Buffer misaligned: need %u-byte alignment", mtr_alignment);
+    }
+    return nullptr;
+  }
+
+  // Placement new to construct mtr_t in the provided buffer
+  mtr_t *mtr = new (buffer) mtr_t();
+  mtr->start();
+
+  return static_cast<vef_storage_mtr_ref_t>(mtr);
+}
+
+extern "C" void vef_storage_mtr_commit(vef_storage_mtr_ref_t ref) {
+  if (ref == nullptr) {
+    return;
+  }
+
+  mtr_t *mtr = static_cast<mtr_t *>(ref);
+  mtr->commit();
+  mtr->~mtr_t();
+}
+
+// Storage Segment Interface Implementation
+
+extern "C" int vef_storage_segment_create(
+    vef_storage_space_ref_t space_ref, uint8_t num_segments,
+    vef_storage_trx_ref_t trx_ref, vef_storage_page_num_t *root_page_num_p,
+    char *error_msg, uint32_t error_msg_len) {
+  if (root_page_num_p == nullptr || num_segments == 0) {
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len, "Invalid argument: %s",
+               root_page_num_p == nullptr ? "root_page_num_p is null"
+                                          : "num_segments is 0");
+    }
+    return VEF_STORAGE_ERROR_INVALID_ARGUMENT;
+  }
+
+  *root_page_num_p = VEF_STORAGE_PAGE_NUM_INVALID;
+  (void)trx_ref;  // TODO(villagesql-indexing): DDL logging
+
+  uint8_t num_allocated = 0;
+
+  // Create first segment
+  log_free_check();
+
+  mtr_t mtr;
+  mtr.start();
+
+  // First segment: allocate root page
+  uint16_t seg_offset =
+      VEF_STORAGE_PAGE_HEADER_SIZE + VEF_STORAGE_SEGMENT_NUM_SEGMENTS_SIZE;
+  buf_block_t *block = fseg_create(space_ref, 0, seg_offset, &mtr);
+
+  if (block == nullptr) {
+    ib::warn() << "VillageSQL: Innodb: First Segment allocation failed.";
+    mtr.commit();
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len, "First segment allocation failed");
+    }
+    return VEF_STORAGE_ERROR_OUT_OF_SPACE;
+  }
+
+  vef_storage_page_num_t root_page_num = block->get_page_no();
+  *root_page_num_p = root_page_num;
+
+  // Set page type
+  unsigned char *page_data = buf_block_get_frame(block);
+  mlog_write_ulint(page_data + FIL_PAGE_TYPE, FIL_PAGE_TYPE_BLOB, MLOG_2BYTES,
+                   &mtr);
+
+  // Write number of segments
+  num_allocated = 1;
+  mlog_write_ulint(page_data + VEF_STORAGE_PAGE_HEADER_SIZE, num_allocated,
+                   MLOG_1BYTE, &mtr);
+  mtr.commit();
+
+  // Create remaining segments
+  while (num_allocated < num_segments) {
+    log_free_check();
+    mtr.start();
+
+    seg_offset = VEF_STORAGE_PAGE_HEADER_SIZE +
+                 VEF_STORAGE_SEGMENT_NUM_SEGMENTS_SIZE +
+                 num_allocated * VEF_STORAGE_SEGMENT_HEADER_SIZE;
+
+    block = fseg_create(space_ref, root_page_num, seg_offset, &mtr);
+
+    if (block == nullptr) {
+      ib::warn() << "VillageSQL: Innodb: Segment allocation failed after"
+                 << " allocating " << num_allocated << " of " << num_segments
+                 << " segments.";
+      mtr.commit();
+      if (error_msg != nullptr && error_msg_len > 0) {
+        snprintf(error_msg, error_msg_len,
+                 "Segment allocation failed after %u of %u segments",
+                 num_allocated, num_segments);
+      }
+      // TODO(villagesql-indexing): Remove after DDL logging is implemented.
+      // This is best effort to clean the segments and won't work if server
+      // crashes before or while performing this step. The segments would leak
+      // in worst case.
+      (void)vef_storage_segment_drop(space_ref, trx_ref, root_page_num, nullptr,
+                                     0);
+      return VEF_STORAGE_ERROR_OUT_OF_SPACE;
+    }
+    num_allocated++;
+    page_data = buf_block_get_frame(block);
+    mlog_write_ulint(page_data + VEF_STORAGE_PAGE_HEADER_SIZE, num_allocated,
+                     MLOG_1BYTE, &mtr);
+    mtr.commit();
+  }
+  return VEF_STORAGE_SUCCESS;
+}
+
+// Free all pages of one segment, reloading the root page between mtr restarts,
+// then free the segment header. Leaves mtr active on return.
+static int vef_drop_one_segment(vef_storage_space_ref_t space_ref,
+                                vef_storage_page_num_t root_page_num,
+                                uint8_t seg_no, buf_block_t **root_block_p,
+                                mtr_t *mtr) {
+  uint16_t seg_offset = VEF_STORAGE_PAGE_HEADER_SIZE +
+                        VEF_STORAGE_SEGMENT_NUM_SEGMENTS_SIZE +
+                        seg_no * VEF_STORAGE_SEGMENT_HEADER_SIZE;
+
+  unsigned char *page_data = buf_block_get_frame(*root_block_p);
+  unsigned char *seg_header = page_data + seg_offset;
+
+  // Free all pages except the segment header. Commit and restart the mtr
+  // between steps, reloading the root page each time.
+  while (!fseg_free_step_not_header(seg_header, false, mtr)) {
+    mtr->commit();
+    log_free_check();
+    mtr->start();
+
+    page_size_t page_size(UNIV_PAGE_SIZE, UNIV_PAGE_SIZE, false);
+    page_id_t page_id(space_ref, root_page_num);
+    *root_block_p =
+        buf_page_get(page_id, page_size, RW_X_LATCH, UT_LOCATION_HERE, mtr);
+
+    if (*root_block_p == nullptr) {
+      return VEF_STORAGE_ERROR_PAGE_LOAD;
+    }
+
+    // Re-get header pointer after reloading the page
+    page_data = buf_block_get_frame(*root_block_p);
+    seg_header = page_data + seg_offset;
+  }
+
+  // Free the segment header
+  while (!fseg_free_step(seg_header, false, mtr));
+
+  return VEF_STORAGE_SUCCESS;
+}
+
+extern "C" int vef_storage_segment_drop(vef_storage_space_ref_t space_ref,
+                                        vef_storage_trx_ref_t trx_ref,
+                                        vef_storage_page_num_t root_page_num,
+                                        char *error_msg,
+                                        uint32_t error_msg_len) {
+  // TODO(villagesql-indexing): DDL log to defer drop
+  (void)trx_ref;
+
+  log_free_check();
+
+  mtr_t mtr;
+  mtr.start();
+
+  page_size_t page_size(UNIV_PAGE_SIZE, UNIV_PAGE_SIZE, false);
+  page_id_t page_id(space_ref, root_page_num);
+
+  buf_block_t *block =
+      buf_page_get(page_id, page_size, RW_X_LATCH, UT_LOCATION_HERE, &mtr);
+
+  if (block == nullptr) {
+    ib::warn() << "VillageSQL: Innodb: Segment drop failed while loading"
+               << " root page with page ID: " << page_id;
+    mtr.commit();
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len,
+               "Segment drop failed to load root page %u in space %u",
+               root_page_num, space_ref);
+    }
+    return VEF_STORAGE_ERROR_PAGE_LOAD;
+  }
+
+  unsigned char *page_data = buf_block_get_frame(block);
+  uint8_t num_segments =
+      mach_read_from_1(page_data + VEF_STORAGE_PAGE_HEADER_SIZE);
+
+  if (num_segments == 0) {
+    mtr.commit();
+    return VEF_STORAGE_SUCCESS;
+  }
+
+  auto num_total = num_segments;
+
+  do {
+    --num_segments;
+
+    int err = vef_drop_one_segment(space_ref, root_page_num, num_segments,
+                                   &block, &mtr);
+
+    if (err != 0) {
+      auto num_dropped = num_total - (num_segments + 1);
+      ib::warn() << "VillageSQL: Innodb: Segment drop failed after"
+                 << " dropping " << num_dropped << " of "
+                 << static_cast<uint32_t>(num_total) << " segments.";
+      mtr.commit();
+      if (error_msg != nullptr && error_msg_len > 0) {
+        snprintf(error_msg, error_msg_len,
+                 "Segment drop failed after dropping %u of %u segments",
+                 static_cast<uint32_t>(num_dropped),
+                 static_cast<uint32_t>(num_total));
+      }
+      return VEF_STORAGE_ERROR_PAGE_LOAD;
+    }
+
+    page_data = buf_block_get_frame(block);
+    mlog_write_ulint(page_data + VEF_STORAGE_PAGE_HEADER_SIZE, num_segments,
+                     MLOG_1BYTE, &mtr);
+  } while (num_segments > 0);
+
+  mtr.commit();
+  return VEF_STORAGE_SUCCESS;
+}
+
+// Page Interface Implementation
+
+extern "C" int vef_storage_page_load(
+    vef_storage_block_ref_t *block_p, uint64_t *position_p,
+    unsigned char **data_p, uint32_t *data_size_p,
+    vef_storage_space_ref_t space_ref, vef_storage_page_num_t page_num,
+    vef_storage_latch_t latch_mode, vef_storage_mtr_ref_t mtr_ref,
+    char *error_msg, uint32_t error_msg_len) {
+  if (block_p == nullptr || position_p == nullptr || data_p == nullptr ||
+      data_size_p == nullptr || mtr_ref == nullptr) {
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len, "Invalid argument: null pointer");
+    }
+    return VEF_STORAGE_ERROR_INVALID_ARGUMENT;
+  }
+
+  mtr_t *mtr = static_cast<mtr_t *>(mtr_ref);
+
+  page_size_t page_size(UNIV_PAGE_SIZE, UNIV_PAGE_SIZE, false);
+  page_id_t page_id(space_ref, page_num);
+
+  ulint innodb_latch = abi_to_innodb_latch(latch_mode);
+  ulint savepoint = mtr->get_savepoint();
+
+  buf_block_t *buf_block =
+      buf_page_get(page_id, page_size, innodb_latch, UT_LOCATION_HERE, mtr);
+
+  if (buf_block == nullptr) {
+    ib::warn() << "VillageSQL: Innodb: Failed to load page for page ID: "
+               << page_id;
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len, "Failed to load page %u in space %u",
+               page_num, space_ref);
+    }
+    return VEF_STORAGE_ERROR_PAGE_LOAD;
+  }
+
+  *block_p = static_cast<vef_storage_block_ref_t>(buf_block);
+  *position_p = static_cast<uint64_t>(savepoint);
+  *data_p = buf_block_get_frame(buf_block);
+  *data_size_p = UNIV_PAGE_SIZE;
+
+  return VEF_STORAGE_SUCCESS;
+}
+
+extern "C" int vef_storage_page_allocate_and_load(
+    vef_storage_block_ref_t *block_p, vef_storage_page_num_t *page_num_p,
+    unsigned char **data_p, uint32_t *data_size_p,
+    unsigned char *segment_header, vef_storage_mtr_ref_t mtr_ref,
+    char *error_msg, uint32_t error_msg_len) {
+  if (block_p == nullptr || page_num_p == nullptr || data_p == nullptr ||
+      data_size_p == nullptr || segment_header == nullptr ||
+      mtr_ref == nullptr) {
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len, "Invalid argument: null pointer");
+    }
+    return VEF_STORAGE_ERROR_INVALID_ARGUMENT;
+  }
+
+  mtr_t *mtr = static_cast<mtr_t *>(mtr_ref);
+
+  buf_block_t *buf_block =
+      fseg_alloc_free_page(segment_header, 0, FSP_NO_DIR, mtr);
+  if (buf_block == nullptr) {
+    ib::warn() << "VillageSQL: Innodb: Failed to allocate page.";
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len, "Failed to allocate page");
+    }
+    return VEF_STORAGE_ERROR_OUT_OF_SPACE;
+  }
+
+  // Set page type
+  unsigned char *page_data = buf_block_get_frame(buf_block);
+  mlog_write_ulint(page_data + FIL_PAGE_TYPE, FIL_PAGE_TYPE_BLOB, MLOG_2BYTES,
+                   mtr);
+
+  *block_p = static_cast<vef_storage_block_ref_t>(buf_block);
+  *page_num_p = buf_block->get_page_no();
+  *data_p = page_data;
+  *data_size_p = UNIV_PAGE_SIZE;
+
+  return VEF_STORAGE_SUCCESS;
+}
+
+extern "C" int vef_storage_page_latch(vef_storage_block_ref_t block,
+                                      uint64_t position,
+                                      vef_storage_latch_t latch,
+                                      vef_storage_mtr_ref_t mtr_ref,
+                                      char *error_msg, uint32_t error_msg_len) {
+  if (block == nullptr || mtr_ref == nullptr) {
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len, "Invalid argument: %s is null",
+               block == nullptr ? "block" : "mtr_ref");
+    }
+    return VEF_STORAGE_ERROR_INVALID_ARGUMENT;
+  }
+
+  mtr_t *mtr = static_cast<mtr_t *>(mtr_ref);
+  buf_block_t *buf_block = static_cast<buf_block_t *>(block);
+
+  ulint savepoint = static_cast<ulint>(position);
+
+  if (latch == VEF_STORAGE_PAGE_LATCH_SHARED_EXCLUSIVE) {
+    mtr->sx_latch_at_savepoint(savepoint, buf_block);
+  } else if (latch == VEF_STORAGE_PAGE_LATCH_EXCLUSIVE) {
+    mtr->x_latch_at_savepoint(savepoint, buf_block);
+  }
+  return VEF_STORAGE_SUCCESS;
+}
+
+extern "C" int vef_storage_page_release(vef_storage_block_ref_t block,
+                                        uint64_t position,
+                                        vef_storage_mtr_ref_t mtr_ref,
+                                        char *error_msg,
+                                        uint32_t error_msg_len) {
+  if (block == nullptr || mtr_ref == nullptr) {
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len, "Invalid argument: %s is null",
+               block == nullptr ? "block" : "mtr_ref");
+    }
+    return VEF_STORAGE_ERROR_INVALID_ARGUMENT;
+  }
+
+  mtr_t *mtr = static_cast<mtr_t *>(mtr_ref);
+  buf_block_t *buf_block = static_cast<buf_block_t *>(block);
+
+  ulint savepoint = static_cast<ulint>(position);
+  mtr->release_block_at_savepoint(savepoint, buf_block);
+
+  return VEF_STORAGE_SUCCESS;
+}
+
+extern "C" uint32_t vef_storage_page_get_size(
+    vef_storage_space_ref_t space_ref) {
+  (void)space_ref;  // Currently all pages are same size
+  return UNIV_PAGE_SIZE;
+}
+
+extern "C" void vef_storage_page_write_integer(
+    vef_storage_block_ref_t block, vef_storage_page_offset_t offset,
+    uint64_t value, vef_storage_integer_bytes_t bytes,
+    vef_storage_mtr_ref_t mtr_ref) {
+  if (block == nullptr || mtr_ref == nullptr) {
+    return;
+  }
+
+  buf_block_t *buf_block = static_cast<buf_block_t *>(block);
+  unsigned char *page_data = buf_block_get_frame(buf_block);
+  mtr_t *mtr = static_cast<mtr_t *>(mtr_ref);
+
+  unsigned char *loc = page_data + offset;
+  auto val = static_cast<ulint>(value);
+
+  switch (bytes) {
+    case VEF_STORAGE_PAGE_INT_1BYTE:
+      mlog_write_ulint(loc, val, MLOG_1BYTE, mtr);
+      break;
+    case VEF_STORAGE_PAGE_INT_2BYTES:
+      mlog_write_ulint(loc, val, MLOG_2BYTES, mtr);
+      break;
+    case VEF_STORAGE_PAGE_INT_4BYTES:
+      mlog_write_ulint(loc, val, MLOG_4BYTES, mtr);
+      break;
+    case VEF_STORAGE_PAGE_INT_8BYTES:
+      mlog_write_ull(loc, val, mtr);
+      break;
+    default:
+      ib::warn() << "VillageSQL: Innodb: Invalid integer type to write: "
+                 << val;
+  }
+}
+
+extern "C" void vef_storage_page_write_string(vef_storage_block_ref_t block,
+                                              vef_storage_page_offset_t offset,
+                                              const unsigned char *str,
+                                              uint32_t len,
+                                              vef_storage_mtr_ref_t mtr_ref) {
+  if (block == nullptr || str == nullptr || mtr_ref == nullptr) {
+    return;
+  }
+
+  buf_block_t *buf_block = static_cast<buf_block_t *>(block);
+  unsigned char *page_data = buf_block_get_frame(buf_block);
+  mtr_t *mtr = static_cast<mtr_t *>(mtr_ref);
+
+  unsigned char *loc = page_data + offset;
+  mlog_write_string(loc, str, len, mtr);
+}

--- a/villagesql/sdk/include/villagesql/abi/storage.h
+++ b/villagesql/sdk/include/villagesql/abi/storage.h
@@ -20,8 +20,42 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-// Storage Types and functions for column data stored by the extension.
+#ifdef __cplusplus
+extern "C" {
+#endif
 
+// ===========================================================================
+// ABI Header Overview
+// ===========================================================================
+// This header contains two logical sections:
+//
+// Section 1: Custom Type Storage Interfaces
+// -----------------------------------------
+// Defines storage-related types and function signatures for column data of
+// custom types implemented by an extension.
+
+// If an extension chooses to manage the storage of columns for its custom
+// types, it must implement these functions. They allow the extension to
+// control how values of the custom type are stored, retrieved, and managed
+// at the column level.
+//
+// Section 2: InnoDB Storage Engine Interfaces
+// -------------------------------------------
+// Defines the ABI interfaces implemented by InnoDB and exposed to extensions.
+//
+// These interfaces allow an extension to use InnoDB’s storage infrastructure
+// to persist and access its data through the InnoDB buffer pool. Extensions
+// are typically expected to call these functions through a language-specific
+// wrapper layer (for example a C++ convenience API).
+//
+// InnoDB owns and manages the underlying storage structures such as segments
+// and pages, including their layout and life cycle. The extension may define
+// the format used to store its data within the page payload area (for example,
+// for custom column storage or index structures).
+// ===========================================================================
+
+// Section 1: Custom Type Storage Interfaces
+// -----------------------------------------
 // InnoDB tablespace reference.
 typedef uint32_t vef_storage_space_ref_t;
 
@@ -48,16 +82,17 @@ typedef struct {
 // Empty column reference.
 #define VEF_STORAGE_EMPTY_COLUMN_REF 0
 // Alignment requirement for arena allocators
-#define VEF_STORAGE_ALLOCATOR_ALIGNMENT 8
+#define VEF_STORAGE_MIN_ALLOCATOR_ALIGNMENT 8
 
 // Opaque storage arena context managed by VillageSQL/InnoDB.
 typedef struct vef_storage_arena vef_storage_arena_t;
 
 // Arena allocator callback type
 // Arena Allocator function is implemented by VillageSQL. It returns a pointer
-// to size bytes aligned to VEF_STORAGE_ALLOCATOR_ALIGNMENT. Author can use
-// the Allocator callback to allocate memory for context. The allocated memory
-// would be tracked and freed by InnoDB after the storage is dropped.
+// to size bytes aligned to at least VEF_STORAGE_MIN_ALLOCATOR_ALIGNMENT.
+// Author can use the Allocator callback to allocate memory for context. The
+// allocated memory would be tracked and freed by InnoDB after the storage is
+// dropped.
 typedef void *(*vef_storage_arena_func_t)(vef_storage_arena_t *arena_ctx,
                                           uint32_t size);
 
@@ -81,23 +116,26 @@ typedef struct {
 //   arena_alloc - Allocator for the storage context; memory is freed when
 //                 storage is dropped
 //   storage     - Output: newly created storage context
-//   error_msg   - Output: error description on failure (VEF_MAX_ERROR_LEN)
+//   error_msg   - Output: error description on failure
+//   error_msg_len - length of error message buffer
 // Returns false on success, true on error (writes to error_msg).
 typedef bool (*vef_type_storage_create_func_t)(
     vef_storage_space_ref_t space_ref, vef_storage_trx_ref_t trx_ref,
     uint32_t col_len, vef_storage_arena_t *arena_ctx,
     vef_storage_arena_func_t arena_alloc, vef_storage_ctx_t **storage,
-    char *error_msg);
+    char *error_msg, uint32_t error_msg_len);
 
 // Drop storage for column data.
 // Parameters:
 //   storage   - Storage context to drop
 //   trx_ref   - Transaction under which the drop runs
-//   error_msg - Output: error description on failure (VEF_MAX_ERROR_LEN)
+//   error_msg - Output: error description on failure
+//   error_msg_len - length of error message buffer
 // Returns false on success, true on error (writes to error_msg).
 typedef bool (*vef_type_storage_drop_func_t)(vef_storage_ctx_t *storage,
                                              vef_storage_trx_ref_t trx_ref,
-                                             char *error_msg);
+                                             char *error_msg,
+                                             uint32_t error_msg_len);
 
 // Load existing storage from a storage reference.
 // Parameters:
@@ -106,12 +144,13 @@ typedef bool (*vef_type_storage_drop_func_t)(vef_storage_ctx_t *storage,
 //   arena_alloc - Allocator for the storage context; memory is freed when
 //                 storage is dropped
 //   storage     - Output: loaded storage context
-//   error_msg   - Output: error description on failure (VEF_MAX_ERROR_LEN)
+//   error_msg   - Output: error description on failure
+//   error_msg_len - length of error message buffer
 // Returns false on success, true on error (writes to error_msg).
 typedef bool (*vef_type_storage_load_func_t)(
     vef_storage_ref_t storage_ref, vef_storage_arena_t *arena_ctx,
     vef_storage_arena_func_t arena_alloc, vef_storage_ctx_t **storage,
-    char *error_msg);
+    char *error_msg, uint32_t error_msg_len);
 
 // Insert column data into column storage along with transaction reference.
 // Parameters:
@@ -121,13 +160,14 @@ typedef bool (*vef_type_storage_load_func_t)(
 //   col_data     - Column data to store
 //   rowid_prefix - Row identifier prefix
 //   col_ref      - Output: reference to the newly inserted column entry
-//   error_msg    - Output: error description on failure (VEF_MAX_ERROR_LEN)
+//   error_msg    - Output: error description on failure
+//   error_msg_len - length of error message buffer
 // Returns false on success, true on error (writes to error_msg).
 typedef bool (*vef_type_storage_insert_func_t)(
     vef_storage_ctx_t *storage, vef_storage_mtr_ref_t mctx,
     vef_storage_trx_ref_t trx_ref, vef_storage_col_data_t col_data,
     vef_storage_col_data_t rowid_prefix, vef_storage_col_ref_t *col_ref,
-    char *error_msg);
+    char *error_msg, uint32_t error_msg_len);
 
 // Fetch column data reference pointer acquiring appropriate latch.
 // Parameters:
@@ -138,13 +178,14 @@ typedef bool (*vef_type_storage_insert_func_t)(
 //   rowid_prefix   - Output: row identifier prefix
 //   trx_ref        - Output: transaction that last wrote this entry
 //   delete_marked  - Output: whether the entry is marked for deletion
-//   error_msg      - Output: error description on failure (VEF_MAX_ERROR_LEN)
+//   error_msg      - Output: error description on failure
+//   error_msg_len  - length of error message buffer
 // Returns false on success, true on error (writes to error_msg).
 typedef bool (*vef_type_storage_select_func_t)(
     vef_storage_ctx_t *storage, vef_storage_mtr_ref_t mctx,
     vef_storage_col_ref_t col_ref, vef_storage_col_data_t *col_data,
     vef_storage_col_data_t *rowid_prefix, vef_storage_trx_ref_t *trx_ref,
-    bool *delete_marked, char *error_msg);
+    bool *delete_marked, char *error_msg, uint32_t error_msg_len);
 
 // Mark or unmark column as deleted by the transaction.
 // Parameters:
@@ -153,12 +194,13 @@ typedef bool (*vef_type_storage_select_func_t)(
 //   trx_ref     - Transaction performing the operation
 //   col_ref     - Reference to the column entry to mark
 //   delete_mark - true to mark as deleted, false to unmark
-//   error_msg   - Output: error description on failure (VEF_MAX_ERROR_LEN)
+//   error_msg   - Output: error description on failure
+//   error_msg_len - length of error message buffer
 // Returns false on success, true on error (writes to error_msg).
 typedef bool (*vef_type_storage_mark_delete_func_t)(
     vef_storage_ctx_t *storage, vef_storage_mtr_ref_t mctx,
     vef_storage_trx_ref_t trx_ref, vef_storage_col_ref_t col_ref,
-    bool delete_mark, char *error_msg);
+    bool delete_mark, char *error_msg, uint32_t error_msg_len);
 
 // Remove column only if it has the matching transaction reference.
 // Parameters:
@@ -166,16 +208,19 @@ typedef bool (*vef_type_storage_mark_delete_func_t)(
 //   mctx      - Mini-transaction context
 //   trx_ref   - Transaction to match with the record to purge
 //   col_ref   - Reference to the column entry to purge
-//   error_msg - Output: error description on failure (VEF_MAX_ERROR_LEN)
+//   error_msg - Output: error description on failure
+//   error_msg_len - length of error message buffer
 // Returns false on success, true on error (writes to error_msg).
 typedef bool (*vef_type_storage_purge_func_t)(vef_storage_ctx_t *storage,
                                               vef_storage_mtr_ref_t mctx,
                                               vef_storage_trx_ref_t trx_ref,
                                               vef_storage_col_ref_t col_ref,
-                                              char *error_msg);
+                                              char *error_msg,
+                                              uint32_t error_msg_len);
 
-// Storage interface version constants.
-#define VEF_STORAGE_INTF_VERSION_1 1
+// Custom type storage interface version constants.
+#define VEF_STORAGE_TYPE_INTF_VERSION_1 1
+#define VEF_STORAGE_TYPE_INTF_VERSION VEF_STORAGE_TYPE_INTF_VERSION_1
 
 // Storage interface provided by an extension for custom column storage.
 // The extension sets version to the storage interface version it implements.
@@ -184,10 +229,10 @@ typedef bool (*vef_type_storage_purge_func_t)(vef_storage_ctx_t *storage,
 // determine which fields are present. New fields must always be appended at
 // the end so that older structs remain a valid prefix.
 typedef struct {
-  // Must be set to one of the VEF_STORAGE_INTF_VERSION_* constants above.
+  // Must be set to one of the VEF_STORAGE_TYPE_INTF_VERSION_* constants above.
   uint32_t version;
 
-  // version >= VEF_STORAGE_INTF_VERSION_1
+  // version >= VEF_STORAGE_TYPE_INTF_VERSION_1
   vef_type_storage_create_func_t create;
   vef_type_storage_drop_func_t drop;
   vef_type_storage_load_func_t load;
@@ -196,5 +241,247 @@ typedef struct {
   vef_type_storage_mark_delete_func_t mark_delete;
   vef_type_storage_purge_func_t purge;
 } vef_type_storage_intf_t;
+
+// Section 2: InnoDB Storage Engine Interfaces
+// -------------------------------------------
+// TODO(villagesql-windows): Export symbols with __declspec(dllexport) on
+// Windows so that extensions can link against these functions.
+
+// Storage engine interface version constants.
+#define VEF_STORAGE_SE_INTF_VERSION_1 1
+#define VEF_STORAGE_SE_INTF_VERSION VEF_STORAGE_SE_INTF_VERSION_1
+#define VEF_STORAGE_MINIMUM_SE_INTF_VERSION VEF_STORAGE_SE_INTF_VERSION_1
+
+// ABI compatibility guarantee:
+// 1. Extensions built against any ABI version in the range
+//    [VEF_STORAGE_MINIMUM_SE_INTF_VERSION, VEF_STORAGE_SE_INTF_VERSION]
+//    MUST continue to work with this server.
+//
+// 2. Extensions built against an ABI version greater than
+//    VEF_STORAGE_SE_INTF_VERSION MUST fail to load.
+//
+// 3. Extensions built against an ABI version lower than
+//    VEF_STORAGE_MINIMUM_SE_INTF_VERSION MUST fail to load.
+//
+// ABI change rules:
+// 1. Functions:
+//     A. Modify existing functions (signature, behavior, ownership): NEVER
+//     B. Add new functions: Bump VEF_STORAGE_SE_INTF_VERSION
+//
+// 2. Structures/Enums:
+//     A. Modify, remove, reorder existing fields: NEVER
+//     B. Add new fields at the end only (with size/version guarding):
+//        Bump VEF_STORAGE_SE_INTF_VERSION
+//
+// 3. Constants:
+//     A. Constants appearing in this file affects ABI-visible memory layout,
+//        buffer size, on-disk format, or extension-visible limit.
+//
+//     B. If a constant must be changed:
+//        Bump VEF_STORAGE_MINIMUM_SE_INTF_VERSION and document the break.
+//
+
+// Constants defining the on-page storage format used by the storage engine.
+// These values are part of the persistent page layout and must not change
+// without an incompatible format revision.
+#define VEF_STORAGE_SEGMENT_NUM_SEGMENTS_SIZE 1
+#define VEF_STORAGE_SEGMENT_HEADER_SIZE 10
+#define VEF_STORAGE_PAGE_HEADER_SIZE 38
+#define VEF_STORAGE_PAGE_TRAILER_SIZE 8
+// Page header offsets for linked list pointers
+#define VEF_STORAGE_FIL_PAGE_PREV 8
+#define VEF_STORAGE_FIL_PAGE_NEXT 12
+
+// Sentinel values representing an invalid number, position.
+#define VEF_STORAGE_PAGE_NUM_INVALID UINT32_MAX
+#define VEF_STORAGE_PAGE_POS_INVALID UINT64_MAX
+
+// Error codes returned by ABI functions
+#define VEF_STORAGE_SUCCESS 0
+#define VEF_STORAGE_ERROR_GENERAL 1
+#define VEF_STORAGE_ERROR_OUT_OF_MEMORY 2
+#define VEF_STORAGE_ERROR_OUT_OF_SPACE 3
+#define VEF_STORAGE_ERROR_INVALID_ARGUMENT 4
+#define VEF_STORAGE_ERROR_PAGE_LOAD 5
+
+//=======================================
+// VEF Storage Mini-Transaction Interface
+//=======================================
+
+// Start a mini-transaction (mtr)
+// @param buffer - Pre-allocated buffer for mtr (can be stack or heap allocated)
+// @param buffer_size - Size of the provided buffer in bytes
+// @param required_size - Output: actual size needed if buffer is too small
+// @param required_alignment - Output: required alignment for the buffer
+// @param error_msg - Output: error description on failure
+// @param error_msg_len - length of error message buffer
+// @return Non-NULL mtr reference on success, NULL if buffer too small
+//         (caller should allocate larger buffer and retry)
+vef_storage_mtr_ref_t vef_storage_mtr_start(void *buffer, uint32_t buffer_size,
+                                            uint32_t *required_size,
+                                            uint32_t *required_alignment,
+                                            char *error_msg,
+                                            uint32_t error_msg_len);
+
+// Commit a mini-transaction, making all changes durable
+// @param ref - Mini-transaction reference from vef_storage_mtr_start
+void vef_storage_mtr_commit(vef_storage_mtr_ref_t ref);
+
+//==============================
+// VEF Storage Segment Interface
+//==============================
+// Page number
+typedef uint32_t vef_storage_page_num_t;
+
+// Buffer pool block reference. The block reference remains valid only while
+// the page is latched.
+typedef void *vef_storage_block_ref_t;
+
+// Create storage segments within a tablespace
+// Creates num_segments segments and returns the root page number.
+// The root page contains headers for all created segments.
+// @param space_ref - Tablespace identifier
+// @param num_segments - Number of segments to create (1-255)
+// @param trx_ref - Transaction ID for DDL logging
+// @param root_page_num_p - Output: root page number containing segment headers
+// @param error_msg - Output: error description on failure
+// @param error_msg_len - length of error message buffer
+// @return VEF_STORAGE_SUCCESS on success, error code on failure
+int vef_storage_segment_create(vef_storage_space_ref_t space_ref,
+                               uint8_t num_segments,
+                               vef_storage_trx_ref_t trx_ref,
+                               vef_storage_page_num_t *root_page_num_p,
+                               char *error_msg, uint32_t error_msg_len);
+
+// Drop storage segments associated with a root page
+// Frees all pages allocated to the segments on the root page.
+// @param space_ref - Tablespace identifier
+// @param trx_ref - Transaction ID for DDL logging
+// @param root_page_num - Root page number from vef_storage_segment_create
+// @param error_msg - Output: error description on failure
+// @param error_msg_len - length of error message buffer
+// @return VEF_STORAGE_SUCCESS on success, error code on failure
+int vef_storage_segment_drop(vef_storage_space_ref_t space_ref,
+                             vef_storage_trx_ref_t trx_ref,
+                             vef_storage_page_num_t root_page_num,
+                             char *error_msg, uint32_t error_msg_len);
+
+//===========================
+// VEF Storage Page Interface
+//===========================
+
+// Offset within a page.
+typedef uint16_t vef_storage_page_offset_t;
+
+// Page latch types.
+typedef int32_t vef_storage_latch_t;
+#define VEF_STORAGE_PAGE_LATCH_NONE 0
+#define VEF_STORAGE_PAGE_LATCH_SHARED 1
+#define VEF_STORAGE_PAGE_LATCH_SHARED_EXCLUSIVE 2
+#define VEF_STORAGE_PAGE_LATCH_EXCLUSIVE 3
+
+// Integer byte sizes for page read/write operations
+typedef int32_t vef_storage_integer_bytes_t;
+#define VEF_STORAGE_PAGE_INT_1BYTE 0
+#define VEF_STORAGE_PAGE_INT_2BYTES 1
+#define VEF_STORAGE_PAGE_INT_4BYTES 2
+#define VEF_STORAGE_PAGE_INT_8BYTES 3
+
+// Load an existing page into the buffer pool and latch it
+// @param block_p - Output: opaque buffer pool block reference
+// @param position_p - Output: position for later latch/release
+// @param data_p - Output: pointer to page data (valid while latched)
+// @param data_size_p - Output: size of page data in bytes
+// @param space_ref - Tablespace identifier
+// @param page_num - Page number to load
+// @param latch_mode - Latch type (SHARED, EXCLUSIVE, etc.)
+// @param mtr_ref - Mini-transaction reference
+// @param error_msg - Output: error description on failure
+// @param error_msg_len - length of error message buffer
+// @return VEF_STORAGE_SUCCESS on success, error code on failure
+int vef_storage_page_load(vef_storage_block_ref_t *block_p,
+                          uint64_t *position_p, unsigned char **data_p,
+                          uint32_t *data_size_p,
+                          vef_storage_space_ref_t space_ref,
+                          vef_storage_page_num_t page_num,
+                          vef_storage_latch_t latch_mode,
+                          vef_storage_mtr_ref_t mtr_ref, char *error_msg,
+                          uint32_t error_msg_len);
+
+// Allocate a new page from a segment, load it into the buffer pool, and set
+// its page type
+// @param block_p - Output: opaque buffer pool block reference
+// @param page_num_p - Output: page number of the allocated page
+// @param data_p - Output: pointer to page data (valid while latched)
+// @param data_size_p - Output: size of page data in bytes
+// @param segment_header - Pointer to segment header to allocate from
+// @param mtr_ref - Mini-transaction reference
+// @param error_msg - Output: error description on failure
+// @param error_msg_len - length of error message buffer
+// @return VEF_STORAGE_SUCCESS on success, error code on failure
+int vef_storage_page_allocate_and_load(vef_storage_block_ref_t *block_p,
+                                       vef_storage_page_num_t *page_num_p,
+                                       unsigned char **data_p,
+                                       uint32_t *data_size_p,
+                                       unsigned char *segment_header,
+                                       vef_storage_mtr_ref_t mtr_ref,
+                                       char *error_msg, uint32_t error_msg_len);
+
+// Latch a page that was loaded with VEF_STORAGE_PAGE_LATCH_NONE
+// @param block - Buffer pool block reference from vef_storage_page_load
+// @param position - Position handle from vef_storage_page_load
+// @param latch - requested latch type, actual latch type acquired
+// @param mtr_ref - Mini-transaction reference
+// @param error_msg - Output: error description on failure
+// @param error_msg_len - length of error message buffer
+// @return VEF_STORAGE_SUCCESS on success, error code on failure
+int vef_storage_page_latch(vef_storage_block_ref_t block, uint64_t position,
+                           vef_storage_latch_t latch,
+                           vef_storage_mtr_ref_t mtr_ref, char *error_msg,
+                           uint32_t error_msg_len);
+
+// Release a page latch acquired via vef_storage_page_load or
+// vef_storage_page_latch
+// @param block - Buffer pool block reference
+// @param position - Position handle from vef_storage_page_load
+// @param mtr_ref - Mini-transaction reference
+// @param error_msg - Output: error description on failure
+// @param error_msg_len - length of error message buffer
+// @return VEF_STORAGE_SUCCESS on success, error code on failure
+int vef_storage_page_release(vef_storage_block_ref_t block, uint64_t position,
+                             vef_storage_mtr_ref_t mtr_ref, char *error_msg,
+                             uint32_t error_msg_len);
+
+// Get the logical page size for a tablespace
+// @param space_ref - Tablespace identifier
+// @return Page size in bytes (typically 4K, 8K, 16K, 32K, or 64K)
+uint32_t vef_storage_page_get_size(vef_storage_space_ref_t space_ref);
+
+// Write an integer to a page with WAL/redo logging
+// @param block - Buffer pool block reference (page must be latched)
+// @param offset - Byte offset within page (must be in valid range)
+// @param value - Integer value to write
+// @param bytes - Size: VEF_STORAGE_PAGE_INT_1BYTE/2BYTES/4BYTES/8BYTES
+// @param mtr_ref - Mini-transaction reference
+void vef_storage_page_write_integer(vef_storage_block_ref_t block,
+                                    vef_storage_page_offset_t offset,
+                                    uint64_t value,
+                                    vef_storage_integer_bytes_t bytes,
+                                    vef_storage_mtr_ref_t mtr_ref);
+
+// Write a byte string to a page with WAL/redo logging
+// @param block - Buffer pool block reference (page must be latched)
+// @param offset - Byte offset within page
+// @param str - Byte string to write
+// @param len - Length of string in bytes
+// @param mtr_ref - Mini-transaction reference
+void vef_storage_page_write_string(vef_storage_block_ref_t block,
+                                   vef_storage_page_offset_t offset,
+                                   const unsigned char *str, uint32_t len,
+                                   vef_storage_mtr_ref_t mtr_ref);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
 
 #endif  // VILLAGESQL_ABI_STORAGE_H_


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the change. -->
Add ABI interfaces implemented by InnoDB that allow extensions to use the InnoDB storage infrastructure.

The interfaces provide access to mini-transactions, segments, and buffer pool pages so extensions can persist custom column storage and index structures.

Includes the internal wrapper implementation mapping the ABI interfaces to InnoDB primitives.

## Related Issue

<!-- Link the GitHub issue this PR addresses, e.g. Fixes #123 -->

## How was this tested?

<!-- Describe how you verified your changes. Include test commands you ran. -->

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
