### PR TITLE
sdK: check Params bound to ArgType

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_mismatched_params_type.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_mismatched_params_type.result
@@ -1,0 +1,11 @@
+# restart: --veb-dir=MYSQLTEST_VARDIR/veb
+Creating extension mismatched_params_type using SDK...
+Created mismatched_params_type.veb
+call mtr.add_suppression("vef_register returned an error: VDF");
+# Attempt to install: expect failure because faketype_b_hash uses
+# params registered for FAKETYPE_A but operates on FAKETYPE_B
+INSTALL EXTENSION mismatched_params_type;
+ERROR HY000: Failed to load VEF extension 'mismatched_params_type': vef_register returned an error: VDF 'faketype_b_hash' uses params type registered for 'FAKETYPE_A' but does not operate on that type
+# Verify extension was NOT installed
+SELECT * FROM INFORMATION_SCHEMA.EXTENSIONS;
+EXTENSION_NAME	EXTENSION_VERSION

--- a/mysql-test/suite/villagesql/extension/t/extension_mismatched_params_type.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_mismatched_params_type.test
@@ -1,0 +1,24 @@
+# Test that vef_register rejects an extension whose VDF uses a params type
+# registered for a different custom type (FAKETYPE_A), but the VDF itself
+# operates on a different type (FAKETYPE_B).
+
+--let $veb_dir = $MYSQLTEST_VARDIR/veb
+--exec mkdir -p $veb_dir
+
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--let $restart_parameters = restart: --veb-dir=$veb_dir
+--source include/restart_mysqld.inc
+
+--let $extension_name = mismatched_params_type
+--let $extension_version = 0.0.1-devtest
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/mismatched_params_type.cc
+--source include/villagesql/create_extension_sdk.inc
+
+call mtr.add_suppression("vef_register returned an error: VDF");
+--echo # Attempt to install: expect failure because faketype_b_hash uses
+--echo # params registered for FAKETYPE_A but operates on FAKETYPE_B
+--error ER_VILLAGESQL_GENERIC_ERROR
+INSTALL EXTENSION mismatched_params_type;
+
+--echo # Verify extension was NOT installed
+SELECT * FROM INFORMATION_SCHEMA.EXTENSIONS;

--- a/mysql-test/suite/villagesql/std_data/mismatched_params_type.cc
+++ b/mysql-test/suite/villagesql/std_data/mismatched_params_type.cc
@@ -1,0 +1,96 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Registration-fail test: VDF registered for FAKETYPE_B but uses a params
+// type (FakeParams) that was registered for FAKETYPE_A. Compiles fine
+// because FakeParams IS in the TypeTuple, but vef_register returns an error
+// because the VDF does not operate on FAKETYPE_A.
+
+#include <villagesql/extension.h>
+
+#include <cstddef>
+#include <cstring>
+#include <map>
+#include <string>
+#include <string_view>
+
+struct FakeParams {
+  int value;
+  static FakeParams parse(const std::map<std::string, std::string> &) {
+    return FakeParams{0};
+  }
+};
+
+bool faketype_encode(std::string_view from, villagesql::Span<unsigned char> buf,
+                     size_t *length) {
+  size_t n = from.size() < buf.size() ? from.size() : buf.size();
+  memcpy(buf.data(), from.data(), n);
+  *length = n;
+  return false;
+}
+
+bool faketype_decode(villagesql::Span<const unsigned char> data,
+                     villagesql::Span<char> out, size_t *out_len) {
+  size_t n = data.size() < out.size() ? data.size() : out.size();
+  memcpy(out.data(), data.data(), n);
+  *out_len = n;
+  return false;
+}
+
+int faketype_compare(villagesql::Span<const unsigned char> a,
+                     villagesql::Span<const unsigned char> b) {
+  size_t n = a.size() < b.size() ? a.size() : b.size();
+  int r = memcmp(a.data(), b.data(), n);
+  if (r != 0) return r;
+  return static_cast<int>(a.size()) - static_cast<int>(b.size());
+}
+
+// Hash VDF for FAKETYPE_B that uses FakeParams — which was registered for
+// FAKETYPE_A. This mismatch is caught at registration time.
+size_t faketype_b_hash(const FakeParams &,
+                       villagesql::Span<const unsigned char> data) {
+  size_t h = 0;
+  for (size_t i = 0; i < data.size(); ++i) h = h * 31 + data[i];
+  return h;
+}
+
+constexpr const char *FAKETYPE_A = "FAKETYPE_A";
+constexpr const char *FAKETYPE_B = "FAKETYPE_B";
+
+VEF_GENERATE_ENTRY_POINTS(
+    make_extension(VEF_EXTENSION_NAME, "0.0.1-devtest")
+        .type(make_type(FAKETYPE_A)
+                  .persisted_length(64)
+                  .max_decode_buffer_length(64)
+                  .encode("faketype_a_encode")
+                  .decode("faketype_a_decode")
+                  .compare("faketype_a_compare")
+                  .params<FakeParams, &FakeParams::parse>()
+                  .build())
+        .type(make_type(FAKETYPE_B)
+                  .persisted_length(64)
+                  .max_decode_buffer_length(64)
+                  .encode("faketype_b_encode")
+                  .decode("faketype_b_decode")
+                  .compare("faketype_b_compare")
+                  .hash("faketype_b_hash")
+                  .build())
+        .func(make_type_encode<&faketype_encode>("faketype_a_encode", FAKETYPE_A))
+        .func(make_type_decode<&faketype_decode>("faketype_a_decode", FAKETYPE_A))
+        .func(make_type_compare<&faketype_compare>("faketype_a_compare", FAKETYPE_A))
+        .func(make_type_encode<&faketype_encode>("faketype_b_encode", FAKETYPE_B))
+        .func(make_type_decode<&faketype_decode>("faketype_b_decode", FAKETYPE_B))
+        .func(make_type_compare<&faketype_compare>("faketype_b_compare", FAKETYPE_B))
+        .func(make_type_hash<&faketype_b_hash>("faketype_b_hash", FAKETYPE_B)))

--- a/villagesql/sdk/include/villagesql/extension_builder.h
+++ b/villagesql/sdk/include/villagesql/extension_builder.h
@@ -104,8 +104,8 @@ struct ExtensionBuilder {
   TypeTuple types_;
   vef_protocol_t min_protocol_;
 
-  // Add a function from a StaticFuncDesc. This is the terminal overload that
-  // all other func() overloads delegate to after validation.
+  // Add a function from a StaticFuncDesc. This is the terminal overload for
+  // plain (non-parameterized) descriptors.
   template <typename F>
   constexpr auto func(F f) const {
     auto new_funcs = std::tuple_cat(funcs_, std::make_tuple(f));
@@ -121,6 +121,9 @@ struct ExtensionBuilder {
   //   - for parameterized type operation VDFs (ParamsType != void), ParamsType
   //     is likewise registered.
   // Works whether the descriptor is inline or pre-built.
+  // Stores the TypedFuncDesc directly (not sliced to StaticFuncDesc) so that
+  // params_type is preserved for the runtime cross-reference check in
+  // vef_register_impl.
   template <auto Func, size_t N, typename ParamsType>
   constexpr auto func(const TypedFuncDesc<Func, N, ParamsType> &desc) const {
     detail::validate_custom_params<Func, TypeTuple>();
@@ -130,7 +133,9 @@ struct ExtensionBuilder {
           "type operation VDF uses a parameterized cache but its params "
           "type P is not registered via .params<P, &fn>() on any type builder");
     }
-    return func(static_cast<const StaticFuncDesc<N> &>(desc));
+    auto new_funcs = std::tuple_cat(funcs_, std::make_tuple(desc));
+    return ExtensionBuilder<decltype(new_funcs), TypeTuple>{
+        name_, version_, new_funcs, types_, min_protocol_};
   }
 
   // Convenience overload: accepts a FuncBuilder directly (without calling
@@ -195,6 +200,82 @@ namespace detail {
 // Implementation helpers used by VEF_GENERATE_ENTRY_POINTS. Not part of the
 // public API.
 
+// Detects whether T has a params_type member (i.e. is a TypedFuncDesc rather
+// than a plain StaticFuncDesc).
+template <typename T, typename = void>
+struct has_params_type : std::false_type {};
+template <typename T>
+struct has_params_type<T, std::void_t<typename T::params_type>>
+    : std::true_type {};
+
+// Returns the vef_type_desc name of the first type in ext whose params_type
+// equals P, or nullptr if none. Uses lambdas in a fold to allow if constexpr.
+template <typename P, typename Ext, size_t... TypeIs>
+const char *vef_find_type_name_for_params(const Ext &e,
+                                           std::index_sequence<TypeIs...>) {
+  const char *result = nullptr;
+  (([&]() {
+     using TD = std::remove_const_t<
+         std::remove_reference_t<decltype(e.template type_at<TypeIs>())>>;
+     if constexpr (std::is_same_v<typename TD::params_type, P>) {
+       result = e.template type_at<TypeIs>().vef_desc.name;
+     }
+   }()),
+   ...);
+  return result;
+}
+
+// Returns true if VDF at index FuncI has a custom-type param or return type
+// whose name matches the type registered for its ParamsType. On mismatch,
+// writes an error message to error_buf and returns false.
+template <size_t FuncI, size_t TypeCount, typename Ext>
+bool vef_check_func_params_type_ref(const Ext &e, char *error_buf,
+                                     size_t error_buf_size) {
+  const auto &func = e.template func_at<FuncI>();
+  using FuncType =
+      std::remove_const_t<std::remove_reference_t<decltype(func)>>;
+  if constexpr (!has_params_type<FuncType>::value) {
+    return true;
+  } else {
+    using P = typename FuncType::params_type;
+    if constexpr (std::is_void_v<P>) return true;
+
+    const char *type_name = vef_find_type_name_for_params<P>(
+        e, std::make_index_sequence<TypeCount>{});
+    // nullptr means P is not registered — already caught by static_assert
+    if (type_name == nullptr) return true;
+
+    const vef_type_t rt = func.return_type();
+    if (rt.id == VEF_TYPE_CUSTOM &&
+        std::string_view(rt.custom_type) == type_name)
+      return true;
+    for (size_t i = 0; i < func.num_params(); ++i) {
+      const vef_type_t pt = func.params()[i];
+      if (pt.id == VEF_TYPE_CUSTOM &&
+          std::string_view(pt.custom_type) == type_name)
+        return true;
+    }
+
+    snprintf(error_buf, error_buf_size,
+             "VDF '%s' uses params type registered for '%s' "
+             "but does not operate on that type",
+             func.name(), type_name);
+    return false;
+  }
+}
+
+// Validates that every VDF whose ParamsType is non-void operates on the
+// type registered for that ParamsType. Returns false and writes to error_buf
+// on the first mismatch.
+template <size_t TypeCount, typename Ext, size_t... FuncIs>
+bool vef_validate_params_type_refs(const Ext &e, char *error_buf,
+                                    size_t error_buf_size,
+                                    std::index_sequence<FuncIs...>) {
+  return (vef_check_func_params_type_ref<FuncIs, TypeCount>(e, error_buf,
+                                                             error_buf_size) &&
+          ...);
+}
+
 // Fills arr[I] with the materialized vef_func_desc_t* for each function.
 template <typename Ext, size_t... Is>
 void vef_fill_func_ptrs(vef_func_desc_t **arr, const Ext &e,
@@ -240,6 +321,15 @@ vef_registration_t *vef_register_impl(vef_registration_t &reg,
              static_cast<unsigned>(arg->protocol));
     reg.protocol = arg->protocol;
     reg.error_msg = error_buf;
+    return &reg;
+  }
+
+  static char xref_error_buf[256];
+  if (!vef_validate_params_type_refs<TypeCount>(
+          ext, xref_error_buf, sizeof(xref_error_buf),
+          std::make_index_sequence<FuncCount>{})) {
+    reg.protocol = arg->protocol;
+    reg.error_msg = xref_error_buf;
     return &reg;
   }
 


### PR DESCRIPTION
Adds a registration-time check that catches a class of silent correctness bug: a VDF whose params type P is registered for custom type A but the VDF itself operates on a different custom type B. Previously this passed all checks and silently used A's parse function to interpret B's type parameters at query time.  Now vef_register rejects the extension with a descriptive error message identifying the offending VDF and the type it was incorrectly associated with.

