### PR TITLE
.github/CLA: skip upstream

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.pull_request.labels.*.name, 'upstream-merge')"
     steps:
       - name: "CLA Assistant"
         if: >


### PR DESCRIPTION
## Description

CLA bot will skip PRs with the merge-upstream label, to avoid @ mentioning them.

## Related Issue

## How was this tested?

## Checklist
