### PR TITLE
sql: fix Field::val_external_str

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_decode_failure.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_decode_failure.result
@@ -20,22 +20,22 @@ id	val
 3	OK abc
 # Insert a value that will fail on decode
 INSERT INTO t1 VALUES (4, 'DECODE_FAIL');
-# SELECT the decode-failing row alone: returns NULL with a warning
+# SELECT the decode-failing row alone: returns empty string with a warning
 SELECT id, val FROM t1 WHERE id = 4;
 id	val
-4	NULL
+4	
 Warnings:
 Warning	1366	Incorrect FAULT_BLOB value: 'DECODE_FAIL\x00\x00\x00\x00\x00' for column 'val' at row 1
 SHOW WARNINGS;
 Level	Code	Message
 Warning	1366	Incorrect FAULT_BLOB value: 'DECODE_FAIL\x00\x00\x00\x00\x00' for column 'val' at row 1
-# SELECT all rows: healthy rows decode fine, DECODE_FAIL row returns NULL
+# SELECT all rows: healthy rows decode fine, DECODE_FAIL row returns empty string
 SELECT id, val FROM t1 ORDER BY id;
 id	val
 1	OK hello
 2	OK world
 3	OK abc
-4	NULL
+4	
 Warnings:
 Warning	1366	Incorrect FAULT_BLOB value: 'DECODE_FAIL\x00\x00\x00\x00\x00' for column 'val' at row 4
 SHOW WARNINGS;
@@ -52,10 +52,10 @@ id	val
 4	OK fixed
 # UPDATE: overwrite a good row with a DECODE_FAIL value
 UPDATE t1 SET val = 'DECODE_FAIL' WHERE id = 1;
-# The updated row now decodes as NULL with a warning
+# The updated row now decodes as empty string with a warning
 SELECT id, val FROM t1 ORDER BY id;
 id	val
-1	NULL
+1	
 2	OK world
 3	OK abc
 4	OK fixed

--- a/mysql-test/suite/villagesql/extension/t/extension_decode_failure.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_decode_failure.test
@@ -9,11 +9,11 @@
 #
 # Test coverage:
 #   1. Normal INSERT/SELECT round-trip with "OK" values.
-#   2. "DECODE_FAIL" rows: SELECT returns NULL with a warning.
+#   2. "DECODE_FAIL" rows: SELECT returns empty string with a warning.
 #   3. Mixing healthy and decode-failing rows in the same query.
 #   4. "ENCODE_FAIL": INSERT is rejected with an error.
 #   5. UPDATE overwriting a DECODE_FAIL row with a good value: row becomes readable.
-#   6. UPDATE overwriting a good row with DECODE_FAIL: value is stored, decodes as NULL.
+#   6. UPDATE overwriting a good row with DECODE_FAIL: value is stored, decodes as empty string.
 
 INSTALL EXTENSION vsql_test_only;
 
@@ -37,11 +37,11 @@ SELECT id, val FROM t1 ORDER BY id;
 --echo # Insert a value that will fail on decode
 INSERT INTO t1 VALUES (4, 'DECODE_FAIL');
 
---echo # SELECT the decode-failing row alone: returns NULL with a warning
+--echo # SELECT the decode-failing row alone: returns empty string with a warning
 SELECT id, val FROM t1 WHERE id = 4;
 SHOW WARNINGS;
 
---echo # SELECT all rows: healthy rows decode fine, DECODE_FAIL row returns NULL
+--echo # SELECT all rows: healthy rows decode fine, DECODE_FAIL row returns empty string
 SELECT id, val FROM t1 ORDER BY id;
 SHOW WARNINGS;
 
@@ -54,7 +54,7 @@ SELECT id, val FROM t1 ORDER BY id;
 --echo # UPDATE: overwrite a good row with a DECODE_FAIL value
 UPDATE t1 SET val = 'DECODE_FAIL' WHERE id = 1;
 
---echo # The updated row now decodes as NULL with a warning
+--echo # The updated row now decodes as empty string with a warning
 SELECT id, val FROM t1 ORDER BY id;
 SHOW WARNINGS;
 

--- a/sql/dd/dd_table.cc
+++ b/sql/dd/dd_table.cc
@@ -359,10 +359,7 @@ static void prepare_default_value_string(uchar *buf, TABLE *table,
         f->val_str(&type);
     } else {
       // VillageSQL: val_external_str handles both custom and regular types.
-      // Copy if val_str returned a different pointer than the buffer we passed.
-      if (const String *res = f->val_external_str(&type);
-          res != nullptr && res != &type)
-        type.copy(*res);
+      f->val_external_str(&type);
     }
 
     if (type.length()) {

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -10653,12 +10653,12 @@ String *Field::val_external_str(String *buf) const {
             this->field_name, da->current_row_for_condition());
       }
     } else {
-      // OOMs will just return nullptr, but have called my_error.
+      // OOMs have already called my_error
     }
-    return nullptr;
+    // MySQL errors return empty strings
+    buf->length(0);
   }
 
-  // Success: the decoded string is in buf.
   return buf;
 }
 
@@ -10666,6 +10666,6 @@ bool Field_varstring::send_to_protocol(Protocol *protocol) const {
   if (is_null()) return protocol->store_null();
   char buff[MAX_FIELD_WIDTH];
   String tmp(buff, sizeof(buff), charset());
-  String *res = val_external_str(&tmp);
-  return res ? protocol->store(res) : protocol->store_null();
+  val_external_str(&tmp);
+  return protocol->store(&tmp);
 }

--- a/sql/field.h
+++ b/sql/field.h
@@ -1033,7 +1033,6 @@ class Field {
   // Unlike val_str(), val_external_str() takes only one buffer because custom
   // types always decode binary data to a new string (never returning existing
   // string data), so the two-buffer optimization doesn't apply.
-  // TODO(villagesql-beta): Return buf with zero length in case of error.
   String *val_external_str(String *buf) const;
   String *val_external_str(String *str, uchar *new_ptr) {
     uchar *old_ptr = ptr;

--- a/sql/key.cc
+++ b/sql/key.cc
@@ -324,10 +324,8 @@ void field_unpack(String *to, Field *field, uint max_length, bool prefix_key) {
     }
     const CHARSET_INFO *cs = field->charset();
     // VillageSQL: val_external_str handles both custom and regular types.
-    // For custom types the return value is a different pointer, so copy it.
-    if (const String *res = field->val_external_str(&tmp);
-        res != nullptr && res != &tmp)
-      tmp.copy(*res);
+    field->val_external_str(&tmp);
+
     /*
       For BINARY(N) strip trailing zeroes to make
       the error message nice-looking

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -759,9 +759,8 @@ static void do_field_custom_to_string(Copy_field *, const Field *from,
   // NULL is handled outside this function
   // TODO(villagesql-performance): evaluate something more performant
   String buf;
-  if (const String *res = from->val_external_str(&buf)) {
-    to->store(res->ptr(), res->length(), res->charset());
-  }
+  from->val_external_str(&buf);
+  to->store(buf.ptr(), buf.length(), buf.charset());
 }
 
 FieldCopyFunc *GetCopyFunc(const Field *from, const Field *to) {


### PR DESCRIPTION
## Description

When an error is encountered set the buffer to an empty string.  This is consistent with Field::val_str().

## Related Issue

N/A

## How was this tested?

VillageSQL tests were run.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
