### PR TITLE
ci: improve build caching

### DIFF
--- a/.github/actions/setup-villagesql-build/action.yml
+++ b/.github/actions/setup-villagesql-build/action.yml
@@ -4,8 +4,12 @@ description: 'Install dependencies and setup ccache for VillageSQL builds'
 inputs:
   cache-key-prefix:
     description: 'Prefix for ccache key (e.g., "build", "nightly")'
-    required: true
+    required: false
     default: 'build'
+  setup-ccache:
+    description: 'Whether to use GitHub Actions cache for ccache'
+    required: false
+    default: 'true'
 
 runs:
   using: "composite"
@@ -17,12 +21,12 @@ runs:
         sudo scripts/setup_linux_build_env.sh
 
     - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      if: inputs.setup-ccache == 'true'
+      uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639  # v1.2
       with:
         key: ${{ runner.os }}-${{ inputs.cache-key-prefix }}-${{ github.sha }}
         restore-keys: |
           ${{ runner.os }}-${{ inputs.cache-key-prefix }}
-          ${{ runner.os }}-build
-        max-size: 2G
+        max-size: 4G
         verbose: 2
         append-timestamp: false

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -15,11 +15,6 @@ on:
         required: false
         type: string
         default: 'debug'
-      cache-key-prefix:
-        description: 'Prefix for cache keys'
-        required: false
-        type: string
-        default: 'full-test'
       artifact-prefix:
         description: 'Prefix for artifact names'
         required: false
@@ -53,7 +48,7 @@ jobs:
     - name: Setup VillageSQL build environment
       uses: ./source/.github/actions/setup-villagesql-build
       with:
-        cache-key-prefix: ${{ inputs.cache-key-prefix }}
+        setup-ccache: 'false'
 
     - name: Build VillageSQL
       working-directory: ./source
@@ -61,9 +56,6 @@ jobs:
       env:
         PARALLEL_JOBS: 16
         BUILD_TYPE: ${{ inputs.build-type }}
-
-    - name: Show ccache statistics
-      run: ccache -s
 
     - name: Run tests
       uses: ./source/.github/actions/run-tests

--- a/.github/workflows/nightly-tag-test.yml
+++ b/.github/workflows/nightly-tag-test.yml
@@ -37,6 +37,5 @@ jobs:
     with:
       ref: ${{ needs.get-tag.outputs.tag }}
       build-type: release
-      cache-key-prefix: nightly-release
       artifact-prefix: nightly-tag-${{ needs.get-tag.outputs.tag }}
       run-all-suites-conditional: true

--- a/.github/workflows/release-dev-server.yml
+++ b/.github/workflows/release-dev-server.yml
@@ -61,16 +61,6 @@ jobs:
         if: matrix.os == 'macos'
         run: brew install bison cmake openssl
 
-      - name: Setup ccache
-        uses: hendrikmuhs/ccache-action@v1.2
-        with:
-          key: ${{ runner.os }}-${{ runner.arch }}-release-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-release
-            ${{ runner.os }}-${{ runner.arch }}-build
-          max-size: 2G
-          append-timestamp: false
-
       - name: Cache Boost
         uses: actions/cache@v4
         with:
@@ -82,8 +72,6 @@ jobs:
           mkdir -p "$BUILD_DIR" "$OUTPUT_DIR"
 
           EXTRA_FLAGS="-DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost"
-          EXTRA_FLAGS="$EXTRA_FLAGS -DCMAKE_C_COMPILER_LAUNCHER=ccache"
-          EXTRA_FLAGS="$EXTRA_FLAGS -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
           if [ "${{ matrix.os }}" = "macos" ]; then
             EXTRA_FLAGS="$EXTRA_FLAGS -DWITH_SSL=$(brew --prefix openssl)"
           fi

--- a/.github/workflows/testall.yml
+++ b/.github/workflows/testall.yml
@@ -79,6 +79,5 @@ jobs:
     with:
       ref: ${{ needs.check-trigger.outputs.ref }}
       build-type: debug
-      cache-key-prefix: testall
       artifact-prefix: testall
       run-all-suites-conditional: false

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Setup VillageSQL build environment
       uses: ./source/.github/actions/setup-villagesql-build
       with:
-        cache-key-prefix: valgrind
+        setup-ccache: 'false'
 
     - name: Build VillageSQL with Valgrind support
       working-directory: ./source
@@ -52,9 +52,6 @@ jobs:
         PARALLEL_JOBS: 16
         BUILD_TYPE: debug
         CMAKE_EXTRA_FLAGS: -DWITH_VALGRIND=1
-
-    - name: Show ccache statistics
-      run: ccache -s
 
     - name: Run Valgrind tests
       uses: ./source/.github/actions/run-tests


### PR DESCRIPTION
Set the cache size to 4GB

Only use the cache for the nightly and build and test flows, as no other jobs run frequently enough to be benefit from caching, and it would just slow down those jobs by downloading a useless cache object and pollute the cache when it up loads.

This is informed by looking at the recent CI slowness is do to a slowdown of build, which is correlated with poor cache hit performance.
