### PR TITLE
TypeParameters in SpecialVdfCall

### DIFF
--- a/villagesql/types/special_vdf_call.h
+++ b/villagesql/types/special_vdf_call.h
@@ -16,20 +16,23 @@
 
 // SpecialVdfCall<ResultTag, ArgTags...> wraps a VDF function descriptor for
 // repeated calls where the argument and result types are known at compile time.
-// The constructor validates the descriptor, stores the call context, and
-// pre-initializes the type/is_null fields of each input slot once. invoke()
-// updates only the per-call data fields and dispatches to the VDF.
+// The constructor sets up the call context and argument arrays. init() must be
+// called once after construction to initialize the type/is_null fields of each
+// input slot. invoke() updates only the per-call data fields and dispatches to
+// the VDF.
 //
 // Non-overlapping: invoke() is non-const and modifies shared input state.
 // Multiple concurrent invoke() calls on the same object are not safe.
 //
 // Example (IntResult):
 //   SpecialVdfCall<IntResult, CustomArg, CustomArg> call(vdf_);
+//   call.init();
 //   auto r = call.invoke(BinarySlice{data1, len1}, BinarySlice{data2, len2});
 //   if (!r) LogVSQL(ERROR_LEVEL, "%s: %s", call.name(), call.error_msg());
 //
 // Example (BinaryResult, data in out param to reduce data copy):
 //   SpecialVdfCall<BinaryResult, IntArg> call(vdf_);
+//   call.init();
 //   auto r = call.invoke(buffer_size, out_buf, max_len);
 //   if (!r) snprintf(error_msg, VEF_MAX_ERROR_LEN, "%s", call.error_msg());
 
@@ -67,14 +70,28 @@ struct BinarySlice {
         len(s.length()) {}
 };
 
+struct TypeParameterSlice {
+  unsigned int count;
+  const char *const *keys;
+  const char *const *values;
+  TypeParameterSlice() : count(0), keys(nullptr), values(nullptr) {}
+  TypeParameterSlice(unsigned int c, const char *const *k, const char *const *v)
+      : count(c), keys(k), values(v) {}
+};
+
+// Placeholder for arg tags that need no init-time data.
+struct NoInitData {};
+
 // Arg type tags for SpecialVdfCall. Each tag defines:
 //   cpp_t  — the C++ type passed to invoke() for this argument
-//   init() — called once in SpecialVdfCall's constructor to set type/is_null
+//   init_t — the type passed to init() for one-time setup of this argument
+//   init() — called once by SpecialVdfCall::init() to set type/is_null
 //   fill() — called per invoke() to update the per-call data fields
 struct IntArg {
   using cpp_t = int64_t;
+  using init_t = NoInitData;
   template <typename T>
-  static void init(T &v) {
+  static void init(T &v, NoInitData) {
     v.type = VEF_TYPE_INT;
     v.is_null = false;
   }
@@ -86,8 +103,9 @@ struct IntArg {
 
 struct StringArg {
   using cpp_t = StringSlice;
+  using init_t = NoInitData;
   template <typename T>
-  static void init(T &v) {
+  static void init(T &v, NoInitData) {
     v.type = VEF_TYPE_STRING;
     v.is_null = false;
   }
@@ -100,10 +118,16 @@ struct StringArg {
 
 struct CustomArg {
   using cpp_t = BinarySlice;
+  using init_t = TypeParameterSlice;
   template <typename T>
-  static void init(T &v) {
+  static void init(T &v, TypeParameterSlice tp) {
     v.type = VEF_TYPE_CUSTOM;
     v.is_null = false;
+    if constexpr (std::is_same_v<T, vef_invalue_t>) {
+      v.type_params.count = tp.count;
+      v.type_params.keys = tp.keys;
+      v.type_params.values = tp.values;
+    }
   }
   template <typename T>
   static void fill(T &v, BinarySlice b) {
@@ -135,11 +159,26 @@ class SpecialVdfCall {
     vdf_args_.value_count = static_cast<unsigned int>(kN);
     if (fd->protocol >= VEF_PROTOCOL_2) {
       for (size_t i = 0; i < kN; i++) input_ptrs_[i] = &inputs_[i];
-      init_inputs(inputs_);
       vdf_args_.values = input_ptrs_;
     } else {
-      init_inputs(inputs_v1_);
       vdf_args_.values_v1 = inputs_v1_;
+    }
+  }
+
+  // Initialize the type/is_null fields of each input slot. Must be called
+  // once after construction and before the first invoke().
+  // The no-arg overload default-constructs each arg's init_t (e.g. empty
+  // TypeParameterSlice for CustomArg). The explicit overload accepts one
+  // init_t value per arg tag.
+  void init() { init(typename ArgTags::init_t{}...); }
+
+  void init(typename ArgTags::init_t... init_args) {
+    if (ctx_.protocol >= VEF_PROTOCOL_2) {
+      unsigned int i = 0;
+      ((ArgTags::init(inputs_[i++], init_args)), ...);
+    } else {
+      unsigned int i = 0;
+      ((ArgTags::init(inputs_v1_[i++], init_args)), ...);
     }
   }
 
@@ -232,12 +271,6 @@ class SpecialVdfCall {
   }
 
  private:
-  template <typename InvalueType>
-  void init_inputs(InvalueType *inputs) {
-    unsigned int i = 0;
-    ((ArgTags::init(inputs[i++])), ...);
-  }
-
   void fill_inputs(typename ArgTags::cpp_t... args) {
     if (ctx_.protocol >= VEF_PROTOCOL_2) {
       unsigned int i = 0;

--- a/villagesql/types/type_decoder.cc
+++ b/villagesql/types/type_decoder.cc
@@ -39,6 +39,7 @@ TypeDecoder::TypeDecoder(const TypeContext &tc, MEM_ROOT &mem_root)
   const DecodeOp &op = tc.descriptor()->decode_op();
   if (op.vdf() != nullptr) {
     vdf_call_.emplace(op.vdf());
+    vdf_call_->init();
   } else {
     fn_ = op.fn();
   }

--- a/villagesql/types/type_encoder.cc
+++ b/villagesql/types/type_encoder.cc
@@ -39,6 +39,7 @@ TypeEncoder::TypeEncoder(const TypeContext *tc, MEM_ROOT &mem_root)
   const EncodeOp &op = tc->descriptor()->encode_op();
   if (op.vdf() != nullptr) {
     vdf_call_.emplace(op.vdf());
+    vdf_call_->init();
   } else {
     fn_ = op.fn();
   }

--- a/villagesql/types/type_op.cc
+++ b/villagesql/types/type_op.cc
@@ -37,6 +37,7 @@ int CompareOp::invoke(const unsigned char *data1, size_t len1,
   }
 
   SpecialVdfCall<IntResult, CustomArg, CustomArg> call(vdf_);
+  call.init();
   auto result = call.invoke(BinarySlice{data1, len1}, BinarySlice{data2, len2});
   if (!result) {
     LogVSQL(ERROR_LEVEL, "compare VDF '%s' returned error: %s", call.name(),
@@ -52,6 +53,7 @@ size_t HashOp::invoke(const unsigned char *data, size_t len) const {
   }
 
   SpecialVdfCall<IntResult, CustomArg> call(vdf_);
+  call.init();
   auto result = call.invoke(BinarySlice{data, len});
   if (!result) {
     LogVSQL(ERROR_LEVEL, "hash VDF '%s' returned error: %s", call.name(),
@@ -65,6 +67,7 @@ bool IntToParamsOp::invoke(int64_t value, std::string *result,
                            char *error_msg) const {
   char str_buffer[VEF_MAX_TYPE_PARAMS_STRING_LEN];
   SpecialVdfCall<StringResult, IntArg> call(vdf_);
+  call.init();
   auto r = call.invoke(value, str_buffer, sizeof(str_buffer));
   if (!r) {
     snprintf(error_msg, VEF_MAX_ERROR_LEN, "%s", call.error_msg());
@@ -82,6 +85,7 @@ bool ResolveParamsOp::invoke(const std::string &params_str,
                              char *error_msg) const {
   char str_buffer[VEF_MAX_TYPE_PARAMS_STRING_LEN];
   SpecialVdfCall<StringResult, StringArg> call(vdf_);
+  call.init();
   auto r = call.invoke(StringSlice{params_str.c_str(), params_str.size()},
                        str_buffer, sizeof(str_buffer));
   if (!r) {
@@ -122,6 +126,7 @@ bool ResolveParamsOp::invoke(const std::string &params_str,
 bool IntrinsicDefaultOp::invoke(int64_t buffer_size, unsigned char *buffer,
                                 size_t *length, char *error_msg) const {
   SpecialVdfCall<BinaryResult, IntArg> call(vdf_);
+  call.init();
   auto r = call.invoke(buffer_size, buffer, static_cast<size_t>(buffer_size));
   if (!r) {
     snprintf(error_msg, VEF_MAX_ERROR_LEN, "%s", call.error_msg());


### PR DESCRIPTION
Replace init_inputs with init, which is broken out from the constructor, since it is now dynamic.