### PR TITLE
sdk: cleanup up builder pattern

### DIFF
--- a/villagesql/sdk/include/villagesql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/func_builder.h
@@ -787,10 +787,9 @@ struct FuncBuilder {
   vef_postrun_func_t postrun_;
   bool deterministic_;
 
-  constexpr FuncBuilder<Func, NumParams> returns(const char *t) const {
-    FuncBuilder<Func, NumParams> copy = *this;
-    copy.return_type_ = t;
-    return copy;
+  constexpr FuncBuilder<Func, NumParams> &returns(const char *t) {
+    return_type_ = t;
+    return *this;
   }
 
   constexpr FuncBuilder<Func, NumParams + 1> param(const char *t) const {
@@ -808,30 +807,26 @@ struct FuncBuilder {
     return next;
   }
 
-  constexpr FuncBuilder<Func, NumParams> buffer_size(size_t s) const {
-    FuncBuilder<Func, NumParams> copy = *this;
-    copy.buffer_size_ = s;
-    return copy;
+  constexpr FuncBuilder<Func, NumParams> &buffer_size(size_t s) {
+    buffer_size_ = s;
+    return *this;
   }
 
-  constexpr FuncBuilder<Func, NumParams> deterministic(bool d = true) const {
-    FuncBuilder<Func, NumParams> copy = *this;
-    copy.deterministic_ = d;
-    return copy;
+  constexpr FuncBuilder<Func, NumParams> &deterministic(bool d = true) {
+    deterministic_ = d;
+    return *this;
   }
 
   template <vef_prerun_func_t Hook>
-  constexpr FuncBuilder<Func, NumParams> prerun() const {
-    FuncBuilder<Func, NumParams> copy = *this;
-    copy.prerun_ = Hook;
-    return copy;
+  constexpr FuncBuilder<Func, NumParams> &prerun() {
+    prerun_ = Hook;
+    return *this;
   }
 
   template <vef_postrun_func_t Hook>
-  constexpr FuncBuilder<Func, NumParams> postrun() const {
-    FuncBuilder<Func, NumParams> copy = *this;
-    copy.postrun_ = Hook;
-    return copy;
+  constexpr FuncBuilder<Func, NumParams> &postrun() {
+    postrun_ = Hook;
+    return *this;
   }
 
   // Finalize the function definition and produce the StaticFuncDesc

--- a/villagesql/sdk/include/villagesql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/type_builder.h
@@ -60,82 +60,69 @@ class TypeBuilder {
         resolve_params_vdf_name_(nullptr),
         intrinsic_default_vdf_name_(nullptr) {}
 
-  constexpr TypeBuilder persisted_length(int64_t len) const {
-    TypeBuilder copy = *this;
-    copy.persisted_length_ = len;
-    return copy;
+  constexpr TypeBuilder &persisted_length(int64_t len) {
+    persisted_length_ = len;
+    return *this;
   }
 
-  constexpr TypeBuilder max_decode_buffer_length(int64_t len) const {
-    TypeBuilder copy = *this;
-    copy.max_decode_buffer_length_ = len;
-    return copy;
+  constexpr TypeBuilder &max_decode_buffer_length(int64_t len) {
+    max_decode_buffer_length_ = len;
+    return *this;
   }
 
-  constexpr TypeBuilder encode(vef_encode_func_t f) const {
-    TypeBuilder copy = *this;
-    copy.encode_ = f;
-    return copy;
+  constexpr TypeBuilder &encode(vef_encode_func_t f) {
+    encode_ = f;
+    return *this;
   }
 
-  constexpr TypeBuilder encode(const char *vdf_name) const {
-    TypeBuilder copy = *this;
-    copy.encode_vdf_name_ = vdf_name;
-    return copy;
+  constexpr TypeBuilder &encode(const char *vdf_name) {
+    encode_vdf_name_ = vdf_name;
+    return *this;
   }
 
-  constexpr TypeBuilder decode(vef_decode_func_t f) const {
-    TypeBuilder copy = *this;
-    copy.decode_ = f;
-    return copy;
+  constexpr TypeBuilder &decode(vef_decode_func_t f) {
+    decode_ = f;
+    return *this;
   }
 
-  constexpr TypeBuilder decode(const char *vdf_name) const {
-    TypeBuilder copy = *this;
-    copy.decode_vdf_name_ = vdf_name;
-    return copy;
+  constexpr TypeBuilder &decode(const char *vdf_name) {
+    decode_vdf_name_ = vdf_name;
+    return *this;
   }
 
-  constexpr TypeBuilder compare(vef_compare_func_t f) const {
-    TypeBuilder copy = *this;
-    copy.compare_ = f;
-    return copy;
+  constexpr TypeBuilder &compare(vef_compare_func_t f) {
+    compare_ = f;
+    return *this;
   }
 
-  constexpr TypeBuilder compare(const char *vdf_name) const {
-    TypeBuilder copy = *this;
-    copy.compare_vdf_name_ = vdf_name;
-    return copy;
+  constexpr TypeBuilder &compare(const char *vdf_name) {
+    compare_vdf_name_ = vdf_name;
+    return *this;
   }
 
-  constexpr TypeBuilder hash(vef_hash_func_t f) const {
-    TypeBuilder copy = *this;
-    copy.hash_ = f;
-    return copy;
+  constexpr TypeBuilder &hash(vef_hash_func_t f) {
+    hash_ = f;
+    return *this;
   }
 
-  constexpr TypeBuilder hash(const char *vdf_name) const {
-    TypeBuilder copy = *this;
-    copy.hash_vdf_name_ = vdf_name;
-    return copy;
+  constexpr TypeBuilder &hash(const char *vdf_name) {
+    hash_vdf_name_ = vdf_name;
+    return *this;
   }
 
-  constexpr TypeBuilder intrinsic_default(const char *vdf_name) const {
-    TypeBuilder copy = *this;
-    copy.intrinsic_default_vdf_name_ = vdf_name;
-    return copy;
+  constexpr TypeBuilder &intrinsic_default(const char *vdf_name) {
+    intrinsic_default_vdf_name_ = vdf_name;
+    return *this;
   }
 
-  constexpr TypeBuilder int_to_params(const char *vdf_name) const {
-    TypeBuilder copy = *this;
-    copy.int_to_params_vdf_name_ = vdf_name;
-    return copy;
+  constexpr TypeBuilder &int_to_params(const char *vdf_name) {
+    int_to_params_vdf_name_ = vdf_name;
+    return *this;
   }
 
-  constexpr TypeBuilder resolve_params(const char *vdf_name) const {
-    TypeBuilder copy = *this;
-    copy.resolve_params_vdf_name_ = vdf_name;
-    return copy;
+  constexpr TypeBuilder &resolve_params(const char *vdf_name) {
+    resolve_params_vdf_name_ = vdf_name;
+    return *this;
   }
 
   // Build the final vef_type_desc_t. Protocol is set automatically:


### PR DESCRIPTION
This is all constexpr so it doesn't matter in terms of
performance, but it is more idiomatic so therefore won't
lead to as much head scratching.
