### PR TITLE
Fix VDF IS NULL optimizer fold 

### DIFF
--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -4717,6 +4717,8 @@ bool udf_handler::fix_fields(THD *thd, Item_result_field *func, uint arg_count,
     // runtime nullability. Without this, the optimizer folds `vdf(...) IS NULL`
     // to 0 for constant non-nullable arguments.
     func->set_nullable(true);
+    // TODO(villagesql-performance): allow the extension author to express
+    // nullability.
     void *mem = (*THR_MALLOC)->Alloc(sizeof(villagesql::vdf::vdf_handler));
     if (!mem) return true;
     m_vdf = ::new (mem) villagesql::vdf::vdf_handler(u_d);


### PR DESCRIPTION
## Description
When a VDF is called with all-constant non-nullable arguments and returns VEF_RESULT_NULL at runtime (e.g., invalid algorithm name, malformed input), IS NULL on the result incorrectly returned 0. Every other operator (HEX, LENGTH, =) correctly treated the result as NULL. The value was in an inconsistent state from SQL's perspective.
                                                                                                                        
Root cause: udf_handler::fix_fields() sets func->set_nullable(false) initially and inherits nullability only from arguments. The VDF initialization block returns early without ever calling set_nullable(true), unlike classic UDFs which get their nullability round-tripped through initid.maybe_null. With all-constant non-nullable arguments, the optimizer folded IS NULL to 0 at compile time without evaluating the function.                                      

Fix: Call func->set_nullable(true) in the VDF initialization block of udf_handler::fix_fields() so the optimizer always evaluates IS NULL at runtime for VDF expressions.

## Related Issue

n/a but test results for vsql-network-address and vsql-crypto will need to be re-run as both those extensions have IS NULL assertions.

## How was this tested?

Verified on 8.4.8-villagesql-0.0.3-dev-654e2704e1a:                                                                   
                                                                                                                        
  -- All returned 0 before fix, now return 1:                                                                           
  SELECT digest('hello', 'INVALID') IS NULL;                                                                            
  SELECT cidr_from_string('not-a-cidr') IS NULL;                                                                        
                                                                                                                        
  -- These were already correct and remain so:                                                                          
  SELECT digest('hello', 'SHA256') IS NULL;   -- 0 (has a value)                                                        
  SELECT digest(NULL, 'sha256') IS NULL;      -- 1 (null propagates)                                                    
  SELECT cidr_from_string(NULL) IS NULL;      -- 1 (null propagates)                                                    
                                                                                                         
Confirmed the optimizer-fold path using a nullable column (forces runtime evaluation), which returned expected results before and after the fix.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
