### PR TITLE
Revert PR #146

### DIFF
--- a/storage/innobase/include/mem0mem.h
+++ b/storage/innobase/include/mem0mem.h
@@ -1,7 +1,6 @@
 /*****************************************************************************
 
 Copyright (c) 1994, 2025, Oracle and/or its affiliates.
-Copyright (c) 2026 VillageSQL Contributors
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License, version 2.0, as published by the
@@ -130,17 +129,6 @@ static inline mem_heap_t *mem_heap_create(ulint size, ut::Location loc,
 /** Frees the space occupied by a memory heap.
 @param[in]      heap    Heap to be freed */
 static inline void mem_heap_free(mem_heap_t *heap);
-
-/** Register a cleanup callback to be called when this heap is freed or emptied.
-Callbacks are called in reverse order of registration (LIFO), before the
-memory is freed. The callback node is allocated on the heap itself.
-@param[in]      heap    memory heap
-@param[in]      fn      function to call, must not be nullptr
-@param[in]      arg     argument to pass to fn, may be nullptr
-@return false on success, true if allocation failed (only possible for
-MEM_HEAP_BTR_SEARCH type heaps) */
-static inline bool mem_heap_register_cleanup(mem_heap_t *heap,
-                                             void (*fn)(void *), void *arg);
 
 /** Allocates and zero-fills n bytes of memory from a memory heap.
 @param[in]      heap    memory heap
@@ -310,14 +298,6 @@ void mem_heap_validate(const mem_heap_t *heap);
 
 struct buf_block_t;
 
-// Cleanup callback node, allocated on the heap itself.
-// Forms a singly-linked list of callbacks to run before memory is freed.
-struct mem_heap_cleanup_t {
-  void (*fn)(void *);        // Function to call.
-  void *arg;                 // Argument to pass to fn.
-  mem_heap_cleanup_t *next;  // Next callback in the list.
-};
-
 /** The info structure stored at the beginning of a heap block */
 struct mem_block_info_t {
   /** Magic number for debugging. */
@@ -356,10 +336,6 @@ struct mem_block_info_t {
   /* if this block has been allocated from the buffer pool, this contains the
   buf_block_t handle; otherwise, this is NULL */
   buf_block_t *buf_block;
-
-  // Head of cleanup callback list (only used in heap root block).
-  // Callbacks are called in LIFO order when the heap is freed or emptied.
-  mem_heap_cleanup_t *cleanup_callbacks;
 };
 /* We use the UT_LIST_BASE_NODE_T_EXTERN instead of simpler UT_LIST_BASE_NODE_T
 because DevStudio12.6 initializes the pointer-to-member offset to 0 otherwise.*/

--- a/storage/innobase/include/mem0mem.ic
+++ b/storage/innobase/include/mem0mem.ic
@@ -63,29 +63,6 @@ void mem_heap_free_block_free(mem_heap_t *heap); /*!< in: heap */
  MEM_HEAP_BTR_SEARCH type heaps) */
 mem_block_t *mem_heap_add_block(mem_heap_t *heap, ulint n);
 
-/** Run all registered cleanup callbacks in LIFO order and reset the list.
-@param[in,out]  heap    memory heap */
-static inline void mem_heap_run_cleanup(mem_heap_t *heap) {
-  for (mem_heap_cleanup_t *cb = heap->cleanup_callbacks; cb != nullptr;
-       cb = cb->next) {
-    cb->fn(cb->arg);
-  }
-  heap->cleanup_callbacks = nullptr;
-}
-
-static inline bool mem_heap_register_cleanup(mem_heap_t *heap,
-                                             void (*fn)(void *), void *arg) {
-  ut_ad(fn != nullptr);
-  auto *cb = static_cast<mem_heap_cleanup_t *>(
-      mem_heap_alloc(heap, sizeof(mem_heap_cleanup_t)));
-  if (cb == nullptr) return true;
-  cb->fn = fn;
-  cb->arg = arg;
-  cb->next = heap->cleanup_callbacks;
-  heap->cleanup_callbacks = cb;
-  return false;
-}
-
 static inline void mem_block_set_len(mem_block_t *block, ulint len) {
   ut_ad(len > 0);
 
@@ -299,9 +276,6 @@ static inline void mem_heap_free_heap_top(mem_heap_t *heap, byte *old_top) {
 The first memory block of the heap is not freed.
 @param[in]      heap    heap to empty */
 static inline void mem_heap_empty(mem_heap_t *heap) {
-  // Run cleanup callbacks in LIFO order while memory is still valid.
-  mem_heap_run_cleanup(heap);
-
   mem_heap_free_heap_top(heap, (byte *)heap + mem_block_get_start(heap));
 #ifndef UNIV_HOTBACKUP
 #ifndef UNIV_LIBRARY
@@ -477,9 +451,6 @@ static inline void mem_heap_free(mem_heap_t *heap) {
   mem_block_t *prev_block;
 
   ut_d(mem_block_validate(heap));
-
-  // Run cleanup callbacks in LIFO order while memory is still valid.
-  mem_heap_run_cleanup(heap);
 
   block = UT_LIST_GET_LAST(heap->base);
 

--- a/storage/innobase/mem/memory.cc
+++ b/storage/innobase/mem/memory.cc
@@ -1,7 +1,6 @@
 /*****************************************************************************
 
 Copyright (c) 1994, 2025, Oracle and/or its affiliates.
-Copyright (c) 2026 VillageSQL Contributors
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License, version 2.0, as published by the
@@ -316,7 +315,6 @@ mem_block_t *mem_heap_create_block(mem_heap_t *heap, ulint n,
 
   block->buf_block = buf_block;
   block->free_block_ptr = nullptr;
-  block->cleanup_callbacks = nullptr;
 
 #else  /* !UNIV_LIBRARY && !UNIV_HOTBACKUP */
   len = MEM_BLOCK_HEADER_SIZE + MEM_SPACE_NEEDED(n);
@@ -324,7 +322,6 @@ mem_block_t *mem_heap_create_block(mem_heap_t *heap, ulint n,
       ut::malloc_withkey(UT_NEW_THIS_FILE_PSI_KEY, len));
   ut_a(block);
   block->free_block_ptr = nullptr;
-  block->cleanup_callbacks = nullptr;
 #endif /* !UNIV_LIBRARY && !UNIV_HOTBACKUP */
 
   ut_d(ut_strlcpy_rev(block->file_name, file_name, sizeof(block->file_name)));

--- a/unittest/gunit/innodb/mem0mem-t.cc
+++ b/unittest/gunit/innodb/mem0mem-t.cc
@@ -1,5 +1,4 @@
 /* Copyright (c) 2013, 2025, Oracle and/or its affiliates.
-   Copyright (c) 2026 VillageSQL Contributors
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -26,7 +25,6 @@
 
 #include <gtest/gtest.h>
 #include <stddef.h>
-#include <vector>
 
 #include "sql/handler.h"
 #include "storage/innobase/include/mem0mem.h"
@@ -132,95 +130,6 @@ TEST_F(mem0mem, memheapreplace) {
   EXPECT_TRUE(mem_heap_is_top(heap, p5, p5_size));
 
   mem_heap_free(heap);
-}
-
-// Test that cleanup callbacks run on mem_heap_free.
-TEST_F(mem0mem, cleanupCallbacksRunOnFree) {
-  mem_heap_t *heap = mem_heap_create(512, UT_LOCATION_HERE);
-
-  int counter = 0;
-  auto increment = [](void *arg) { (*static_cast<int *>(arg))++; };
-
-  EXPECT_FALSE(mem_heap_register_cleanup(heap, increment, &counter));
-  EXPECT_FALSE(mem_heap_register_cleanup(heap, increment, &counter));
-  EXPECT_FALSE(mem_heap_register_cleanup(heap, increment, &counter));
-
-  EXPECT_EQ(counter, 0);
-  mem_heap_free(heap);
-  EXPECT_EQ(counter, 3);
-}
-
-// Test that cleanup callbacks run in LIFO order.
-TEST_F(mem0mem, cleanupCallbacksLIFOOrder) {
-  mem_heap_t *heap = mem_heap_create(512, UT_LOCATION_HERE);
-
-  std::vector<int> order;
-  struct Ctx {
-    std::vector<int> *vec;
-    int id;
-  };
-
-  auto record = [](void *arg) {
-    auto *ctx = static_cast<Ctx *>(arg);
-    ctx->vec->push_back(ctx->id);
-  };
-
-  // Allocate contexts on the heap so they live until free.
-  auto *c1 = static_cast<Ctx *>(mem_heap_alloc(heap, sizeof(Ctx)));
-  auto *c2 = static_cast<Ctx *>(mem_heap_alloc(heap, sizeof(Ctx)));
-  auto *c3 = static_cast<Ctx *>(mem_heap_alloc(heap, sizeof(Ctx)));
-  c1->vec = &order;
-  c1->id = 1;
-  c2->vec = &order;
-  c2->id = 2;
-  c3->vec = &order;
-  c3->id = 3;
-
-  mem_heap_register_cleanup(heap, record, c1);
-  mem_heap_register_cleanup(heap, record, c2);
-  mem_heap_register_cleanup(heap, record, c3);
-
-  mem_heap_free(heap);
-  ASSERT_EQ(order.size(), 3u);
-  EXPECT_EQ(order[0], 3);
-  EXPECT_EQ(order[1], 2);
-  EXPECT_EQ(order[2], 1);
-}
-
-// Test that cleanup callbacks run on mem_heap_empty.
-TEST_F(mem0mem, cleanupCallbacksRunOnEmpty) {
-  mem_heap_t *heap = mem_heap_create(512, UT_LOCATION_HERE);
-
-  int counter = 0;
-  auto increment = [](void *arg) { (*static_cast<int *>(arg))++; };
-
-  mem_heap_register_cleanup(heap, increment, &counter);
-  mem_heap_register_cleanup(heap, increment, &counter);
-
-  EXPECT_EQ(counter, 0);
-  mem_heap_empty(heap);
-  EXPECT_EQ(counter, 2);
-
-  // After empty, callbacks should not fire again on free.
-  mem_heap_free(heap);
-  EXPECT_EQ(counter, 2);
-}
-
-// Test that new callbacks can be registered after empty.
-TEST_F(mem0mem, cleanupCallbacksReregisterAfterEmpty) {
-  mem_heap_t *heap = mem_heap_create(512, UT_LOCATION_HERE);
-
-  int counter = 0;
-  auto increment = [](void *arg) { (*static_cast<int *>(arg))++; };
-
-  mem_heap_register_cleanup(heap, increment, &counter);
-  mem_heap_empty(heap);
-  EXPECT_EQ(counter, 1);
-
-  // Register new callbacks after empty.
-  mem_heap_register_cleanup(heap, increment, &counter);
-  mem_heap_free(heap);
-  EXPECT_EQ(counter, 2);
 }
 
 }  // namespace innodb_mem0mem_unittest


### PR DESCRIPTION
Reason:
- We actually don't need this, as we were going to tie the lifetime to the table's mem_heap_t
- We want to tie it to the Custom_column, instead, which means just keeping a client-managed ref
