### PR TITLE
sql: decode errors are mysql errors

### DIFF
--- a/mysql-test/include/villagesql/decode_failure_log_init.inc
+++ b/mysql-test/include/villagesql/decode_failure_log_init.inc
@@ -1,0 +1,23 @@
+# Record the current end-of-file position in the MySQL error log so that
+# subsequent calls to decode_failure_log_print.inc only show entries written
+# after this point.
+#
+# Usage:
+#   --source include/villagesql/decode_failure_log_init.inc
+#   ... trigger decode failure ...
+#   --source include/villagesql/decode_failure_log_print.inc
+#   ... cleanup ...
+#   --remove_file $MYSQLTEST_VARDIR/tmp/decode_fail_log_pos.txt
+
+--perl
+use strict;
+my $log = $ENV{MYSQLTEST_VARDIR} . "/log/mysqld.1.err";
+my $pos_file = $ENV{MYSQLTEST_VARDIR} . "/tmp/decode_fail_log_pos.txt";
+open(my $fh, "<", $log) or die "Cannot open $log: $!";
+seek($fh, 0, 2);
+my $pos = tell($fh);
+close $fh;
+open(my $pf, ">", $pos_file) or die "Cannot write $pos_file: $!";
+print $pf $pos;
+close $pf;
+EOF

--- a/mysql-test/include/villagesql/decode_failure_log_print.inc
+++ b/mysql-test/include/villagesql/decode_failure_log_print.inc
@@ -1,0 +1,27 @@
+# Print decode-failure log entries written since the last call to
+# decode_failure_log_init.inc or this file, then advance the saved position.
+# Matches lines containing "Invalid value in column" or
+# "Extension error decoding column", stripping the timestamp/thread prefix.
+#
+# Usage:
+#   --source include/villagesql/decode_failure_log_init.inc
+#   ... trigger decode failure ...
+#   --source include/villagesql/decode_failure_log_print.inc
+
+--perl
+use strict;
+my $log = $ENV{MYSQLTEST_VARDIR} . "/log/mysqld.1.err";
+my $pos_file = $ENV{MYSQLTEST_VARDIR} . "/tmp/decode_fail_log_pos.txt";
+open(my $pf, "<", $pos_file) or die "Cannot open $pos_file: $!";
+my $pos = <$pf>; chomp $pos; close $pf;
+open(my $fh, "<", $log) or die "Cannot open $log: $!";
+seek($fh, $pos, 0);
+while (my $line = <$fh>) {
+  next unless $line =~ /Invalid value in column|Extension error decoding column/;
+  $line =~ s/^\S+\s+\d+\s+\[Warning\]\s+\[MY-\d+\]\s+\[Server\]\s+//;
+  print $line;
+}
+my $new_pos = tell($fh); close $fh;
+open($pf, ">", $pos_file) or die "Cannot write $pos_file: $!";
+print $pf $new_pos; close $pf;
+EOF

--- a/mysql-test/suite/villagesql/extension/r/extension_decode_failure.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_decode_failure.result
@@ -1,4 +1,6 @@
 INSTALL EXTENSION vsql_test_only;
+call mtr.add_suppression("VillageSQL.*Invalid value in column.*FAULT_BLOB");
+call mtr.add_suppression("VillageSQL.*Extension error decoding column.*FAULT_BLOB");
 # Verify extension is installed
 SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
 EXTENSION_NAME	EXTENSION_VERSION
@@ -20,27 +22,16 @@ id	val
 3	OK abc
 # Insert a value that will fail on decode
 INSERT INTO t1 VALUES (4, 'DECODE_FAIL');
-# SELECT the decode-failing row alone: returns empty string with a warning
+# SELECT the decode-failing row alone: returns an error
 SELECT id, val FROM t1 WHERE id = 4;
-id	val
-4	
-Warnings:
-Warning	1366	Incorrect FAULT_BLOB value: 'DECODE_FAIL\x00\x00\x00\x00\x00' for column 'val' at row 1
-SHOW WARNINGS;
-Level	Code	Message
-Warning	1366	Incorrect FAULT_BLOB value: 'DECODE_FAIL\x00\x00\x00\x00\x00' for column 'val' at row 1
-# SELECT all rows: healthy rows decode fine, DECODE_FAIL row returns empty string
+ERROR HY000: Invalid value in column 'val' of type 'vsql_test_only.FAULT_BLOB' at row 1: check server log for details
+# Verify the failure was logged
+VillageSQL: 'Invalid value in column 'val' of type 'vsql_test_only.FAULT_BLOB' at row 1 (value: DECODE_FAIL\x00\x00\x00\x00\x00): failed to decode value'
+# SELECT all rows: healthy rows decode fine, DECODE_FAIL row causes an error
 SELECT id, val FROM t1 ORDER BY id;
-id	val
-1	OK hello
-2	OK world
-3	OK abc
-4	
-Warnings:
-Warning	1366	Incorrect FAULT_BLOB value: 'DECODE_FAIL\x00\x00\x00\x00\x00' for column 'val' at row 4
-SHOW WARNINGS;
-Level	Code	Message
-Warning	1366	Incorrect FAULT_BLOB value: 'DECODE_FAIL\x00\x00\x00\x00\x00' for column 'val' at row 4
+ERROR HY000: Invalid value in column 'val' of type 'vsql_test_only.FAULT_BLOB' at row 4: check server log for details
+# Verify the failure was logged
+VillageSQL: 'Invalid value in column 'val' of type 'vsql_test_only.FAULT_BLOB' at row 4 (value: DECODE_FAIL\x00\x00\x00\x00\x00): failed to decode value'
 # UPDATE: overwrite the DECODE_FAIL row with a good value
 UPDATE t1 SET val = 'OK fixed' WHERE id = 4;
 # The previously-failing row should now decode successfully
@@ -52,18 +43,11 @@ id	val
 4	OK fixed
 # UPDATE: overwrite a good row with a DECODE_FAIL value
 UPDATE t1 SET val = 'DECODE_FAIL' WHERE id = 1;
-# The updated row now decodes as empty string with a warning
+# The updated row now causes an error on SELECT
 SELECT id, val FROM t1 ORDER BY id;
-id	val
-1	
-2	OK world
-3	OK abc
-4	OK fixed
-Warnings:
-Warning	1366	Incorrect FAULT_BLOB value: 'DECODE_FAIL\x00\x00\x00\x00\x00' for column 'val' at row 1
-SHOW WARNINGS;
-Level	Code	Message
-Warning	1366	Incorrect FAULT_BLOB value: 'DECODE_FAIL\x00\x00\x00\x00\x00' for column 'val' at row 1
+ERROR HY000: Invalid value in column 'val' of type 'vsql_test_only.FAULT_BLOB' at row 1: check server log for details
+# Verify the failure was logged
+VillageSQL: 'Invalid value in column 'val' of type 'vsql_test_only.FAULT_BLOB' at row 1 (value: DECODE_FAIL\x00\x00\x00\x00\x00): failed to decode value'
 # Clean up
 DROP TABLE t1;
 # ENCODE_FAIL: INSERT is rejected with an error, nothing is stored

--- a/mysql-test/suite/villagesql/extension/t/extension_decode_failure.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_decode_failure.test
@@ -9,13 +9,16 @@
 #
 # Test coverage:
 #   1. Normal INSERT/SELECT round-trip with "OK" values.
-#   2. "DECODE_FAIL" rows: SELECT returns empty string with a warning.
-#   3. Mixing healthy and decode-failing rows in the same query.
+#   2. "DECODE_FAIL" rows: SELECT returns an error and logs the failure.
+#   3. Mixing healthy and decode-failing rows in the same query: error on the bad row.
 #   4. "ENCODE_FAIL": INSERT is rejected with an error.
 #   5. UPDATE overwriting a DECODE_FAIL row with a good value: row becomes readable.
-#   6. UPDATE overwriting a good row with DECODE_FAIL: value is stored, decodes as empty string.
+#   6. UPDATE overwriting a good row with DECODE_FAIL: value is stored, SELECT returns error.
 
 INSTALL EXTENSION vsql_test_only;
+
+call mtr.add_suppression("VillageSQL.*Invalid value in column.*FAULT_BLOB");
+call mtr.add_suppression("VillageSQL.*Extension error decoding column.*FAULT_BLOB");
 
 --echo # Verify extension is installed
 SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
@@ -37,13 +40,22 @@ SELECT id, val FROM t1 ORDER BY id;
 --echo # Insert a value that will fail on decode
 INSERT INTO t1 VALUES (4, 'DECODE_FAIL');
 
---echo # SELECT the decode-failing row alone: returns empty string with a warning
-SELECT id, val FROM t1 WHERE id = 4;
-SHOW WARNINGS;
+# Record log file position before first decode failure.
+--source include/villagesql/decode_failure_log_init.inc
 
---echo # SELECT all rows: healthy rows decode fine, DECODE_FAIL row returns empty string
+--echo # SELECT the decode-failing row alone: returns an error
+--error ER_VILLAGESQL_GENERIC_ERROR
+SELECT id, val FROM t1 WHERE id = 4;
+
+--echo # Verify the failure was logged
+--source include/villagesql/decode_failure_log_print.inc
+
+--echo # SELECT all rows: healthy rows decode fine, DECODE_FAIL row causes an error
+--error ER_VILLAGESQL_GENERIC_ERROR
 SELECT id, val FROM t1 ORDER BY id;
-SHOW WARNINGS;
+
+--echo # Verify the failure was logged
+--source include/villagesql/decode_failure_log_print.inc
 
 --echo # UPDATE: overwrite the DECODE_FAIL row with a good value
 UPDATE t1 SET val = 'OK fixed' WHERE id = 4;
@@ -54,12 +66,16 @@ SELECT id, val FROM t1 ORDER BY id;
 --echo # UPDATE: overwrite a good row with a DECODE_FAIL value
 UPDATE t1 SET val = 'DECODE_FAIL' WHERE id = 1;
 
---echo # The updated row now decodes as empty string with a warning
+--echo # The updated row now causes an error on SELECT
+--error ER_VILLAGESQL_GENERIC_ERROR
 SELECT id, val FROM t1 ORDER BY id;
-SHOW WARNINGS;
+
+--echo # Verify the failure was logged
+--source include/villagesql/decode_failure_log_print.inc
 
 --echo # Clean up
 DROP TABLE t1;
+--remove_file $MYSQLTEST_VARDIR/tmp/decode_fail_log_pos.txt
 
 --echo # ENCODE_FAIL: INSERT is rejected with an error, nothing is stored
 CREATE TABLE t2 (

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -10636,26 +10636,9 @@ const char *get_field_name_or_expression(THD *thd, const Field *field) {
 String *Field::val_external_str(String *buf) const {
   if (!has_type_context()) return val_str(buf);
 
-  bool is_valid = true;
-  if (villagesql::DecodeStringForField(this, buf, is_valid)) {
-    if (!is_valid) {
-      THD *thd = current_thd;
-      if (!thd->lex->is_ignore() && thd->is_strict_mode()) {
-        const uchar *encoded_data = data_ptr();
-        size_t encoded_length = data_length();
-        const ErrConvString errmsg(pointer_cast<const char *>(encoded_data),
-                                   encoded_length, &my_charset_bin);
-        const Diagnostics_area *da = thd->get_stmt_da();
-        push_warning_printf(
-            thd, Sql_condition::SL_WARNING, ER_TRUNCATED_WRONG_VALUE_FOR_FIELD,
-            ER_THD(thd, ER_TRUNCATED_WRONG_VALUE_FOR_FIELD),
-            get_type_context()->type_name().c_str(), errmsg.ptr(),
-            this->field_name, da->current_row_for_condition());
-      }
-    } else {
-      // OOMs have already called my_error
-    }
-    // MySQL errors return empty strings
+  if (villagesql::DecodeStringForField(this, buf)) {
+    // Return empty string to satisfy the String* contract; the actual error
+    // propagates via the THD diagnostics area.
     buf->length(0);
   }
 

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -291,14 +291,7 @@ String *Item::val_external_str(String *str) {
   if (!has_type_context() || null_value) return binary_data;
 
   // Decode using TypeContext's to_string function
-  bool is_valid = true;
-  if (villagesql::DecodeStringForItem(this, *binary_data, str, is_valid)) {
-    if (!is_valid) {
-      // Invalid custom type data - set null and return nullptr
-      null_value = true;
-      return nullptr;
-    }
-    // OOM or other error (my_error already called)
+  if (villagesql::DecodeStringForItem(this, *binary_data, str)) {
     null_value = true;
     return nullptr;
   }
@@ -3626,10 +3619,8 @@ void Item_string::print(const THD *, String *str,
   if (has_type_context()) {
     str->append('\'');
     String decoded;
-    bool is_valid;
     if (!villagesql::DecodeStringUncached(*get_type_context(), str_value,
-                                          &decoded, is_valid) &&
-        is_valid) {
+                                          &decoded)) {
       // TODO(villagesql-beta): Should we print a placeholder in case of error?
       str->append(decoded);
     }

--- a/villagesql/types/type_decoder.cc
+++ b/villagesql/types/type_decoder.cc
@@ -54,25 +54,23 @@ bool TypeDecoder::Init() {
   return false;
 }
 
-bool TypeDecoder::decode(const uchar *data, size_t len, String *out,
-                         bool &is_valid) {
-  is_valid = true;
-
+DecodeResult TypeDecoder::decode(const uchar *data, size_t len, String *out) {
   if (vdf_call_.has_value()) {
     auto r = vdf_call_->invoke(BinarySlice{data, len}, buffer_, buffer_size_);
     if (!r) {
-      // TODO(villagesql-beta): log errors.
-      is_valid = false;
-      return true;
+      last_error_msg_ = vdf_call_->error_msg();
+      return DecodeResult::kInvalidData;
     }
 
     if (vdf_call_->alt_str_buf() != nullptr) {
       // TODO(villagesql-beta): support caller supplied buffers.
-      return true;
+      last_error_msg_ = "VDF provided unsupported alternate output buffer";
+      return DecodeResult::kExtensionError;
     }
 
     if (*r > buffer_size_) {
-      return true;
+      last_error_msg_ = "decoded length exceeds buffer";
+      return DecodeResult::kExtensionError;
     }
 
     out->set(buffer_, *r, &my_charset_utf8mb4_bin);
@@ -81,18 +79,19 @@ bool TypeDecoder::decode(const uchar *data, size_t len, String *out,
     assert(fn_ != nullptr);
     size_t decoded_length = 0;
     if (fn_(data, len, buffer_, buffer_size_, &decoded_length)) {
-      is_valid = false;
-      return true;
+      last_error_msg_ = "decode function reported invalid data";
+      return DecodeResult::kInvalidData;
     }
-    // the buffer rather than silently returning invalid.
+
     if (should_assert_if_false(decoded_length <= buffer_size_)) {
-      return true;
+      last_error_msg_ = "decoded length exceeds buffer";
+      return DecodeResult::kExtensionError;
     }
 
     out->set(buffer_, decoded_length, &my_charset_utf8mb4_bin);
   }
 
-  return false;
+  return DecodeResult::kSuccess;
 }
 
 }  // namespace villagesql

--- a/villagesql/types/type_decoder.h
+++ b/villagesql/types/type_decoder.h
@@ -30,6 +30,12 @@ struct MEM_ROOT;
 
 namespace villagesql {
 
+enum class DecodeResult {
+  kSuccess,
+  kInvalidData,    // the stored bytes are not a valid encoding for this type
+  kExtensionError  // the extension misbehaved (e.g. returned oversized output)
+};
+
 // TypeDecoder holds per-Field (or per-Item) decoding state, lazily allocated
 // from the owning object's mem_root on first decode and reused for all
 // subsequent decodes within the same lifetime.
@@ -63,10 +69,16 @@ class TypeDecoder {
   TypeDecoder &operator=(TypeDecoder &&) = delete;
 
   // Decode binary data in [data, data+len) into the pre-allocated buffer_ and
-  // set out to point at the result. Returns true on success, false on error
-  // (is_valid is false for invalid data, true for OOM with my_error already
-  // called). out is valid until the next decode() call.
-  bool decode(const uchar *data, size_t len, String *out, bool &is_valid);
+  // set out to point at the result. Returns kSuccess on success, kInvalidData
+  // if the value is not a valid encoding for this type, or kExtensionError if
+  // the extension misbehaved. out is valid until the next decode() call.
+  // On any non-kSuccess result, last_error_msg() is populated.
+  DecodeResult decode(const uchar *data, size_t len, String *out);
+
+  // Human-readable description of the most recent decode() failure.
+  // Valid only after decode() returns non-kSuccess; undefined otherwise.
+  // Lifetime: valid until the next call to decode().
+  const char *last_error_msg() const { return last_error_msg_; }
 
  private:
   MEM_ROOT *mem_root_{nullptr};  // owning mem_root used for buffers
@@ -79,6 +91,10 @@ class TypeDecoder {
   // VDF path: SpecialVdfCall owns ctx/inputs/vdf_args, error_msg, and alt_buf.
   // The output buffer (buffer_) is passed per decode() call.
   std::optional<SpecialVdfCall<StringResult, CustomArg>> vdf_call_{};
+
+  // Points to a string literal or vdf_call_->error_msg() after a failed
+  // decode(). Undefined when decode() returns kSuccess.
+  const char *last_error_msg_{nullptr};
 };
 
 }  // namespace villagesql

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -379,42 +379,67 @@ static TypeDecoder *GetTypeDecoderFor(Item *item) {
 }
 
 bool DecodeStringUncached(const TypeContext &tc, const String &from,
-                          String *out, bool &is_valid) {
+                          String *out) {
   TypeDecoder decoder(tc, *current_thd->mem_root);
-  if (decoder.Init()) {
-    is_valid = true;  // OOM, my_error already called
-    return true;
-  }
+  if (decoder.Init()) return true;
   return decoder.decode(pointer_cast<const uchar *>(from.ptr()), from.length(),
-                        out, is_valid);
+                        out) != DecodeResult::kSuccess;
 }
 
-bool DecodeStringForField(const Field *field, String *out, bool &is_valid) {
+// Logs a decode failure and reports an error (or warning in IGNORE mode) to
+// the client. result must be kInvalidData or kExtensionError.
+static void ReportDecodeError(DecodeResult result, const char *column_name,
+                              const char *type_name, const uchar *data,
+                              size_t len, const char *decoder_error_msg) {
+  const ErrConvString value_prefix(pointer_cast<const char *>(data), len,
+                                   &my_charset_bin);
+  ha_rows row = current_thd->get_stmt_da()->current_row_for_condition();
+  const char *label = (result == DecodeResult::kInvalidData)
+                          ? "Invalid value in column"
+                          : "Extension error decoding column";
+  LogVSQL(WARNING_LEVEL, "%s '%s' of type '%s' at row %llu (value: %s): %s",
+          label, column_name, type_name, static_cast<unsigned long long>(row),
+          value_prefix.ptr(), decoder_error_msg);
+  villagesql_error(
+      "%s '%s' of type '%s' at row %llu: check server log for details", MYF(0),
+      label, column_name, type_name, static_cast<unsigned long long>(row));
+}
+
+bool DecodeStringForField(const Field *field, String *out) {
   if (should_assert_if_false(field->has_type_context())) {
     return true;
   }
   TypeDecoder *decoder = GetTypeDecoderFor(field);
   if (decoder == nullptr) {
-    is_valid = true;  // OOM, my_error already called
-    return true;
+    return true;  // OOM, my_error already called
   }
-  return decoder->decode(field->data_ptr(), field->data_length(), out,
-                         is_valid);
+  DecodeResult result =
+      decoder->decode(field->data_ptr(), field->data_length(), out);
+  if (result == DecodeResult::kSuccess) return false;
+  ReportDecodeError(result, field->field_name,
+                    field->get_type_context()->qualified_name().c_str(),
+                    field->data_ptr(), field->data_length(),
+                    decoder->last_error_msg());
+  return true;
 }
 
-bool DecodeStringForItem(Item *item, const String &from, String *out,
-                         bool &is_valid) {
+bool DecodeStringForItem(Item *item, const String &from, String *out) {
   if (should_assert_if_false(item->has_type_context())) {
     return true;
   }
   TypeDecoder *decoder = GetTypeDecoderFor(item);
   if (decoder == nullptr) {
-    is_valid = true;  // OOM, my_error already called
-    return true;
+    return true;  // OOM, my_error already called
   }
   // Extract ptr/len before decode() writes to out: from and *out may alias.
-  return decoder->decode(pointer_cast<const uchar *>(from.ptr()), from.length(),
-                         out, is_valid);
+  const uchar *data = pointer_cast<const uchar *>(from.ptr());
+  size_t len = from.length();
+  DecodeResult result = decoder->decode(data, len, out);
+  if (result == DecodeResult::kSuccess) return false;
+  ReportDecodeError(result, item->full_name(),
+                    item->get_type_context()->qualified_name().c_str(), data,
+                    len, decoder->last_error_msg());
+  return true;
 }
 
 void AppendFullyQualifiedName(const TypeContext &tc, String *out) {

--- a/villagesql/types/util.h
+++ b/villagesql/types/util.h
@@ -97,22 +97,20 @@ extern String *EncodeStringForField(Field *field, const String &from,
 
 // Decode [data, data+len) for the given TypeContext without caching any state.
 // Use this for one-shot decodes outside the row-reading hot path (e.g. query
-// printing). Returns false on success. On failure returns true; is_valid false
-// means invalid data, true means OOM (my_error already called).
+// printing). Returns false on success, true on failure. On OOM, my_error is
+// called; decode failures are silent (caller gets true but no error is set).
 extern bool DecodeStringUncached(const TypeContext &tc, const String &from,
-                                 String *out, bool &is_valid);
+                                 String *out);
 
 // Decode the field's current value into out. Returns false on success. On
-// failure returns true; is_valid false means invalid data (warning pushed),
-// true means OOM (my_error already called).
-extern bool DecodeStringForField(const Field *field, String *out,
-                                 bool &is_valid);
+// failure returns true; error already reported via villagesql_error (or
+// my_error for OOM).
+extern bool DecodeStringForField(const Field *field, String *out);
 
 // Decode binary data from [data, data+len) into out for a custom type item.
-// Returns false on success. On failure returns true; is_valid false means
-// invalid data, true means OOM (my_error already called).
-extern bool DecodeStringForItem(Item *item, const String &from, String *out,
-                                bool &is_valid);
+// Returns false on success. On failure returns true; error already reported
+// via villagesql_error (or my_error for OOM).
+extern bool DecodeStringForItem(Item *item, const String &from, String *out);
 
 // Appends "extension_name.type_name" to the given String.
 extern void AppendFullyQualifiedName(const TypeContext &tc, String *out);


### PR DESCRIPTION
* Return an error and log an error for every decode error.
* This pushes error handling down into the villagesql::DecodeString... methods.
* Different messages for decode returned an error, vs. decode misvehaved, e.g. returned a buffer too long.