### PR TITLE
sdk: Static Verification of Params

### DIFF
--- a/mysql-test/include/villagesql/compile_extension_expect_fail.inc
+++ b/mysql-test/include/villagesql/compile_extension_expect_fail.inc
@@ -1,0 +1,57 @@
+# compile_extension_expect_fail.inc - Build extension expecting compile failure
+#
+# Mirrors create_extension_sdk.inc but asserts that compilation fails and that
+# the build output contains $expect_fail_pattern.
+#
+# Usage:
+#   --let $extension_name   = my_extension
+#   --let $extension_source = $MYSQL_TEST_DIR/.../my_extension.cc
+#   --let $expect_fail_pattern = some string that must appear in the error output
+#   --source include/villagesql/compile_extension_expect_fail.inc
+#
+# The include configures and compiles the extension, then:
+#   - fails the test if the build unexpectedly succeeds, or
+#   - fails the test if $expect_fail_pattern is absent from the build output.
+#
+# Requirements:
+#   - SDK must be built (make sdk)
+#   - cmake and make must be available
+
+if (!$extension_name)
+{
+  --die ERROR: compile_extension_expect_fail.inc requires $extension_name to be set
+}
+
+if (!$extension_source)
+{
+  --die ERROR: compile_extension_expect_fail.inc requires $extension_source to be set
+}
+
+if (!$expect_fail_pattern)
+{
+  --die ERROR: compile_extension_expect_fail.inc requires $expect_fail_pattern to be set
+}
+
+--let $build_dir    = `SELECT @@basedir`
+--let $sdk_version  = `SELECT @@villagesql_server_version`
+--let $sdk_dir      = $build_dir/villagesql-extension-sdk-$sdk_version
+--let $ext_build_dir = $MYSQLTEST_VARDIR/tmp/ext_build_$extension_name
+--let $cmake_template = $MYSQL_TEST_DIR/suite/villagesql/data/extension_creator/CMakeLists.txt.template
+
+--exec test -d "$sdk_dir" || (echo "ERROR: SDK not found at $sdk_dir. Run 'make sdk' first." && exit 1)
+
+--exec rm -rf $ext_build_dir
+--exec mkdir -p $ext_build_dir/src $ext_build_dir/build
+--exec cp $extension_source $ext_build_dir/src/extension.cc
+--exec printf '%s' '{"name": "$extension_name", "version": "1.0.0"}' > $ext_build_dir/manifest.json
+--exec sed 's/@EXTENSION_NAME@/$extension_name/g' $cmake_template > $ext_build_dir/CMakeLists.txt
+
+--exec cd $ext_build_dir/build && cmake -DVillageSQL_SDK_DIR=$sdk_dir -DCMAKE_MODULE_PATH=$sdk_dir/lib/cmake/VillageSQLExtensionFramework -DVSQL_USE_DEV_ABI=ON .. > cmake_output.txt 2>&1 || (cat cmake_output.txt && exit 1)
+
+--exec cd $ext_build_dir/build && make > make_output.txt 2>&1 && { echo "ERROR: Build should have failed with: $expect_fail_pattern"; exit 1; } || grep -q "$expect_fail_pattern" make_output.txt
+
+--exec rm -rf $ext_build_dir
+
+--let $extension_name =
+--let $extension_source =
+--let $expect_fail_pattern =

--- a/mysql-test/suite/villagesql/extension/r/extension_missing_params_fn.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_missing_params_fn.result
@@ -1,12 +1,10 @@
-call mtr.add_suppression("Orphaned expansion directory found but not removed");
-call mtr.add_suppression("vef_register returned an error");
-# restart: --veb-dir=MYSQLTEST_VARDIR/veb
-Creating extension missing_params_fn using SDK...
-Created missing_params_fn.veb
-# Attempt to install extension with parameterized VDF but no parse function
-# (should fail: vef_register detects unbound params cache)
-INSTALL EXTENSION missing_params_fn;
-ERROR HY000: Failed to load VEF extension 'missing_params_fn': vef_register returned an error: VDF 'faketype_encode' uses a parameterized type cache but no .params<P, &parse_fn>() was registered for that params type; add .params<P, &parse_fn>() to the type builder
-# Verify extension was NOT installed
-SELECT * FROM INFORMATION_SCHEMA.EXTENSIONS;
-EXTENSION_NAME	EXTENSION_VERSION
+# vdf: expect compile failure for missing .params<>()
+# vdf: static_assert triggered as expected
+# encode: expect compile failure for missing .params<>()
+# encode: static_assert triggered as expected
+# decode: expect compile failure for missing .params<>()
+# decode: static_assert triggered as expected
+# compare: expect compile failure for missing .params<>()
+# compare: static_assert triggered as expected
+# hash: expect compile failure for missing .params<>()
+# hash: static_assert triggered as expected

--- a/mysql-test/suite/villagesql/extension/t/extension_missing_params_fn.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_missing_params_fn.test
@@ -1,26 +1,41 @@
-# Test that INSTALL EXTENSION fails when a parameterized VDF is registered
-# without a corresponding .params<P, &parse_fn>() call in the type builder.
-# vef_register detects the unbound params cache and returns an error rather
-# than letting the server crash on the first VDF invocation.
+# Test that compilation fails when a parameterized VDF is registered without
+# .params<P, &parse_fn>() in the type builder. Cases cover both regular VDFs
+# (CustomArgWith<P>) and each type operation (encode, decode, compare, hash).
+# This is a compile-time static_assert rather than a runtime error.
 
---let $veb_dir = $MYSQLTEST_VARDIR/veb
---exec mkdir -p $veb_dir
+--let $std_data = $MYSQL_TEST_DIR/suite/villagesql/std_data
 
-call mtr.add_suppression("Orphaned expansion directory found but not removed");
-call mtr.add_suppression("vef_register returned an error");
---replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
---let $restart_parameters = restart: --veb-dir=$veb_dir
---source include/restart_mysqld.inc
+--let $extension_name    = missing_params_vdf
+--let $extension_source  = $std_data/missing_params_vdf.cc
+--let $expect_fail_pattern = VDF parameter uses CustomArgWith
+--echo # vdf: expect compile failure for missing .params<>()
+--source include/villagesql/compile_extension_expect_fail.inc
+--echo # vdf: static_assert triggered as expected
 
---let $extension_name = missing_params_fn
---let $extension_version = 1.0.0
---let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/missing_params_fn.cc
---source include/villagesql/create_extension_sdk.inc
+--let $extension_name    = missing_params_encode
+--let $extension_source  = $std_data/missing_params_encode.cc
+--let $expect_fail_pattern = type operation VDF uses a parameterized cache
+--echo # encode: expect compile failure for missing .params<>()
+--source include/villagesql/compile_extension_expect_fail.inc
+--echo # encode: static_assert triggered as expected
 
---echo # Attempt to install extension with parameterized VDF but no parse function
---echo # (should fail: vef_register detects unbound params cache)
---error ER_VILLAGESQL_GENERIC_ERROR
-INSTALL EXTENSION missing_params_fn;
+--let $extension_name    = missing_params_decode
+--let $extension_source  = $std_data/missing_params_decode.cc
+--let $expect_fail_pattern = type operation VDF uses a parameterized cache
+--echo # decode: expect compile failure for missing .params<>()
+--source include/villagesql/compile_extension_expect_fail.inc
+--echo # decode: static_assert triggered as expected
 
---echo # Verify extension was NOT installed
-SELECT * FROM INFORMATION_SCHEMA.EXTENSIONS;
+--let $extension_name    = missing_params_compare
+--let $extension_source  = $std_data/missing_params_compare.cc
+--let $expect_fail_pattern = type operation VDF uses a parameterized cache
+--echo # compare: expect compile failure for missing .params<>()
+--source include/villagesql/compile_extension_expect_fail.inc
+--echo # compare: static_assert triggered as expected
+
+--let $extension_name    = missing_params_hash
+--let $extension_source  = $std_data/missing_params_hash.cc
+--let $expect_fail_pattern = type operation VDF uses a parameterized cache
+--echo # hash: expect compile failure for missing .params<>()
+--source include/villagesql/compile_extension_expect_fail.inc
+--echo # hash: static_assert triggered as expected

--- a/mysql-test/suite/villagesql/std_data/missing_params_compare.cc
+++ b/mysql-test/suite/villagesql/std_data/missing_params_compare.cc
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Compile-fail test: parameterized compare VDF without .params<>().
+// The SDK static_assert fires at the make_type_compare .func() call.
+
+#include <villagesql/extension.h>
+
+#include <cstddef>
+#include <cstring>
+#include <map>
+#include <string>
+#include <string_view>
+
+struct FakeParams {
+  int value;
+  static FakeParams parse(const std::map<std::string, std::string> &) {
+    return FakeParams{0};
+  }
+};
+
+bool faketype_encode(std::string_view from, villagesql::Span<unsigned char> buf,
+                     size_t *length) {
+  size_t n = from.size() < buf.size() ? from.size() : buf.size();
+  memcpy(buf.data(), from.data(), n);
+  *length = n;
+  return false;
+}
+
+bool faketype_decode(villagesql::Span<const unsigned char> data,
+                     villagesql::Span<char> out, size_t *out_len) {
+  size_t n = data.size() < out.size() ? data.size() : out.size();
+  memcpy(out.data(), data.data(), n);
+  *out_len = n;
+  return false;
+}
+
+int faketype_compare(const FakeParams &,
+                     villagesql::Span<const unsigned char> a,
+                     villagesql::Span<const unsigned char> b) {
+  size_t n = a.size() < b.size() ? a.size() : b.size();
+  int r = memcmp(a.data(), b.data(), n);
+  if (r != 0) return r;
+  return static_cast<int>(a.size()) - static_cast<int>(b.size());
+}
+
+constexpr const char *FAKETYPE = "FAKETYPE";
+
+VEF_GENERATE_ENTRY_POINTS(
+    make_extension(VEF_EXTENSION_NAME, "0.0.1-devtest")
+        .type(
+            make_type(FAKETYPE)
+                .persisted_length(64)
+                .max_decode_buffer_length(64)
+                .encode("faketype_encode")
+                .decode("faketype_decode")
+                .compare("faketype_compare")
+                .build())  // .params<FakeParams, &FakeParams::parse>() omitted
+        .func(make_type_encode<&faketype_encode>("faketype_encode", FAKETYPE))
+        .func(make_type_decode<&faketype_decode>("faketype_decode", FAKETYPE))
+        .func(make_type_compare<&faketype_compare>("faketype_compare",
+                                                   FAKETYPE)))

--- a/mysql-test/suite/villagesql/std_data/missing_params_decode.cc
+++ b/mysql-test/suite/villagesql/std_data/missing_params_decode.cc
@@ -1,0 +1,74 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Compile-fail test: parameterized decode VDF without .params<>().
+// The SDK static_assert fires at the make_type_decode .func() call.
+
+#include <villagesql/extension.h>
+
+#include <cstddef>
+#include <cstring>
+#include <map>
+#include <string>
+#include <string_view>
+
+struct FakeParams {
+  int value;
+  static FakeParams parse(const std::map<std::string, std::string> &) {
+    return FakeParams{0};
+  }
+};
+
+bool faketype_encode(std::string_view from, villagesql::Span<unsigned char> buf,
+                     size_t *length) {
+  size_t n = from.size() < buf.size() ? from.size() : buf.size();
+  memcpy(buf.data(), from.data(), n);
+  *length = n;
+  return false;
+}
+
+bool faketype_decode(const FakeParams &,
+                     villagesql::Span<const unsigned char> data,
+                     villagesql::Span<char> out, size_t *out_len) {
+  size_t n = data.size() < out.size() ? data.size() : out.size();
+  memcpy(out.data(), data.data(), n);
+  *out_len = n;
+  return false;
+}
+
+int faketype_compare(villagesql::Span<const unsigned char> a,
+                     villagesql::Span<const unsigned char> b) {
+  size_t n = a.size() < b.size() ? a.size() : b.size();
+  int r = memcmp(a.data(), b.data(), n);
+  if (r != 0) return r;
+  return static_cast<int>(a.size()) - static_cast<int>(b.size());
+}
+
+constexpr const char *FAKETYPE = "FAKETYPE";
+
+VEF_GENERATE_ENTRY_POINTS(
+    make_extension(VEF_EXTENSION_NAME, "0.0.1-devtest")
+        .type(
+            make_type(FAKETYPE)
+                .persisted_length(64)
+                .max_decode_buffer_length(64)
+                .encode("faketype_encode")
+                .decode("faketype_decode")
+                .compare("faketype_compare")
+                .build())  // .params<FakeParams, &FakeParams::parse>() omitted
+        .func(make_type_encode<&faketype_encode>("faketype_encode", FAKETYPE))
+        .func(make_type_decode<&faketype_decode>("faketype_decode", FAKETYPE))
+        .func(make_type_compare<&faketype_compare>("faketype_compare",
+                                                   FAKETYPE)))

--- a/mysql-test/suite/villagesql/std_data/missing_params_encode.cc
+++ b/mysql-test/suite/villagesql/std_data/missing_params_encode.cc
@@ -13,8 +13,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
-// Test extension: parameterized encode VDF registered without .params<>().
-// vef_register should fail immediately rather than crashing on first VDF call.
+// Compile-fail test: parameterized encode VDF without .params<>().
+// The SDK static_assert fires at the make_type_encode .func() call.
 
 #include <villagesql/extension.h>
 
@@ -26,15 +26,11 @@
 
 struct FakeParams {
   int value;
-
   static FakeParams parse(const std::map<std::string, std::string> &) {
     return FakeParams{0};
   }
 };
 
-// Parameterized encode: takes const FakeParams& as first argument, so the SDK
-// will route through the params cache. .params<FakeParams,
-// &FakeParams::parse>() is intentionally omitted from the type builder below.
 bool faketype_encode(const FakeParams &, std::string_view from,
                      villagesql::Span<unsigned char> buf, size_t *length) {
   size_t n = from.size() < buf.size() ? from.size() : buf.size();
@@ -59,23 +55,18 @@ int faketype_compare(villagesql::Span<const unsigned char> a,
   return static_cast<int>(a.size()) - static_cast<int>(b.size());
 }
 
-using namespace villagesql::extension_builder;
-using namespace villagesql::func_builder;
-using namespace villagesql::type_builder;
-
 constexpr const char *FAKETYPE = "FAKETYPE";
 
-// .params<FakeParams, &FakeParams::parse>() is deliberately omitted so that
-// the params cache is never bound. vef_register should detect this and fail.
 VEF_GENERATE_ENTRY_POINTS(
     make_extension(VEF_EXTENSION_NAME, "0.0.1-devtest")
-        .type(make_type(FAKETYPE)
-                  .persisted_length(64)
-                  .max_decode_buffer_length(64)
-                  .encode("faketype_encode")
-                  .decode("faketype_decode")
-                  .compare("faketype_compare")
-                  .build())
+        .type(
+            make_type(FAKETYPE)
+                .persisted_length(64)
+                .max_decode_buffer_length(64)
+                .encode("faketype_encode")
+                .decode("faketype_decode")
+                .compare("faketype_compare")
+                .build())  // .params<FakeParams, &FakeParams::parse>() omitted
         .func(make_type_encode<&faketype_encode>("faketype_encode", FAKETYPE))
         .func(make_type_decode<&faketype_decode>("faketype_decode", FAKETYPE))
         .func(make_type_compare<&faketype_compare>("faketype_compare",

--- a/mysql-test/suite/villagesql/std_data/missing_params_hash.cc
+++ b/mysql-test/suite/villagesql/std_data/missing_params_hash.cc
@@ -1,0 +1,82 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Compile-fail test: parameterized hash VDF without .params<>().
+// The SDK static_assert fires at the make_type_hash .func() call.
+
+#include <villagesql/extension.h>
+
+#include <cstddef>
+#include <cstring>
+#include <map>
+#include <string>
+#include <string_view>
+
+struct FakeParams {
+  int value;
+  static FakeParams parse(const std::map<std::string, std::string> &) {
+    return FakeParams{0};
+  }
+};
+
+bool faketype_encode(std::string_view from, villagesql::Span<unsigned char> buf,
+                     size_t *length) {
+  size_t n = from.size() < buf.size() ? from.size() : buf.size();
+  memcpy(buf.data(), from.data(), n);
+  *length = n;
+  return false;
+}
+
+bool faketype_decode(villagesql::Span<const unsigned char> data,
+                     villagesql::Span<char> out, size_t *out_len) {
+  size_t n = data.size() < out.size() ? data.size() : out.size();
+  memcpy(out.data(), data.data(), n);
+  *out_len = n;
+  return false;
+}
+
+int faketype_compare(villagesql::Span<const unsigned char> a,
+                     villagesql::Span<const unsigned char> b) {
+  size_t n = a.size() < b.size() ? a.size() : b.size();
+  int r = memcmp(a.data(), b.data(), n);
+  if (r != 0) return r;
+  return static_cast<int>(a.size()) - static_cast<int>(b.size());
+}
+
+size_t faketype_hash(const FakeParams &,
+                     villagesql::Span<const unsigned char> data) {
+  size_t h = 0;
+  for (size_t i = 0; i < data.size(); ++i) h = h * 31 + data[i];
+  return h;
+}
+
+constexpr const char *FAKETYPE = "FAKETYPE";
+
+VEF_GENERATE_ENTRY_POINTS(
+    make_extension(VEF_EXTENSION_NAME, "0.0.1-devtest")
+        .type(
+            make_type(FAKETYPE)
+                .persisted_length(64)
+                .max_decode_buffer_length(64)
+                .encode("faketype_encode")
+                .decode("faketype_decode")
+                .compare("faketype_compare")
+                .hash("faketype_hash")
+                .build())  // .params<FakeParams, &FakeParams::parse>() omitted
+        .func(make_type_encode<&faketype_encode>("faketype_encode", FAKETYPE))
+        .func(make_type_decode<&faketype_decode>("faketype_decode", FAKETYPE))
+        .func(make_type_compare<&faketype_compare>("faketype_compare",
+                                                   FAKETYPE))
+        .func(make_type_hash<&faketype_hash>("faketype_hash", FAKETYPE)))

--- a/mysql-test/suite/villagesql/std_data/missing_params_vdf.cc
+++ b/mysql-test/suite/villagesql/std_data/missing_params_vdf.cc
@@ -1,0 +1,93 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Compile-fail test: regular VDF using CustomArgWith<FakeParams> without
+// .params<FakeParams, &FakeParams::parse>() in the type builder.
+// The SDK static_assert fires at the make_func .func() call.
+
+#include <villagesql/extension.h>
+
+#include <cstddef>
+#include <cstring>
+#include <map>
+#include <string>
+
+struct FakeParams {
+  int value;
+  static FakeParams parse(const std::map<std::string, std::string> &) {
+    return FakeParams{0};
+  }
+};
+
+bool faketype_encode(std::string_view from, villagesql::Span<unsigned char> buf,
+                     size_t *length) {
+  size_t n = from.size() < buf.size() ? from.size() : buf.size();
+  memcpy(buf.data(), from.data(), n);
+  *length = n;
+  return false;
+}
+
+bool faketype_decode(villagesql::Span<const unsigned char> data,
+                     villagesql::Span<char> out, size_t *out_len) {
+  size_t n = data.size() < out.size() ? data.size() : out.size();
+  memcpy(out.data(), data.data(), n);
+  *out_len = n;
+  return false;
+}
+
+int faketype_compare(villagesql::Span<const unsigned char> a,
+                     villagesql::Span<const unsigned char> b) {
+  size_t n = a.size() < b.size() ? a.size() : b.size();
+  int r = memcmp(a.data(), b.data(), n);
+  if (r != 0) return r;
+  return static_cast<int>(a.size()) - static_cast<int>(b.size());
+}
+
+// Regular VDF using CustomArgWith<FakeParams>. .params<FakeParams, &parse>()
+// is deliberately omitted from the type builder, so the SDK static_assert
+// fires.
+void faketype_identity(villagesql::CustomArgWith<FakeParams> in,
+                       villagesql::CustomResult out) {
+  if (in.is_null()) {
+    out.set_null();
+    return;
+  }
+  auto src = in.value();
+  auto dst = out.buffer();
+  size_t n = src.size() < dst.size() ? src.size() : dst.size();
+  memcpy(dst.data(), src.data(), n);
+  out.set_length(n);
+}
+
+constexpr const char *FAKETYPE = "FAKETYPE";
+
+VEF_GENERATE_ENTRY_POINTS(
+    make_extension(VEF_EXTENSION_NAME, "0.0.1-devtest")
+        .type(
+            make_type(FAKETYPE)
+                .persisted_length(64)
+                .max_decode_buffer_length(64)
+                .encode("faketype_encode")
+                .decode("faketype_decode")
+                .compare("faketype_compare")
+                .build())  // .params<FakeParams, &FakeParams::parse>() omitted
+        .func(make_type_encode<&faketype_encode>("faketype_encode", FAKETYPE))
+        .func(make_type_decode<&faketype_decode>("faketype_decode", FAKETYPE))
+        .func(make_type_compare<&faketype_compare>("faketype_compare",
+                                                   FAKETYPE))
+        .func(make_func<&faketype_identity>("faketype_identity")
+                  .returns(FAKETYPE)
+                  .param(FAKETYPE)
+                  .build()))

--- a/villagesql/sdk/include/villagesql/extension_builder.h
+++ b/villagesql/sdk/include/villagesql/extension_builder.h
@@ -37,6 +37,52 @@
 #include <villagesql/type_builder.h>
 
 namespace villagesql {
+
+namespace detail {
+
+// Compile-time validation helpers. Defined before ExtensionBuilder so that
+// detail::validate_custom_params is visible when ExtensionBuilder::func() is
+// parsed (qualified names are resolved at template definition time by Clang).
+
+// Extracts params_type from the TypeTuple element at compile-time index I.
+template <size_t I, typename TypeTuple>
+using params_type_at = typename std::tuple_element_t<I, TypeTuple>::params_type;
+
+// Returns true if P appears as the params_type of any element in TypeTuple.
+// P = void is never considered registered.
+template <typename P, typename TypeTuple, size_t I = 0>
+constexpr bool is_params_type_registered() {
+  if constexpr (I >= std::tuple_size_v<TypeTuple>) {
+    return false;
+  } else if constexpr (std::is_same_v<params_type_at<I, TypeTuple>, P>) {
+    return true;
+  } else {
+    return is_params_type_registered<P, TypeTuple, I + 1>();
+  }
+}
+
+// For each parameter of Func that is CustomArgWith<P> or CustomResultWith<P>,
+// asserts at compile time that P is registered as a params_type in TypeTuple
+// via .params<P, &fn>() on the corresponding type builder.
+template <auto Func, typename TypeTuple, size_t I = 0>
+constexpr void validate_custom_params() {
+  using ParamTuple =
+      typename func_builder::FuncParamTypes<decltype(Func)>::type;
+  if constexpr (I < std::tuple_size_v<ParamTuple>) {
+    using T = std::tuple_element_t<I, ParamTuple>;
+    using P = typename func_builder::params_type_of<T>::type;
+    if constexpr (!std::is_void_v<P>) {
+      static_assert(is_params_type_registered<P, TypeTuple>(),
+                    "VDF parameter uses CustomArgWith<P> or "
+                    "CustomResultWith<P> but P is not registered via "
+                    ".params<P, &fn>() on any type builder");
+    }
+    validate_custom_params<Func, TypeTuple, I + 1>();
+  }
+}
+
+}  // namespace detail
+
 namespace extension_builder {
 
 using namespace func_builder;
@@ -58,7 +104,8 @@ struct ExtensionBuilder {
   TypeTuple types_;
   vef_protocol_t min_protocol_;
 
-  // Add a function (returns new builder with function appended)
+  // Add a function from a StaticFuncDesc. This is the terminal overload that
+  // all other func() overloads delegate to after validation.
   template <typename F>
   constexpr auto func(F f) const {
     auto new_funcs = std::tuple_cat(funcs_, std::make_tuple(f));
@@ -66,10 +113,40 @@ struct ExtensionBuilder {
         name_, version_, new_funcs, types_, min_protocol_};
   }
 
+  // Add a function from a TypedFuncDesc (the result of FuncBuilder::build() or
+  // make_type_encode/decode/compare/hash/intrinsic_default).
+  // Validates at compile time that:
+  //   - every CustomArgWith<P> / CustomResultWith<P> parameter has P registered
+  //     in this builder's TypeTuple via .params<P, &fn>(); and
+  //   - for parameterized type operation VDFs (ParamsType != void), ParamsType
+  //     is likewise registered.
+  // Works whether the descriptor is inline or pre-built.
+  template <auto Func, size_t N, typename ParamsType>
+  constexpr auto func(const TypedFuncDesc<Func, N, ParamsType> &desc) const {
+    detail::validate_custom_params<Func, TypeTuple>();
+    if constexpr (!std::is_void_v<ParamsType>) {
+      static_assert(
+          detail::is_params_type_registered<ParamsType, TypeTuple>(),
+          "type operation VDF uses a parameterized cache but its params "
+          "type P is not registered via .params<P, &fn>() on any type builder");
+    }
+    return func(static_cast<const StaticFuncDesc<N> &>(desc));
+  }
+
+  // Convenience overload: accepts a FuncBuilder directly (without calling
+  // .build() at the call site) by delegating to the TypedFuncDesc overload.
+  template <auto Func, size_t N>
+  constexpr auto func(const FuncBuilder<Func, N> &builder) const {
+    return func(builder.build());
+  }
+
   // Add a type (returns new builder with type appended).
-  // If the type requires a higher protocol than min_protocol_, min_protocol_
-  // is raised automatically.
-  constexpr auto type(const TypeDescriptor &type) const {
+  // Accepts TypeDescriptorWithParams<P> so the params type P is preserved in
+  // the TypeTuple, enabling compile-time validation in later steps. If the type
+  // requires a higher protocol than min_protocol_, min_protocol_ is raised
+  // automatically.
+  template <typename P>
+  constexpr auto type(const TypeDescriptorWithParams<P> &type) const {
     auto new_types = std::tuple_cat(types_, std::make_tuple(type));
     const auto &t = type.vef_desc;
     const vef_protocol_t new_min =
@@ -146,21 +223,6 @@ void vef_init_type_params(const Ext &e, std::index_sequence<Is...>) {
    ...);
 }
 
-// Returns the name of the first VDF that requires a bound params cache but
-// whose cache was not bound (i.e., .params<P, &parse_fn>() was omitted from
-// the type builder). Must be called after vef_init_type_params().
-template <typename Ext, size_t... Is>
-const char *vef_check_params_cache(const Ext &e, std::index_sequence<Is...>) {
-  const char *unbound = nullptr;
-  auto check_one = [&unbound](const auto &func) {
-    if (unbound) return;
-    auto check_fn = func.check_params_cache_bound();
-    if (check_fn && !check_fn()) unbound = func.name();
-  };
-  (check_one(e.template func_at<Is>()), ...);
-  return unbound;
-}
-
 // Core registration logic called by VEF_GENERATE_ENTRY_POINTS.
 // FuncCount and TypeCount are explicit template parameters so that array
 // sizes are compile-time constants without relying on VLAs.
@@ -190,22 +252,6 @@ vef_registration_t *vef_register_impl(vef_registration_t &reg,
   if constexpr (TypeCount > 0) {
     vef_fill_type_ptrs(type_ptrs, ext, std::make_index_sequence<TypeCount>{});
     vef_init_type_params(ext, std::make_index_sequence<TypeCount>{});
-  }
-
-  if constexpr (FuncCount > 0) {
-    const char *unbound_vdf =
-        vef_check_params_cache(ext, std::make_index_sequence<FuncCount>{});
-    if (unbound_vdf) {
-      static char error_buf[256];
-      snprintf(error_buf, sizeof(error_buf),
-               "VDF '%s' uses a parameterized type cache but no "
-               ".params<P, &parse_fn>() was registered for that params type; "
-               "add .params<P, &parse_fn>() to the type builder",
-               unbound_vdf);
-      reg.protocol = arg->protocol;
-      reg.error_msg = error_buf;
-      return &reg;
-    }
   }
 
   reg.protocol = VEF_PROTOCOL_2;

--- a/villagesql/sdk/include/villagesql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/func_builder.h
@@ -119,8 +119,7 @@ struct FuncWithMetadata {
         param_types{},
         num_params(0),
         buffer_size(0),
-        deterministic(false),
-        check_params_cache_bound(nullptr) {}
+        deterministic(false) {}
 
   ExtFunc f;
   vef_prerun_func_t prerun;
@@ -130,10 +129,6 @@ struct FuncWithMetadata {
   size_t num_params;
   size_t buffer_size;
   bool deterministic;
-  // Non-null for VDFs that use a parameterized type cache. Points to a
-  // function that returns true if the cache has been bound. Set by the cache
-  // wrapper selection in make_type_encode/decode/compare/intrinsic_default.
-  bool (*check_params_cache_bound)();
 };
 
 // =============================================================================
@@ -333,7 +328,7 @@ struct ToStringWrapper {
 // Extension authors must implement functions with the following signatures
 // to enable a new type to be used in VillageSQL, and use the builders
 // make_type_encode, make_type_decode, make_type_compare, and make_type_hash to
-// and register the names with the type builder.
+// register the names with the type builder.
 //   TypeEncodeFunc  -> VDF: (STRING) -> CUSTOM(type)
 //   TypeDecodeFunc  -> VDF: (CUSTOM(type)) -> STRING
 //   TypeCompareFunc -> VDF: (CUSTOM(type), CUSTOM(type)) -> INT
@@ -826,7 +821,6 @@ struct StaticFuncDesc {
   vef_postrun_func_t postrun_;
   size_t buffer_size_;
   bool deterministic_;
-  bool (*check_params_cache_bound_)();
 
   constexpr StaticFuncDesc(const char *name, const FuncWithMetadata &meta)
       : name_(name),
@@ -836,8 +830,7 @@ struct StaticFuncDesc {
         prerun_(meta.prerun),
         postrun_(meta.postrun),
         buffer_size_(meta.buffer_size),
-        deterministic_(meta.deterministic),
-        check_params_cache_bound_(meta.check_params_cache_bound) {
+        deterministic_(meta.deterministic) {
     for (size_t i = 0; i < NumParams && i < meta.num_params; ++i) {
       params_[i] = meta.param_types[i];
     }
@@ -853,9 +846,21 @@ struct StaticFuncDesc {
   constexpr vef_postrun_func_t postrun() const { return postrun_; }
   constexpr size_t buffer_size() const { return buffer_size_; }
   constexpr bool deterministic() const { return deterministic_; }
-  constexpr auto check_params_cache_bound() const -> bool (*)() {
-    return check_params_cache_bound_;
-  }
+};
+
+// TypedFuncDesc carries the function pointer Func as a template parameter so
+// that ExtensionBuilder::func() can run compile-time validation even when the
+// descriptor was pre-built and stored in a variable before registration.
+// Inherits all data and accessors from StaticFuncDesc<N>.
+//
+// ParamsType is void for regular VDFs. For parameterized type operation VDFs
+// (make_type_encode/decode/compare/hash/intrinsic_default with a const P& first
+// parameter), ParamsType is set to P so ExtensionBuilder can verify that P was
+// registered via .params<P, &fn>() on the type builder.
+template <auto Func, size_t N, typename ParamsType = void>
+struct TypedFuncDesc : StaticFuncDesc<N> {
+  using params_type = ParamsType;
+  using StaticFuncDesc<N>::StaticFuncDesc;
 };
 
 // Materializes the ABI descriptor structures at registration time.
@@ -907,64 +912,6 @@ template <typename P>
 struct params_type_of<CustomResultWith<P>> {
   using type = P;
 };
-
-// Appends T to Tuple<Existing...> only if T is not already present.
-// Uses a fold expression over Existing to check membership.
-template <typename T, typename AccumTuple>
-struct append_if_absent;
-template <typename T, typename... Existing>
-struct append_if_absent<T, std::tuple<Existing...>> {
-  using type =
-      std::conditional_t<(std::is_same_v<T, Existing> || ...),
-                         std::tuple<Existing...>, std::tuple<Existing..., T>>;
-};
-
-// Collects the distinct non-void params types from InputTuple into a
-// std::tuple<P1, P2, ...>, preserving order of first appearance.
-// N is passed explicitly to avoid ill-formed partial specialization on
-// std::tuple_size_v<InputTuple>.
-template <typename InputTuple, size_t I, size_t N, typename AccumTuple>
-struct unique_params_types_impl {
-  using P =
-      typename params_type_of<std::tuple_element_t<I, InputTuple>>::type;
-  using NextAccum =
-      std::conditional_t<std::is_void_v<P>, AccumTuple,
-                         typename append_if_absent<P, AccumTuple>::type>;
-  using type =
-      typename unique_params_types_impl<InputTuple, I + 1, N, NextAccum>::type;
-};
-template <typename InputTuple, size_t N, typename AccumTuple>
-struct unique_params_types_impl<InputTuple, N, N, AccumTuple> {
-  using type = AccumTuple;
-};
-
-// Public entry point: unique_params_types<Tuple>::type is a std::tuple of the
-// distinct P types used by CustomArgWith<P> or CustomResultWith<P> in Tuple.
-template <typename Tuple>
-struct unique_params_types {
-  using type = typename unique_params_types_impl<
-      Tuple, 0, std::tuple_size_v<Tuple>, std::tuple<>>::type;
-};
-
-// Checks that all TypeParamsCaches for Ps... have been bound. Used as the
-// check_params_cache_bound function pointer for VDFs that use parameterized
-// custom types via CustomArgWith<P> or CustomResultWith<P>.
-template <typename... Ps>
-struct params_cache_checker {
-  static bool check() { return (is_params_cache_bound<Ps>() && ...); }
-};
-// Specialization for the no-params case (vacuously true, never stored).
-template <>
-struct params_cache_checker<> {
-  static bool check() { return true; }
-};
-
-// Unpacks a std::tuple<Ps...> into params_cache_checker<Ps...>.
-template <typename Tuple>
-struct apply_params_cache_checker;
-template <typename... Ps>
-struct apply_params_cache_checker<std::tuple<Ps...>>
-    : params_cache_checker<Ps...> {};
 
 // =============================================================================
 // FuncBuilder
@@ -1041,13 +988,13 @@ struct FuncBuilder {
     return *this;
   }
 
-  // Finalize the function definition and produce the StaticFuncDesc
-  constexpr StaticFuncDesc<NumParams> build() const {
+  // Finalize the function definition and produce a TypedFuncDesc, which
+  // preserves Func as a template parameter so that ExtensionBuilder::func()
+  // can run compile-time validation even when the result is stored in a
+  // variable before registration.
+  constexpr TypedFuncDesc<Func, NumParams> build() const {
     static_assert(NumParams <= kMaxParams,
                   "Too many parameters (max is kMaxParams)");
-
-    using AllParams = typename FuncParamTypes<decltype(Func)>::type;
-    using UniquePTuple = typename unique_params_types<AllParams>::type;
 
     FuncWithMetadata meta{};
     meta.f = &Wrapper<Func, NumParams>::invoke;
@@ -1060,12 +1007,8 @@ struct FuncBuilder {
     for (size_t i = 0; i < NumParams; ++i) {
       meta.param_types[i] = to_vef_type(param_types_[i]);
     }
-    if constexpr (std::tuple_size_v<UniquePTuple> > 0) {
-      meta.check_params_cache_bound =
-          &apply_params_cache_checker<UniquePTuple>::check;
-    }
 
-    return StaticFuncDesc<NumParams>(name_, meta);
+    return TypedFuncDesc<Func, NumParams>(name_, meta);
   }
 };
 
@@ -1148,20 +1091,19 @@ constexpr StaticFuncDesc<1> make_resolve_params(const char *name) {
 // (parse function must be bound via .params<P, &parse_fn>() in the type
 // builder).
 template <auto Func>
-constexpr StaticFuncDesc<0> make_intrinsic_default(const char *name,
-                                                   const char *type_name) {
+constexpr auto make_intrinsic_default(const char *name, const char *type_name) {
   FuncWithMetadata meta{};
-  if constexpr (std::is_same_v<decltype(Func), IntrinsicDefaultFunc>) {
-    meta.f = &IntrinsicDefaultWrapper<Func>::invoke;
-  } else {
-    meta.f = &IntrinsicDefaultWithCacheWrapper<Func>::invoke;
-    meta.check_params_cache_bound = &is_params_cache_bound<
-        typename IntrinsicDefaultWithCacheWrapper<Func>::P>;
-  }
   meta.return_type = to_vef_type(type_name);
   meta.num_params = 0;
   meta.buffer_size = 0;  // server provides bin_buf sized to persisted_length
-  return StaticFuncDesc<0>(name, meta);
+  if constexpr (std::is_same_v<decltype(Func), IntrinsicDefaultFunc>) {
+    meta.f = &IntrinsicDefaultWrapper<Func>::invoke;
+    return TypedFuncDesc<Func, 0, void>(name, meta);
+  } else {
+    meta.f = &IntrinsicDefaultWithCacheWrapper<Func>::invoke;
+    using P = typename IntrinsicDefaultWithCacheWrapper<Func>::P;
+    return TypedFuncDesc<Func, 0, P>(name, meta);
+  }
 }
 
 // Entry point for encode VDFs: (STRING) -> CUSTOM(type_name).
@@ -1170,21 +1112,20 @@ constexpr StaticFuncDesc<0> make_intrinsic_default(const char *name,
 // in which case the SDK routes through the params cache (parse function must
 // be bound via .params<P, &parse_fn>() in the type builder).
 template <auto Func>
-constexpr StaticFuncDesc<1> make_type_encode(const char *name,
-                                             const char *type_name) {
+constexpr auto make_type_encode(const char *name, const char *type_name) {
   FuncWithMetadata meta{};
-  if constexpr (std::is_same_v<decltype(Func), TypeEncodeFunc>) {
-    meta.f = &TypeEncodeVdfWrapper<Func>::invoke;
-  } else {
-    meta.f = &TypeEncodeWithCacheVdfWrapper<Func>::invoke;
-    meta.check_params_cache_bound =
-        &is_params_cache_bound<typename TypeEncodeWithCacheVdfWrapper<Func>::P>;
-  }
   meta.return_type = to_vef_type(type_name);
   meta.param_types[0] = to_vef_type(STRING);
   meta.num_params = 1;
   meta.buffer_size = 0;  // server provides bin_buf sized to persisted_length
-  return StaticFuncDesc<1>(name, meta);
+  if constexpr (std::is_same_v<decltype(Func), TypeEncodeFunc>) {
+    meta.f = &TypeEncodeVdfWrapper<Func>::invoke;
+    return TypedFuncDesc<Func, 1, void>(name, meta);
+  } else {
+    meta.f = &TypeEncodeWithCacheVdfWrapper<Func>::invoke;
+    using P = typename TypeEncodeWithCacheVdfWrapper<Func>::P;
+    return TypedFuncDesc<Func, 1, P>(name, meta);
+  }
 }
 
 // Entry point for decode VDFs: (CUSTOM(type_name)) -> STRING.
@@ -1193,21 +1134,20 @@ constexpr StaticFuncDesc<1> make_type_encode(const char *name,
 // in which case the SDK routes through the params cache (parse function must
 // be bound via .params<P, &parse_fn>() in the type builder).
 template <auto Func>
-constexpr StaticFuncDesc<1> make_type_decode(const char *name,
-                                             const char *type_name) {
+constexpr auto make_type_decode(const char *name, const char *type_name) {
   FuncWithMetadata meta{};
-  if constexpr (std::is_same_v<decltype(Func), TypeDecodeFunc>) {
-    meta.f = &TypeDecodeVdfWrapper<Func>::invoke;
-  } else {
-    meta.f = &TypeDecodeWithCacheVdfWrapper<Func>::invoke;
-    meta.check_params_cache_bound =
-        &is_params_cache_bound<typename TypeDecodeWithCacheVdfWrapper<Func>::P>;
-  }
   meta.return_type = to_vef_type(STRING);
   meta.param_types[0] = to_vef_type(type_name);
   meta.num_params = 1;
   meta.buffer_size = 0;
-  return StaticFuncDesc<1>(name, meta);
+  if constexpr (std::is_same_v<decltype(Func), TypeDecodeFunc>) {
+    meta.f = &TypeDecodeVdfWrapper<Func>::invoke;
+    return TypedFuncDesc<Func, 1, void>(name, meta);
+  } else {
+    meta.f = &TypeDecodeWithCacheVdfWrapper<Func>::invoke;
+    using P = typename TypeDecodeWithCacheVdfWrapper<Func>::P;
+    return TypedFuncDesc<Func, 1, P>(name, meta);
+  }
 }
 
 // Entry point for compare VDFs: (CUSTOM(type_name), CUSTOM(type_name)) -> INT.
@@ -1217,22 +1157,21 @@ constexpr StaticFuncDesc<1> make_type_decode(const char *name,
 // in which case the SDK routes through the params cache (parse function must
 // be bound via .params<P, &parse_fn>() in the type builder).
 template <auto Func>
-constexpr StaticFuncDesc<2> make_type_compare(const char *name,
-                                              const char *type_name) {
+constexpr auto make_type_compare(const char *name, const char *type_name) {
   FuncWithMetadata meta{};
-  if constexpr (std::is_same_v<decltype(Func), TypeCompareFunc>) {
-    meta.f = &TypeCompareVdfWrapper<Func>::invoke;
-  } else {
-    meta.f = &TypeCompareWithCacheVdfWrapper<Func>::invoke;
-    meta.check_params_cache_bound = &is_params_cache_bound<
-        typename TypeCompareWithCacheVdfWrapper<Func>::P>;
-  }
   meta.return_type = to_vef_type(INT);
   meta.param_types[0] = to_vef_type(type_name);
   meta.param_types[1] = to_vef_type(type_name);
   meta.num_params = 2;
   meta.buffer_size = 0;
-  return StaticFuncDesc<2>(name, meta);
+  if constexpr (std::is_same_v<decltype(Func), TypeCompareFunc>) {
+    meta.f = &TypeCompareVdfWrapper<Func>::invoke;
+    return TypedFuncDesc<Func, 2, void>(name, meta);
+  } else {
+    meta.f = &TypeCompareWithCacheVdfWrapper<Func>::invoke;
+    using P = typename TypeCompareWithCacheVdfWrapper<Func>::P;
+    return TypedFuncDesc<Func, 2, P>(name, meta);
+  }
 }
 
 // Entry point for hash VDFs: (CUSTOM(type_name)) -> INT.
@@ -1242,21 +1181,20 @@ constexpr StaticFuncDesc<2> make_type_compare(const char *name,
 // in which case the SDK routes through the params cache (parse function must
 // be bound via .params<P, &parse_fn>() in the type builder).
 template <auto Func>
-constexpr StaticFuncDesc<1> make_type_hash(const char *name,
-                                           const char *type_name) {
+constexpr auto make_type_hash(const char *name, const char *type_name) {
   FuncWithMetadata meta{};
-  if constexpr (std::is_same_v<decltype(Func), TypeHashFunc>) {
-    meta.f = &TypeHashVdfWrapper<Func>::invoke;
-  } else {
-    meta.f = &TypeHashWithCacheVdfWrapper<Func>::invoke;
-    meta.check_params_cache_bound =
-        &is_params_cache_bound<typename TypeHashWithCacheVdfWrapper<Func>::P>;
-  }
   meta.return_type = to_vef_type(INT);
   meta.param_types[0] = to_vef_type(type_name);
   meta.num_params = 1;
   meta.buffer_size = 0;
-  return StaticFuncDesc<1>(name, meta);
+  if constexpr (std::is_same_v<decltype(Func), TypeHashFunc>) {
+    meta.f = &TypeHashVdfWrapper<Func>::invoke;
+    return TypedFuncDesc<Func, 1, void>(name, meta);
+  } else {
+    meta.f = &TypeHashWithCacheVdfWrapper<Func>::invoke;
+    using P = typename TypeHashWithCacheVdfWrapper<Func>::P;
+    return TypedFuncDesc<Func, 1, P>(name, meta);
+  }
 }
 
 // =============================================================================

--- a/villagesql/sdk/include/villagesql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/type_builder.h
@@ -51,6 +51,10 @@ void bind_params_cache() {
 // Wrapper around the ABI type descriptor that owns the storage interface
 // structure and ensures vef_desc.storage_intf points to the local copy
 // after copy/move operations.
+//
+// TypeDescriptorWithParams<P> is the parameterized form used when a type
+// registers a params type via .params<P, &fn>(). Code that doesn't care about
+// the params type can hold or accept the base TypeDescriptor.
 struct TypeDescriptor {
   vef_type_desc_t vef_desc{};
   vef_type_storage_intf_t storage_intf{};
@@ -81,164 +85,184 @@ struct TypeDescriptor {
   }
 };
 
+// TypeDescriptor parameterized on its params type. P = void means no params.
+// Inherits from TypeDescriptor so all existing code accepting TypeDescriptor
+// continues to work without changes.
+template <typename P = void>
+struct TypeDescriptorWithParams : TypeDescriptor {
+  using params_type = P;
+};
+
+// Non-template storage for TypeBuilder fields. Extracting these into a plain
+// struct lets TypeBuilder<P>'s cross-specialization copy constructor delegate
+// to the compiler-generated copy instead of listing every field by hand.
+struct TypeBuilderData {
+  const char *name_;
+  int64_t persisted_length_ = 0;
+  int64_t max_decode_buffer_length_ = 0;
+  vef_encode_func_t encode_ = nullptr;
+  vef_decode_func_t decode_ = nullptr;
+  vef_compare_func_t compare_ = nullptr;
+  vef_hash_func_t hash_ = nullptr;
+  const char *encode_vdf_name_ = nullptr;
+  const char *decode_vdf_name_ = nullptr;
+  const char *compare_vdf_name_ = nullptr;
+  const char *hash_vdf_name_ = nullptr;
+  const char *int_to_params_vdf_name_ = nullptr;
+  const char *resolve_params_vdf_name_ = nullptr;
+  const char *intrinsic_default_vdf_name_ = nullptr;
+  vef_type_storage_intf_t storage_intf_ = {};
+  void (*params_init_fn_)() = nullptr;
+
+  constexpr explicit TypeBuilderData(const char *name) : name_(name) {}
+};
+
+template <typename P = void>
 class TypeBuilder {
+  // Allows TypeBuilder<Q>::params<P2>() to copy data_ into TypeBuilder<P2>.
+  template <typename Q>
+  friend class TypeBuilder;
+
  public:
-  constexpr explicit TypeBuilder(const char *name)
-      : name_(name),
-        persisted_length_(0),
-        max_decode_buffer_length_(0),
-        encode_(nullptr),
-        decode_(nullptr),
-        compare_(nullptr),
-        hash_(nullptr),
-        encode_vdf_name_(nullptr),
-        decode_vdf_name_(nullptr),
-        compare_vdf_name_(nullptr),
-        hash_vdf_name_(nullptr),
-        int_to_params_vdf_name_(nullptr),
-        resolve_params_vdf_name_(nullptr),
-        intrinsic_default_vdf_name_(nullptr),
-        storage_intf_{},
-        params_init_fn_(nullptr) {}
+  constexpr explicit TypeBuilder(const char *name) : data_(name) {}
 
   constexpr TypeBuilder &persisted_length(int64_t len) {
-    persisted_length_ = len;
+    data_.persisted_length_ = len;
     return *this;
   }
 
   constexpr TypeBuilder &max_decode_buffer_length(int64_t len) {
-    max_decode_buffer_length_ = len;
+    data_.max_decode_buffer_length_ = len;
     return *this;
   }
 
   constexpr TypeBuilder &encode(vef_encode_func_t f) {
-    encode_ = f;
+    data_.encode_ = f;
     return *this;
   }
 
   constexpr TypeBuilder &encode(const char *vdf_name) {
-    encode_vdf_name_ = vdf_name;
+    data_.encode_vdf_name_ = vdf_name;
     return *this;
   }
 
   constexpr TypeBuilder &decode(vef_decode_func_t f) {
-    decode_ = f;
+    data_.decode_ = f;
     return *this;
   }
 
   constexpr TypeBuilder &decode(const char *vdf_name) {
-    decode_vdf_name_ = vdf_name;
+    data_.decode_vdf_name_ = vdf_name;
     return *this;
   }
 
   constexpr TypeBuilder &compare(vef_compare_func_t f) {
-    compare_ = f;
+    data_.compare_ = f;
     return *this;
   }
 
   constexpr TypeBuilder &compare(const char *vdf_name) {
-    compare_vdf_name_ = vdf_name;
+    data_.compare_vdf_name_ = vdf_name;
     return *this;
   }
 
   constexpr TypeBuilder &hash(vef_hash_func_t f) {
-    hash_ = f;
+    data_.hash_ = f;
     return *this;
   }
 
   constexpr TypeBuilder &hash(const char *vdf_name) {
-    hash_vdf_name_ = vdf_name;
+    data_.hash_vdf_name_ = vdf_name;
     return *this;
   }
 
   constexpr TypeBuilder &intrinsic_default(const char *vdf_name) {
-    intrinsic_default_vdf_name_ = vdf_name;
+    data_.intrinsic_default_vdf_name_ = vdf_name;
     return *this;
   }
 
   constexpr TypeBuilder &int_to_params(const char *vdf_name) {
-    int_to_params_vdf_name_ = vdf_name;
+    data_.int_to_params_vdf_name_ = vdf_name;
     return *this;
   }
 
   constexpr TypeBuilder &resolve_params(const char *vdf_name) {
-    resolve_params_vdf_name_ = vdf_name;
+    data_.resolve_params_vdf_name_ = vdf_name;
     return *this;
   }
 
   constexpr TypeBuilder &column_storage(const vef_type_storage_intf_t &intf) {
-    storage_intf_ = intf;
+    data_.storage_intf_ = intf;
     return *this;
   }
 
-  // Registers the params type P and its parse function with the
-  // TypeParamsCache. Called once during vef_register() before any VDF
-  // invocations. After this, VDF wrappers and CustomArgWith<P> can call
-  // type_params_cache_for<P>().get(raw) without passing the parse function.
-  template <typename P, auto ParseFunc>
-  constexpr TypeBuilder &params() {
-    params_init_fn_ = &bind_params_cache<P, ParseFunc>;
-    return *this;
+  // Registers the params type P2 and its parse function. Returns a new
+  // TypeBuilder<P2> with all fields copied, so the params type is reflected
+  // in the return type of build(). Called once during vef_register() before
+  // any VDF invocations.
+  template <typename P2, auto ParseFunc>
+  constexpr TypeBuilder<P2> params() const {
+    TypeBuilder<P2> b(*this);
+    b.data_.params_init_fn_ = &bind_params_cache<P2, ParseFunc>;
+    return b;
   }
 
-  // Build the final vef_type_desc_t. Protocol is set automatically:
+  // Build the final TypeDescriptorWithParams<P>. Protocol is set automatically:
   // VEF_PROTOCOL_2 if any protocol-2 field is set, otherwise VEF_PROTOCOL_1.
   // ExtensionBuilder::type() propagates this up to the extension's
   // min_protocol, so the registration fails if the server offers a lower
   // protocol.
-  constexpr TypeDescriptor build() const {
-    const bool needs_v2 =
-        encode_vdf_name_ != nullptr || decode_vdf_name_ != nullptr ||
-        compare_vdf_name_ != nullptr || hash_vdf_name_ != nullptr ||
-        int_to_params_vdf_name_ != nullptr ||
-        resolve_params_vdf_name_ != nullptr ||
-        intrinsic_default_vdf_name_ != nullptr || storage_intf_.version != 0;
+  constexpr TypeDescriptorWithParams<P> build() const {
+    const bool needs_v2 = data_.encode_vdf_name_ != nullptr ||
+                          data_.decode_vdf_name_ != nullptr ||
+                          data_.compare_vdf_name_ != nullptr ||
+                          data_.hash_vdf_name_ != nullptr ||
+                          data_.int_to_params_vdf_name_ != nullptr ||
+                          data_.resolve_params_vdf_name_ != nullptr ||
+                          data_.intrinsic_default_vdf_name_ != nullptr ||
+                          data_.storage_intf_.version != 0;
     const vef_protocol_t protocol = needs_v2 ? VEF_PROTOCOL_2 : VEF_PROTOCOL_1;
-    TypeDescriptor desc{};
-    desc.storage_intf = storage_intf_;
+    TypeDescriptorWithParams<P> desc{};
+    desc.storage_intf = data_.storage_intf_;
     desc.vef_desc = vef_type_desc_t{
         protocol,
-        name_,
-        persisted_length_,
-        max_decode_buffer_length_,
-        encode_,
-        decode_,
-        compare_,
-        hash_,
-        encode_vdf_name_,
-        decode_vdf_name_,
-        compare_vdf_name_,
-        hash_vdf_name_,
-        int_to_params_vdf_name_,
-        resolve_params_vdf_name_,
-        intrinsic_default_vdf_name_,
-        storage_intf_.version != 0 ? &desc.storage_intf : nullptr,
+        data_.name_,
+        data_.persisted_length_,
+        data_.max_decode_buffer_length_,
+        data_.encode_,
+        data_.decode_,
+        data_.compare_,
+        data_.hash_,
+        data_.encode_vdf_name_,
+        data_.decode_vdf_name_,
+        data_.compare_vdf_name_,
+        data_.hash_vdf_name_,
+        data_.int_to_params_vdf_name_,
+        data_.resolve_params_vdf_name_,
+        data_.intrinsic_default_vdf_name_,
+        data_.storage_intf_.version != 0 ? &desc.storage_intf : nullptr,
     };
-    desc.params_init_fn = params_init_fn_;
+    desc.params_init_fn = data_.params_init_fn_;
     return desc;
   }
 
  private:
-  const char *name_;
-  int64_t persisted_length_;
-  int64_t max_decode_buffer_length_;
-  vef_encode_func_t encode_;
-  vef_decode_func_t decode_;
-  vef_compare_func_t compare_;
-  vef_hash_func_t hash_;
-  const char *encode_vdf_name_;
-  const char *decode_vdf_name_;
-  const char *compare_vdf_name_;
-  const char *hash_vdf_name_;
-  const char *int_to_params_vdf_name_;
-  const char *resolve_params_vdf_name_;
-  const char *intrinsic_default_vdf_name_;
-  vef_type_storage_intf_t storage_intf_;
-  void (*params_init_fn_)();
+  // Converting copy constructor used only by params<P2, ParseFunc>() to
+  // produce a TypeBuilder<P2> from a TypeBuilder<void>. Restricted to
+  // Q = void so that calling .params<>() twice is a compile error.
+  template <typename Q>
+  constexpr explicit TypeBuilder(const TypeBuilder<Q> &o) : data_(o.data_) {
+    static_assert(std::is_void_v<Q>,
+                  ".params<P, &fn>() may only be called once on a TypeBuilder");
+  }
+
+  TypeBuilderData data_;
 };
 
-// Entry point: make_type("name")
-constexpr TypeBuilder make_type(const char *name) { return TypeBuilder(name); }
+// Entry point: make_type("name") returns TypeBuilder<void>.
+constexpr TypeBuilder<> make_type(const char *name) {
+  return TypeBuilder<>(name);
+}
 
 }  // namespace type_builder
 }  // namespace villagesql


### PR DESCRIPTION
Move detection of missing .params<P, &fn>() from a runtime error at INSTALL EXTENSION time to a compile-time static_assert. Refactors TypeBuilder to track the params type P in the return type of .build(), making TypeDescriptorWithParams<P> carry P through to ExtensionBuilder's TypeTuple. This lets the SDK verify at compile time — for both regular VDFs using CustomArgWith<P> and type operation VDFs — that every params type P referenced in a function signature has a corresponding .params<P, &fn>() registration. Add compile_extension_expect_fail.inc test infrastructure and expands test coverage for each operation that can be missing params.
