### PR TITLE
dev_server: read password from stdin

### DIFF
--- a/villagesql/dev_server/QUICKSTART.md.template
+++ b/villagesql/dev_server/QUICKSTART.md.template
@@ -35,10 +35,17 @@ brew install openssl
 ./villagesql stop
 ```
 
-To set a root password, pass `--password` to `init` — you will be prompted interactively:
+To set a root password, pass `--password` to `init`. When run interactively you will be prompted to enter and confirm the password:
 
 ```bash
 ./villagesql init --password
+./villagesql start
+```
+
+When stdin is not a terminal (e.g. in scripts or CI), the password is read from stdin without a confirmation prompt:
+
+```bash
+echo "mysecretpassword" | ./villagesql init --password
 ./villagesql start
 ```
 

--- a/villagesql/dev_server/villagesql.sh
+++ b/villagesql/dev_server/villagesql.sh
@@ -41,14 +41,18 @@ cmd_init() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --password)
-                read -r -s -p "Password for root: " password
-                echo
-                local confirm
-                read -r -s -p "Confirm password: " confirm
-                echo
-                if [[ "$password" != "$confirm" ]]; then
-                    echo "Error: Passwords do not match"
-                    exit 1
+                if [ ! -t 0 ]; then
+                    read -r password
+                else
+                    read -r -s -p "Password for root: " password
+                    echo
+                    local confirm
+                    read -r -s -p "Confirm password: " confirm
+                    echo
+                    if [[ "$password" != "$confirm" ]]; then
+                        echo "Error: Passwords do not match"
+                        exit 1
+                    fi
                 fi
                 shift
                 ;;


### PR DESCRIPTION
## Description

When run from a script the villagesql server will read the password from stdin with no prompting.

## Related Issue

#30

## How was this tested?

Manual testing

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
