### PR TITLE
Fix README logo in dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-![VillageSQL Logo](https://villagesql.com/assets/logo-light.svg)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://villagesql.com/assets/logo-dark.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://villagesql.com/assets/logo-light.svg">
+  <img alt="VillageSQL Logo" src="https://villagesql.com/assets/logo-light.svg">
+</picture>
 
 # VillageSQL Server
 


### PR DESCRIPTION
## Description
Use <picture> element to serve logo-dark.svg in dark mode and logo-light.svg in light mode.
AI=CLAUDE

## Related Issue
Fixes #191

## How was this tested?
Can't test GitHub Readme behavior locally so live testing is required.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
