### PR TITLE
sdk: new C++ registration

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_missing_params_fn.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_missing_params_fn.result
@@ -6,7 +6,7 @@ Created missing_params_fn.veb
 # Attempt to install extension with parameterized VDF but no parse function
 # (should fail: vef_register detects unbound params cache)
 INSTALL EXTENSION missing_params_fn;
-ERROR HY000: Failed to load VEF extension 'missing_params_fn': vef_register returned an error: VDF 'faketype_encode' uses a parameterized type cache but no .params<P, &parse_fn>() was registered for that params type; add .params<P, &parse_fn>() to the type builder
+ERROR HY000: Failed to load VEF extension 'missing_params_fn': vef_register returned an error: VDF 'FAKETYPE::from_string' uses a parameterized type cache but no .params<P, &parse_fn>() was registered for that params type; add .params<P, &parse_fn>() to the type builder
 # Verify extension was NOT installed
 SELECT * FROM INFORMATION_SCHEMA.EXTENSIONS;
 EXTENSION_NAME	EXTENSION_VERSION

--- a/mysql-test/suite/villagesql/std_data/min_protocol_extension.cc
+++ b/mysql-test/suite/villagesql/std_data/min_protocol_extension.cc
@@ -17,9 +17,9 @@
 // Test extension that requires VEF_PROTOCOL_2.
 // Used to verify that extensions can reject servers offering a lower protocol.
 
-#include <villagesql/extension.h>
+#include <villagesql/vsql.h>
 
-using namespace villagesql::extension_builder;
+using namespace vsql;
 
 VEF_GENERATE_ENTRY_POINTS(make_extension(VEF_EXTENSION_NAME, "7.7.7-devtest")
                               .test_only_require_protocol(VEF_PROTOCOL_2))

--- a/mysql-test/suite/villagesql/std_data/missing_params_fn.cc
+++ b/mysql-test/suite/villagesql/std_data/missing_params_fn.cc
@@ -16,7 +16,7 @@
 // Test extension: parameterized encode VDF registered without .params<>().
 // vef_register should fail immediately rather than crashing on first VDF call.
 
-#include <villagesql/extension.h>
+#include <villagesql/vsql.h>
 
 #include <cstddef>
 #include <cstring>
@@ -59,24 +59,19 @@ int faketype_compare(villagesql::Span<const unsigned char> a,
   return static_cast<int>(a.size()) - static_cast<int>(b.size());
 }
 
-using namespace villagesql::extension_builder;
-using namespace villagesql::func_builder;
-using namespace villagesql::type_builder;
-
-constexpr const char *FAKETYPE = "FAKETYPE";
+static constexpr const char kFakeTypeName[] = "FAKETYPE";
 
 // .params<FakeParams, &FakeParams::parse>() is deliberately omitted so that
 // the params cache is never bound. vef_register should detect this and fail.
+constexpr auto FAKETYPE = vsql::make_type<kFakeTypeName>()
+                              .persisted_length(64)
+                              .max_decode_buffer_length(64)
+                              .from_string<&faketype_encode>()
+                              .to_string<&faketype_decode>()
+                              .compare<&faketype_compare>()
+                              .build();
+
+using namespace vsql;
+
 VEF_GENERATE_ENTRY_POINTS(
-    make_extension(VEF_EXTENSION_NAME, "0.0.1-devtest")
-        .type(make_type(FAKETYPE)
-                  .persisted_length(64)
-                  .max_decode_buffer_length(64)
-                  .encode("faketype_encode")
-                  .decode("faketype_decode")
-                  .compare("faketype_compare")
-                  .build())
-        .func(make_type_encode<&faketype_encode>("faketype_encode", FAKETYPE))
-        .func(make_type_decode<&faketype_decode>("faketype_decode", FAKETYPE))
-        .func(make_type_compare<&faketype_compare>("faketype_compare",
-                                                   FAKETYPE)))
+    make_extension(VEF_EXTENSION_NAME, "0.0.1-devtest").type(FAKETYPE))

--- a/mysql-test/suite/villagesql/std_data/no_default_type.cc
+++ b/mysql-test/suite/villagesql/std_data/no_default_type.cc
@@ -17,7 +17,7 @@
 // and an encode function that rejects empty string. Used to verify that
 // CREATE TABLE fails when a type has no valid intrinsic default.
 
-#include <villagesql/extension.h>
+#include <villagesql/vsql.h>
 
 #include <cstddef>
 #include <cstring>
@@ -56,21 +56,17 @@ int no_default_compare(villagesql::Span<const unsigned char>,
   return 0;
 }
 
-using namespace villagesql::extension_builder;
-using namespace villagesql::type_builder;
+static constexpr const char kNoDefaultTypeName[] = "NO_DEFAULT_TYPE";
+
+constexpr auto NO_DEFAULT_TYPE = vsql::make_type<kNoDefaultTypeName>()
+                                     .persisted_length(kLen)
+                                     .max_decode_buffer_length(16)
+                                     .from_string<&no_default_encode>()
+                                     .to_string<&no_default_decode>()
+                                     .compare<&no_default_compare>()
+                                     .build();
+
+using namespace vsql;
 
 VEF_GENERATE_ENTRY_POINTS(
-    make_extension(VEF_EXTENSION_NAME, "0.0.1-devtest")
-        .type(make_type("NO_DEFAULT_TYPE")
-                  .persisted_length(kLen)
-                  .max_decode_buffer_length(16)
-                  .encode("no_default_encode")
-                  .decode("no_default_decode")
-                  .compare("no_default_compare")
-                  .build())
-        .func(make_type_encode<&no_default_encode>("no_default_encode",
-                                                   "NO_DEFAULT_TYPE"))
-        .func(make_type_decode<&no_default_decode>("no_default_decode",
-                                                   "NO_DEFAULT_TYPE"))
-        .func(make_type_compare<&no_default_compare>("no_default_compare",
-                                                     "NO_DEFAULT_TYPE")))
+    make_extension(VEF_EXTENSION_NAME, "0.0.1-devtest").type(NO_DEFAULT_TYPE))

--- a/mysql-test/suite/villagesql/std_data/noop_extension.cc
+++ b/mysql-test/suite/villagesql/std_data/noop_extension.cc
@@ -18,8 +18,8 @@
 // Used for testing extension installation/uninstallation without any
 // functions or types.
 
-#include <villagesql/extension.h>
+#include <villagesql/vsql.h>
 
-using namespace villagesql::extension_builder;
+using namespace vsql;
 
 VEF_GENERATE_ENTRY_POINTS(make_extension(VEF_EXTENSION_NAME, "0.0.1-devtest"))

--- a/mysql-test/suite/villagesql/std_data/wrong_name_extension.cc
+++ b/mysql-test/suite/villagesql/std_data/wrong_name_extension.cc
@@ -24,9 +24,9 @@
 // Minimal VEF extension that deliberately registers a name different from
 // the VEB package name. Used for testing extension name mismatch validation.
 
-#include <villagesql/extension.h>
+#include <villagesql/vsql.h>
 
-using namespace villagesql::extension_builder;
+using namespace vsql;
 
 VEF_GENERATE_ENTRY_POINTS(make_extension("wrong_registered_name",
                                          "0.0.1-devtest"))

--- a/villagesql/CMakeLists.txt
+++ b/villagesql/CMakeLists.txt
@@ -58,6 +58,7 @@ add_custom_target(sdk ALL
   COMMAND ${CMAKE_COMMAND} -E make_directory "${SDK_STAGING_DIR}/lib/cmake/VillageSQLExtensionFramework"
   COMMAND ${CMAKE_COMMAND} -E make_directory "${SDK_STAGING_DIR}/include/villagesql/abi"
   COMMAND ${CMAKE_COMMAND} -E make_directory "${SDK_STAGING_DIR}/include-dev/villagesql/abi"
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${SDK_STAGING_DIR}/include-dev/villagesql/vsql"
   COMMAND ${CMAKE_COMMAND} -E make_directory "${SDK_STAGING_DIR}/template/src"
 
   # Copy villagesql_config script and make executable
@@ -93,12 +94,16 @@ add_custom_target(sdk ALL
     "${CMAKE_CURRENT_SOURCE_DIR}/sdk/include/villagesql/storage_builder.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/sdk/include/villagesql/type_builder.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/sdk/include/villagesql/type_params_cache.h"
+    "${CMAKE_CURRENT_SOURCE_DIR}/sdk/include/villagesql/vsql.h"
     "${CMAKE_BINARY_DIR}/sdk/include/villagesql/sdk_version.h"
     "${SDK_STAGING_DIR}/include-dev/villagesql/"
   COMMAND ${CMAKE_COMMAND} -E copy
     "${CMAKE_CURRENT_SOURCE_DIR}/sdk/include/villagesql/abi/storage.h"
     "${CMAKE_CURRENT_SOURCE_DIR}/sdk/include/villagesql/abi/types.h"
     "${SDK_STAGING_DIR}/include-dev/villagesql/abi/"
+  COMMAND ${CMAKE_COMMAND} -E copy
+    "${CMAKE_CURRENT_SOURCE_DIR}/sdk/include/villagesql/vsql/type_builder.h"
+    "${SDK_STAGING_DIR}/include-dev/villagesql/vsql/"
 
   # Copy template project
   COMMAND ${CMAKE_COMMAND} -E copy

--- a/villagesql/examples/vsql-complex/src/complex.cc
+++ b/villagesql/examples/vsql-complex/src/complex.cc
@@ -26,7 +26,7 @@
 // The COMPLEX type stores complex numbers as two IEEE 754 doubles (16 bytes).
 // Format: "(real,imaginary)" e.g., "(3.14,2.71)"
 
-#include <villagesql/extension.h>
+#include <villagesql/vsql.h>
 
 #include <cassert>
 #include <cmath>
@@ -411,46 +411,50 @@ void complex_conjugate_impl(vef_context_t *ctx, vef_invalue_t *in,
   ReturnComplex(Complex{cx->re, -cx->im}, out);
 }
 
-constexpr const char *COMPLEX = "COMPLEX";
-constexpr const char *COMPLEX2 = "COMPLEX2";
+// Type name NTTPs — required for auto-generating VDF names like
+// "COMPLEX::from_string" without macros. Each make_type<kName>() call uses
+// the pointer identity of kName to key independent static name buffers, so
+// two types sharing a function pointer (e.g. complex_to_string) still get
+// separate "COMPLEX::to_string" and "COMPLEX2::to_string" buffers.
+static constexpr const char kComplexTypeName[] = "COMPLEX";
+static constexpr const char kComplex2TypeName[] = "COMPLEX2";
+
+// Type objects: encode/decode/compare/hash VDFs are embedded with
+// auto-generated names ("COMPLEX::from_string" etc.) — no manual string
+// matching required.
+constexpr auto COMPLEX =
+    vsql::make_type<kComplexTypeName>()
+        .persisted_length(kComplexSize)
+        .max_decode_buffer_length(64)
+        .from_string<&complex_from_string>()  // auto: "COMPLEX::from_string"
+        .to_string<&complex_to_string>()      // auto: "COMPLEX::to_string"
+        .compare<&complex_compare>()          // auto: "COMPLEX::compare"
+        .intrinsic_default_str("(0,0)")
+        .build();
+
+// COMPLEX2 has a custom hash (to canonicalize -0 before hashing)
+constexpr auto COMPLEX2 =
+    vsql::make_type<kComplex2TypeName>()
+        .persisted_length(kComplexSize)
+        .max_decode_buffer_length(64)
+        .from_string<&complex2_from_string>()  // auto: "COMPLEX2::from_string"
+        .to_string<&complex_to_string>()       // auto: "COMPLEX2::to_string"
+                                               // (separate buffer)
+        .compare<&complex_compare>()           // auto: "COMPLEX2::compare"
+        .hash<&complex2_hash>()                // auto: "COMPLEX2::hash"
+        .intrinsic_default_str("(0,0)")
+        .build();
+
+using namespace vsql;
 
 VEF_GENERATE_ENTRY_POINTS(
     make_extension("vsql_complex", "0.0.1")
-        // COMPLEX type with canonicalization (normalizes -0.0 to +0.0)
-        .type(make_type(COMPLEX)
-                  .persisted_length(kComplexSize)
-                  .max_decode_buffer_length(64)
-                  .encode("COMPLEX::from_string")
-                  .decode("COMPLEX::to_string")
-                  .compare("COMPLEX::compare")
-                  .intrinsic_default_str("(0,0)")
-                  .build())
-        // COMPLEX2 type without canonicalization (preserves -0.0)
-        // Requires custom hash that canonicalizes -0 to +0 before hashing
-        .type(make_type(COMPLEX2)
-                  .persisted_length(kComplexSize)
-                  .max_decode_buffer_length(64)
-                  .encode("COMPLEX2::from_string")
-                  .decode("COMPLEX2::to_string")
-                  .compare("COMPLEX2::compare")
-                  .hash("COMPLEX2::hash")
-                  .intrinsic_default_str("(0,0)")
-                  .build())
-        // Type conversion functions (also serve as encode/decode VDFs)
-        .func(make_type_encode<&complex_from_string>("COMPLEX::from_string",
-                                                     COMPLEX))
-        .func(make_type_decode<&complex_to_string>("COMPLEX::to_string",
-                                                   COMPLEX))
-        .func(make_type_encode<&complex2_from_string>("COMPLEX2::from_string",
-                                                      COMPLEX2))
-        .func(make_type_decode<&complex_to_string>("COMPLEX2::to_string",
-                                                   COMPLEX2))
-        // Compare and hash VDFs
-        .func(make_type_compare<&complex_compare>("COMPLEX::compare", COMPLEX))
-        .func(make_type_compare<&complex_compare>("COMPLEX2::compare",
-                                                  COMPLEX2))
-        .func(make_type_hash<&complex2_hash>("COMPLEX2::hash", COMPLEX2))
-        // Arithmetic functions
+         // COMPLEX type with canonicalization (normalizes -0.0 to +0.0)
+         .type(COMPLEX)
+         // COMPLEX2 type without canonicalization (preserves -0.0)
+         // Requires custom hash that canonicalizes -0 to +0 before hashing
+         .type(COMPLEX2)
+         // Arithmetic functions
         .func(make_func<&complex_add_impl>("complex_add")
                   .returns(COMPLEX)
                   .param(COMPLEX)

--- a/villagesql/examples/vsql-tvector/src/tvector.cc
+++ b/villagesql/examples/vsql-tvector/src/tvector.cc
@@ -31,7 +31,7 @@
 // TVECTOR(3) with float stores 12 bytes (3 * 4). With double, 24 bytes (3 * 8).
 // Text format: "[1.0,2.0,3.0]" (comma-separated values in brackets)
 
-#include <villagesql/extension.h>
+#include <villagesql/vsql.h>
 
 #include <cinttypes>
 #include <cstddef>
@@ -333,30 +333,25 @@ void tvector_dot_product(villagesql::CustomArgWith<TVectorParams> a,
   out.set(sum);
 }
 
-constexpr const char *TVECTOR = "TVECTOR";
+static constexpr const char kTVectorTypeName[] = "TVECTOR";
+
+constexpr auto TVECTOR = vsql::make_type<kTVectorTypeName>()
+                             .persisted_length(-1)
+                             .max_decode_buffer_length(16)
+                             .params<TVectorParams, &TVectorParams::parse>()
+                             .int_to_params<&tvector_int_to_params>()
+                             .resolve_params<&tvector_resolve_params>()
+                             .from_string<&tvector_from_string>()
+                             .to_string<&tvector_to_string>()
+                             .compare<&tvector_compare>()
+                             .intrinsic_default_vdf("tvector_intrinsic_default")
+                             .build();
+
+using namespace vsql;
 
 VEF_GENERATE_ENTRY_POINTS(
     make_extension("vsql_tvector", "0.0.1")
-        .type(make_type(TVECTOR)
-                  .persisted_length(-1)
-                  .max_decode_buffer_length(16)
-                  .params<TVectorParams, &TVectorParams::parse>()
-                  .encode("tvector_from_string")
-                  .decode("tvector_to_string")
-                  .compare("tvector_compare")
-                  .int_to_params("tvector_int_to_params")
-                  .resolve_params("tvector_resolve_params")
-                  .intrinsic_default("tvector_intrinsic_default")
-                  .build())
-        .func(make_type_encode<&tvector_from_string>("tvector_from_string",
-                                                     TVECTOR))
-        .func(make_type_decode<&tvector_to_string>("tvector_to_string",
-                                                   TVECTOR))
-        .func(make_type_compare<&tvector_compare>("tvector_compare", TVECTOR))
-        .func(
-            make_int_to_params<&tvector_int_to_params>("tvector_int_to_params"))
-        .func(make_resolve_params<&tvector_resolve_params>(
-            "tvector_resolve_params"))
+        .type(TVECTOR)
         .func(make_intrinsic_default<&tvector_default>(
             "tvector_intrinsic_default", TVECTOR))
         .func(make_func<&tvector_dot_product>("tvector_dot_product")

--- a/villagesql/sdk/include/villagesql/extension_builder.h
+++ b/villagesql/sdk/include/villagesql/extension_builder.h
@@ -78,6 +78,24 @@ struct ExtensionBuilder {
         name_, version_, funcs_, new_types, new_min};
   }
 
+  // Add a type object that carries embedded SQL-callable VDFs (e.g. the
+  // vsql::TypeObject<EFT> produced by vsql::make_type().build()). The type
+  // descriptor and its embedded VDFs are both registered in one call.
+  // Selected by overload resolution when the argument has an embedded_funcs
+  // member (preferred over the TypeDescriptor overload as an exact match).
+  template <typename TypeObj,
+            typename = decltype(std::declval<TypeObj>().embedded_funcs)>
+  constexpr auto type(const TypeObj &t) const {
+    auto new_types = std::tuple_cat(types_, std::make_tuple(t.descriptor));
+    auto new_funcs = std::tuple_cat(funcs_, t.embedded_funcs);
+    const vef_protocol_t new_min =
+        t.descriptor.vef_desc.protocol > min_protocol_
+            ? t.descriptor.vef_desc.protocol
+            : min_protocol_;
+    return ExtensionBuilder<decltype(new_funcs), decltype(new_types)>{
+        name_, version_, new_funcs, new_types, new_min};
+  }
+
   // This is here only for testing, please don't depend on it.
   // Require a minimum VEF protocol version from the server.
   // If the server offers a lower protocol, registration will fail with an
@@ -146,6 +164,25 @@ void vef_init_type_params(const Ext &e, std::index_sequence<Is...>) {
    ...);
 }
 
+// Calls init_name() on any func that has it (auto-named VDFs from the ::vsql
+// API). Must be called before vef_fill_func_ptrs() so that name buffers are
+// populated before materialize_func_desc reads them.
+template <typename T, typename = void>
+struct has_init_name : std::false_type {};
+template <typename T>
+struct has_init_name<
+    T, std::void_t<decltype(std::declval<const T &>().init_name())>>
+    : std::true_type {};
+
+template <typename Ext, size_t... Is>
+void vef_init_auto_names(const Ext &e, std::index_sequence<Is...>) {
+  auto init_one = [](const auto &f) {
+    using F = std::decay_t<decltype(f)>;
+    if constexpr (has_init_name<F>::value) f.init_name();
+  };
+  (init_one(e.template func_at<Is>()), ...);
+}
+
 // Returns the name of the first VDF that requires a bound params cache but
 // whose cache was not bound (i.e., .params<P, &parse_fn>() was omitted from
 // the type builder). Must be called after vef_init_type_params().
@@ -185,6 +222,7 @@ vef_registration_t *vef_register_impl(vef_registration_t &reg,
   static vef_type_desc_t *type_ptrs[TypeCount > 0 ? TypeCount : 1];
 
   if constexpr (FuncCount > 0) {
+    vef_init_auto_names(ext, std::make_index_sequence<FuncCount>{});
     vef_fill_func_ptrs(func_ptrs, ext, std::make_index_sequence<FuncCount>{});
   }
   if constexpr (TypeCount > 0) {

--- a/villagesql/sdk/include/villagesql/vsql.h
+++ b/villagesql/sdk/include/villagesql/vsql.h
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+#ifndef VILLAGESQL_VSQL_H
+#define VILLAGESQL_VSQL_H
+
+// =============================================================================
+// VillageSQL Extension Framework — Object-based API (::vsql namespace)
+// =============================================================================
+//
+// This header provides the new object-based API for writing VillageSQL
+// extensions. Include this instead of <villagesql/extension.h> when using
+// the new API.
+//
+// QUICK START
+// -----------
+//
+//   #include <villagesql/vsql.h>
+//   using namespace vsql;
+//
+//   // 1. Implement your type operations
+//   bool complex_from_string(std::string_view s,
+//                            villagesql::Span<unsigned char> buf, size_t*
+//                            len);
+//   bool complex_to_string(villagesql::Span<const unsigned char> data,
+//                          villagesql::Span<char> out, size_t* out_len);
+//   int  complex_compare(villagesql::Span<const unsigned char> a,
+//                        villagesql::Span<const unsigned char> b);
+//
+//   // 2. Define the type as a constexpr object
+//   static constexpr const char kComplexTypeName[] = "COMPLEX";
+//   constexpr auto COMPLEX = make_type<kComplexTypeName>()
+//       .persisted_length(16)
+//       .max_decode_buffer_length(64)
+//       .from_string<&complex_from_string>()  // statically checked signature
+//       .to_string<&complex_to_string>()
+//       .compare<&complex_compare>()
+//       .build();  // compile error if any required operation is missing
+//
+//   // 3. Implement regular VDFs, using COMPLEX as a type reference
+//   void complex_add(CustomArg a, CustomArg b, CustomResult out) { ... }
+//
+//   // 4. Register
+//   VEF_GENERATE_ENTRY_POINTS(
+//     make_extension("my_ext", "1.0.0")
+//       .type(COMPLEX)                          // type object, not a string
+//       .func(make_func<&complex_add>("complex_add")
+//           .returns(COMPLEX)                   // type object in signature
+//           .param(COMPLEX)
+//           .param(COMPLEX)
+//           .build()))
+//
+// STATIC CHECKING
+// ---------------
+//
+// - build() fails to compile if from_string, to_string, or compare is missing.
+// - Each template method checks the function signature via static_assert.
+//   Wrong signatures (wrong param count, wrong types) are compile errors.
+// - Type name mismatches are impossible: .returns(COMPLEX) derives the SQL
+//   name from the object; no manual string is involved.
+//
+// BACKWARD COMPATIBILITY
+// ----------------------
+//
+// The existing villagesql::type_builder and villagesql::func_builder APIs
+// are unchanged. Extensions using the old API continue to compile. The new
+// vsql API is additive — both styles can be mixed in the same extension.
+//
+// LIMITATIONS
+// -----------
+//
+// - intrinsic_default VDFs must be registered separately with
+//   make_intrinsic_default(). Reference them by name with
+//   .intrinsic_default_vdf("vdf_name") on the vsql TypeBuilder.
+
+// Pull in the full existing SDK (func_types, func_builder, extension_builder,
+// VEF_GENERATE_ENTRY_POINTS macro, etc.)
+#include <villagesql/extension.h>
+
+// New object-based type builder
+#include <villagesql/vsql/type_builder.h>
+
+// Bring the new vsql API into scope alongside the existing villagesql names.
+// After `using namespace vsql`, make_type() comes from ::vsql, while
+// make_func() and make_extension() continue to come from
+// villagesql::func_builder / villagesql::extension_builder (via extension.h).
+namespace vsql {
+
+// Re-export make_func and make_extension from the existing villagesql API
+// so that `using namespace vsql` is sufficient for a complete extension.
+using villagesql::extension_builder::make_extension;
+using villagesql::func_builder::make_func;
+
+// Re-export typed argument/result wrappers
+using villagesql::CustomArg;
+using villagesql::CustomArgWith;
+using villagesql::CustomResult;
+using villagesql::CustomResultWith;
+using villagesql::IntArg;
+using villagesql::IntResult;
+using villagesql::RealArg;
+using villagesql::RealResult;
+using villagesql::Span;
+using villagesql::StringArg;
+using villagesql::StringResult;
+
+// Re-export built-in type name constants (the string versions, for
+// .returns(INT) / .param(STRING) etc.)
+using villagesql::func_builder::INT;
+using villagesql::func_builder::REAL;
+using villagesql::func_builder::STRING;
+
+}  // namespace vsql
+
+#endif  // VILLAGESQL_VSQL_H

--- a/villagesql/sdk/include/villagesql/vsql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/type_builder.h
@@ -1,0 +1,450 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+#ifndef VILLAGESQL_VSQL_TYPE_BUILDER_H
+#define VILLAGESQL_VSQL_TYPE_BUILDER_H
+
+// Object-based type builder for the ::vsql API.
+//
+// Usage (non-parameterized type):
+//
+//   // One declaration per type — serves as the Non-Type Template Parameter
+//   // (NTTP) for auto-naming.
+//   static constexpr const char kMyTypeName[] = "MYTYPE";
+//
+//   constexpr auto MYTYPE = vsql::make_type<kMyTypeName>()
+//       .persisted_length(16)
+//       .max_decode_buffer_length(64)
+//       .from_string<&my_from_string>()
+//       .to_string<&my_to_string>()
+//       .compare<&my_compare>()
+//       .hash<&my_hash>()    // optional
+//       .build();
+//
+// Usage (parameterized type, e.g. TVECTOR(N)):
+//
+//   struct TVectorParams {
+//     int64_t dimension;
+//     static TVectorParams parse(const std::map<std::string,std::string>&);
+//   };
+//   static constexpr const char kTVectorTypeName[] = "TVECTOR";
+//
+//   constexpr auto TVECTOR = vsql::make_type<kTVectorTypeName>()
+//       .params<TVectorParams, &TVectorParams::parse>()
+//       .int_to_params<&my_int_to_params_fn>()
+//       .resolve_params<&my_resolve_params_fn>()
+//       .from_string<&my_from_string_fn>()
+//       .to_string<&my_to_string_fn>()
+//       .compare<&my_compare_fn>()
+//       .build();
+//
+// VDF names are auto-generated from the type name at compile time:
+//   .from_string<&fn>()      ->  VDF name "MYTYPE::from_string"  (SQL-callable)
+//   .to_string<&fn>()        ->  VDF name "MYTYPE::to_string"    (SQL-callable)
+//   .compare<&fn>()          ->  VDF name "MYTYPE::compare"      (SQL-callable)
+//   .hash<&fn>()             ->  VDF name "MYTYPE::hash"         (SQL-callable)
+//   .int_to_params<&fn>()    ->  VDF name "MYTYPE::int_to_params"
+//   .resolve_params<&fn>()   ->  VDF name "MYTYPE::resolve_params"
+//
+// Two types sharing the same function pointer still get independent VDF name
+// buffers because the (the kMyTypeName pointer value) differs per type.
+//
+// To use a non-SQL-callable operation (v1 ABI direct function pointer, faster),
+// pass the raw ABI function pointer instead:
+//   .from_string(raw_abi_encode_func_ptr)
+//
+// The resulting TypeObject converts implicitly to const char* so it can be
+// passed directly to .returns() and .param() on FuncBuilder:
+//
+//   make_func<&add_impl>("add")
+//       .returns(MYTYPE).param(MYTYPE).param(MYTYPE).build()
+//
+// Pass TypeObject to ExtensionBuilder::type() to register the type and any
+// embedded SQL-callable VDFs in one step:
+//
+//   make_extension("my_ext", "1.0.0")
+//       .type(MYTYPE)   // registers type + all embedded VDFs
+//       .func(...)
+//
+// intrinsic_default VDFs must be registered separately with
+// make_intrinsic_default(). Reference them by name with
+// .intrinsic_default_vdf("vdf_name") on the TypeBuilder.
+
+#include <cstddef>
+#include <cstdint>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+
+#include <villagesql/abi/types.h>
+#include <villagesql/func_builder.h>
+#include <villagesql/type_builder.h>
+
+namespace vsql {
+
+// =============================================================================
+// detail — internal helpers, not part of the public API
+// =============================================================================
+
+namespace detail {
+
+using namespace villagesql::func_builder;
+
+enum class TypeOp {
+  kEncode = 0,
+  kDecode = 1,
+  kCompare = 2,
+  kHash = 3,
+  kIntToParams = 4,
+  kResolveParams = 5,
+};
+
+// TypeOpVdfName: constexpr-initialized string "TypeName::suffix" for a given
+// (TypeName, Op) pair.
+//
+// The buf[] array is filled by the constexpr constructor, so the address
+// kTypeOpVdfName<TypeName,Op>.buf is an address constant expression — usable as
+// a constexpr const char* pointer in vef_type_desc_t fields.
+//
+// The TypeName Template Parameter must point to a static constexpr char array
+// (e.g., `static constexpr const char kFoo[] = "FOO"`), so TypeName[j] is
+// readable in a constant-expression context.
+template <const char *TypeName, TypeOp Op>
+struct TypeOpVdfName {
+  static constexpr std::string_view op_name(TypeOp op) {
+    switch (op) {
+      case TypeOp::kEncode:
+        return "from_string";
+      case TypeOp::kDecode:
+        return "to_string";
+      case TypeOp::kCompare:
+        return "compare";
+      case TypeOp::kHash:
+        return "hash";
+      case TypeOp::kIntToParams:
+        return "int_to_params";
+      case TypeOp::kResolveParams:
+        return "resolve_params";
+    }
+  }
+  static constexpr std::string_view kTypeName = std::string_view{TypeName};
+  static constexpr std::string_view kSep = "::";
+  static constexpr std::string_view kOpName = op_name(Op);
+  static constexpr size_t kSize =
+      kTypeName.size() + kSep.size() + kOpName.size() + 1;
+  char buf[kSize];
+  constexpr TypeOpVdfName() : buf{} {
+    size_t i = 0;
+    for (char c : kTypeName) buf[i++] = c;
+    for (char c : kSep) buf[i++] = c;
+    for (char c : kOpName) buf[i++] = c;
+  }
+};
+
+// One constexpr instance per (TypeName, Op) pair — inline ensures a single
+// definition across translation units (C++17 inline variable).
+template <const char *TypeName, TypeOp Op>
+inline constexpr TypeOpVdfName<TypeName, Op> kTypeOpVdfName{};
+
+// Shared builder state passed by value between TypeBuilder specializations.
+struct TypeBuilderState {
+  villagesql::type_builder::TypeDescriptor desc;
+};
+
+}  // namespace detail
+
+// =============================================================================
+// TypeObject — the built type, usable as a type reference
+// =============================================================================
+//
+// EmbeddedFuncsTuple holds SQL-callable VDFs (from_string/to_string/compare/
+// hash/int_to_params/resolve_params) that are automatically registered
+// alongside the type when passed to ExtensionBuilder::type(). These are
+// produced by the template methods on TypeBuilder.
+
+template <typename EmbeddedFuncsTuple = std::tuple<>>
+struct TypeObject {
+  villagesql::type_builder::TypeDescriptor descriptor;
+  EmbeddedFuncsTuple embedded_funcs;
+
+  // Converts to the SQL type name string for use in .returns() and .param().
+  constexpr operator const char *() const { return descriptor.vef_desc.name; }
+
+  constexpr const char *name() const { return descriptor.vef_desc.name; }
+};
+
+// =============================================================================
+// TypeBuilder
+// =============================================================================
+//
+// Template parameters:
+//   HasFromString / HasToString / HasCompare — set by the corresponding
+//     builder methods; build() static_asserts all three are true.
+//   HasParams — set by .params<P, &ParseFn>(); build() requires this when
+//     HasIntToParams or HasResolveParams is true.
+//   HasIntToParams / HasResolveParams — set by the corresponding template
+//     methods.
+//   EFT — accumulates embedded SQL-callable VDFs (StaticFuncDesc values)
+//     produced by the template methods.
+//   Name — const char* NTTP from make_type<kName>(); drives selection of the
+//     per-(Name,Op) constexpr VDF name buffers via kTypeOpVdfName<Name,Op>.
+//
+//     NB - there is no HasHash because it is optional.
+
+template <bool HasFromString = false, bool HasToString = false,
+          bool HasCompare = false, bool HasParams = false,
+          bool HasIntToParams = false, bool HasResolveParams = false,
+          typename EFT = std::tuple<>, const char *Name = nullptr>
+class TypeBuilder {
+ public:
+  constexpr TypeBuilder &persisted_length(int64_t len) {
+    state_.desc.vef_desc.persisted_length = len;
+    return *this;
+  }
+
+  constexpr TypeBuilder &max_decode_buffer_length(int64_t len) {
+    state_.desc.vef_desc.max_decode_buffer_length = len;
+    return *this;
+  }
+
+  // -------------------------------------------------------------------------
+  // Parameterized type support
+  // -------------------------------------------------------------------------
+
+  // Bind the params parse function to TypeParamsCache<P>.
+  // Must be called before int_to_params() or resolve_params().
+  // P is the params struct type; ParseFunc is a function:
+  //   P fn(const std::map<std::string, std::string>&)
+  template <typename P, auto ParseFunc>
+  constexpr auto params() const {
+    detail::TypeBuilderState s = state_;
+    s.desc.params_init_fn =
+        &villagesql::type_builder::bind_params_cache<P, ParseFunc>;
+    s.desc.vef_desc.protocol = VEF_PROTOCOL_2;
+    return TypeBuilder<HasFromString, HasToString, HasCompare, true,
+                       HasIntToParams, HasResolveParams, EFT, Name>{
+        s, embedded_funcs_};
+  }
+
+  // int_to_params: VDF that converts MYTYPE(N) integer to a params string.
+  // Auto-generates VDF name "TYPENAME::int_to_params".
+  // Function signature: bool fn(int64_t, std::map<std::string,std::string>&,
+  //                             char* error_msg)
+  template <auto Func>
+  constexpr auto int_to_params() const {
+    using namespace detail;
+    static_assert(
+        std::is_same_v<decltype(Func),
+                       villagesql::func_builder::IntToTypeParamsFunc>,
+        "int_to_params<Func>() requires: "
+        "bool fn(int64_t, std::map<std::string,std::string>&, char*)");
+    constexpr const char *vdf_name =
+        kTypeOpVdfName<Name, TypeOp::kIntToParams>.buf;
+    auto inner = villagesql::func_builder::make_int_to_params<Func>(vdf_name);
+    TypeBuilderState s = state_;
+    s.desc.vef_desc.int_to_params_vdf_name = vdf_name;
+    s.desc.vef_desc.protocol = VEF_PROTOCOL_2;
+    auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
+    return TypeBuilder<HasFromString, HasToString, HasCompare, HasParams, true,
+                       HasResolveParams, decltype(new_embedded), Name>{
+        s, new_embedded};
+  }
+
+  // resolve_params: VDF that validates params and computes storage sizes.
+  // Auto-generates VDF name "TYPENAME::resolve_params".
+  // Function signature:
+  //   bool fn(const std::map<std::string,std::string>&,
+  //           villagesql::ResolvedTypeParams*, char* error_msg)
+  template <auto Func>
+  constexpr auto resolve_params() const {
+    using namespace detail;
+    static_assert(
+        std::is_same_v<decltype(Func),
+                       villagesql::func_builder::ResolveTypeParamsFunc>,
+        "resolve_params<Func>() requires: "
+        "bool fn(const std::map<std::string,std::string>&, "
+        "villagesql::ResolvedTypeParams*, char*)");
+    constexpr const char *vdf_name =
+        kTypeOpVdfName<Name, TypeOp::kResolveParams>.buf;
+    auto inner = villagesql::func_builder::make_resolve_params<Func>(vdf_name);
+    TypeBuilderState s = state_;
+    s.desc.vef_desc.resolve_params_vdf_name = vdf_name;
+    s.desc.vef_desc.protocol = VEF_PROTOCOL_2;
+    auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
+    return TypeBuilder<HasFromString, HasToString, HasCompare, HasParams,
+                       HasIntToParams, true, decltype(new_embedded), Name>{
+        s, new_embedded};
+  }
+
+  // -------------------------------------------------------------------------
+  // Auto-named template methods (SQL-callable, v2 ABI)
+  //
+  // VDF name is auto-generated as "TYPENAME::method" at compile time.
+  // The named VDF is embedded in the TypeObject and registered automatically
+  // by ExtensionBuilder::type().
+  // -------------------------------------------------------------------------
+
+  template <auto Func>
+  constexpr auto from_string() const {
+    using namespace detail;
+    // Accepts TypeEncodeFunc or TypeEncodeWithParamsFunc<P> (const P& as first
+    // arg). Signature validation is handled by make_type_encode<Func>.
+    constexpr const char *vdf_name = kTypeOpVdfName<Name, TypeOp::kEncode>.buf;
+    auto inner = villagesql::func_builder::make_type_encode<Func>(
+        vdf_name, state_.desc.vef_desc.name);
+    TypeBuilderState s = state_;
+    s.desc.vef_desc.encode_vdf_name = vdf_name;
+    s.desc.vef_desc.protocol = VEF_PROTOCOL_2;
+    auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
+    return TypeBuilder<true, HasToString, HasCompare, HasParams, HasIntToParams,
+                       HasResolveParams, decltype(new_embedded), Name>{
+        s, new_embedded};
+  }
+
+  template <auto Func>
+  constexpr auto to_string() const {
+    using namespace detail;
+    // Accepts TypeDecodeFunc or TypeDecodeWithParamsFunc<P>.
+    // Signature validation is handled by make_type_decode<Func>.
+    constexpr const char *vdf_name = kTypeOpVdfName<Name, TypeOp::kDecode>.buf;
+    auto inner = villagesql::func_builder::make_type_decode<Func>(
+        vdf_name, state_.desc.vef_desc.name);
+    TypeBuilderState s = state_;
+    s.desc.vef_desc.decode_vdf_name = vdf_name;
+    s.desc.vef_desc.protocol = VEF_PROTOCOL_2;
+    auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
+    return TypeBuilder<HasFromString, true, HasCompare, HasParams,
+                       HasIntToParams, HasResolveParams, decltype(new_embedded),
+                       Name>{s, new_embedded};
+  }
+
+  template <auto Func>
+  constexpr auto compare() const {
+    using namespace detail;
+    // Accepts TypeCompareFunc or TypeCompareWithParamsFunc<P>.
+    // Signature validation is handled by make_type_compare<Func>.
+    constexpr const char *vdf_name = kTypeOpVdfName<Name, TypeOp::kCompare>.buf;
+    auto inner = villagesql::func_builder::make_type_compare<Func>(
+        vdf_name, state_.desc.vef_desc.name);
+    TypeBuilderState s = state_;
+    s.desc.vef_desc.compare_vdf_name = vdf_name;
+    s.desc.vef_desc.protocol = VEF_PROTOCOL_2;
+    auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
+    return TypeBuilder<HasFromString, HasToString, true, HasParams,
+                       HasIntToParams, HasResolveParams, decltype(new_embedded),
+                       Name>{s, new_embedded};
+  }
+
+  template <auto Func>
+  constexpr auto hash() const {
+    using namespace detail;
+    // Accepts TypeHashFunc or TypeHashWithParamsFunc<P>.
+    // Signature validation is handled by make_type_hash<Func>.
+    constexpr const char *vdf_name = kTypeOpVdfName<Name, TypeOp::kHash>.buf;
+    auto inner = villagesql::func_builder::make_type_hash<Func>(
+        vdf_name, state_.desc.vef_desc.name);
+    TypeBuilderState s = state_;
+    s.desc.vef_desc.hash_vdf_name = vdf_name;
+    s.desc.vef_desc.protocol = VEF_PROTOCOL_2;
+    auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
+    return TypeBuilder<HasFromString, HasToString, HasCompare, HasParams,
+                       HasIntToParams, HasResolveParams, decltype(new_embedded),
+                       Name>{s, new_embedded};
+  }
+
+  // intrinsic_default_str:
+  constexpr TypeBuilder &intrinsic_default_str(const char *str) {
+    state_.desc.vef_desc.intrinsic_default_str = str;
+    state_.desc.vef_desc.protocol = VEF_PROTOCOL_2;
+    return *this;
+  }
+
+  // intrinsic_default_vdf: name of a separately-registered VDF that writes the
+  // default binary value for a NOT NULL column receiving NULL with IGNORE.
+  // The named VDF must be registered separately with make_intrinsic_default().
+  //
+  // TODO(villagesql-beta): embed intrinsic_default inline once the vsql API
+  // supports auto-generating its VDF name too.
+  constexpr TypeBuilder &intrinsic_default_vdf(const char *vdf_name) {
+    state_.desc.vef_desc.intrinsic_default_vdf_name = vdf_name;
+    state_.desc.vef_desc.protocol = VEF_PROTOCOL_2;
+    return *this;
+  }
+
+  // -------------------------------------------------------------------------
+  // build() — finalize to TypeObject<EFT>
+  // -------------------------------------------------------------------------
+
+  constexpr TypeObject<EFT> build() const {
+    // TODO(villagesql-beta): Static check that the operation take type params
+    // if they are registered with param functions.
+    static_assert(
+        HasFromString,
+        "vsql::TypeBuilder: from_string() is required before build()");
+    static_assert(HasToString,
+                  "vsql::TypeBuilder: to_string() is required before build()");
+    static_assert(HasCompare,
+                  "vsql::TypeBuilder: compare() is required before build()");
+    static_assert(!HasIntToParams || HasParams,
+                  "vsql::TypeBuilder: params<P, &parse_fn>() is required when "
+                  "int_to_params() is used");
+    static_assert(!HasResolveParams || HasParams,
+                  "vsql::TypeBuilder: params<P, &parse_fn>() is required when "
+                  "resolve_params() is used");
+    return TypeObject<EFT>{state_.desc, embedded_funcs_};
+  }
+
+  // Cross-specialization and make_type access.
+  template <bool, bool, bool, bool, bool, bool, typename, const char *>
+  friend class TypeBuilder;
+
+  template <const char *N>
+  friend constexpr TypeBuilder<false, false, false, false, false, false,
+                               std::tuple<>, N>
+  make_type();
+
+ private:
+  detail::TypeBuilderState state_;
+  EFT embedded_funcs_;
+
+  constexpr explicit TypeBuilder(const detail::TypeBuilderState &s,
+                                 EFT ef = EFT{})
+      : state_(s), embedded_funcs_(ef) {}
+};
+
+// =============================================================================
+// make_type<Name>() — entry point
+// =============================================================================
+//
+// Name must be a const char* — a pointer to a static constexpr char array
+// declared with external or internal linkage, e.g.:
+//
+//   static constexpr const char kMyTypeName[] = "MYTYPE";
+//   constexpr auto MYTYPE = vsql::make_type<kMyTypeName>()...build();
+
+template <const char *Name>
+constexpr TypeBuilder<false, false, false, false, false, false, std::tuple<>,
+                      Name>
+make_type() {
+  detail::TypeBuilderState s{};
+  s.desc.vef_desc.name = Name;
+  s.desc.vef_desc.protocol = VEF_PROTOCOL_1;
+  return TypeBuilder<false, false, false, false, false, false, std::tuple<>,
+                     Name>{s};
+}
+
+}  // namespace vsql
+
+#endif  // VILLAGESQL_VSQL_TYPE_BUILDER_H

--- a/villagesql/test-extensions/vsql-test-only/src/extension.cc
+++ b/villagesql/test-extensions/vsql-test-only/src/extension.cc
@@ -51,7 +51,7 @@
 //                 Any other input is rejected by encode with an assert-style
 //                 error, so tests cannot silently pass unexpected values.
 
-#include <villagesql/extension.h>
+#include <villagesql/vsql.h>
 
 #include <cassert>
 #include <cstddef>
@@ -170,29 +170,23 @@ static void test_result_kind(villagesql::StringArg input,
   out.set(42);
 }
 
-constexpr const char *FAULT_BLOB = "FAULT_BLOB";
+static constexpr const char kFaultBlobTypeName[] = "FAULT_BLOB";
+
+constexpr auto FAULT_BLOB = vsql::make_type<kFaultBlobTypeName>()
+                                .persisted_length(kFaultBlobSize)
+                                .max_decode_buffer_length(kFaultBlobSize)
+                                .from_string<&fault_blob_encode>()
+                                .to_string<&fault_blob_decode>()
+                                .compare<&fault_blob_compare>()
+                                .build();
+
+using namespace vsql;
 
 VEF_GENERATE_ENTRY_POINTS(
     make_extension("vsql_test_only", "0.0.1")
-
         // FAULT_BLOB type: behaviour controlled by
         // "OK"/"DECODE_FAIL"/"ENCODE_FAIL" prefix
-        .type(make_type(FAULT_BLOB)
-                  .persisted_length(kFaultBlobSize)
-                  .max_decode_buffer_length(kFaultBlobSize)
-                  .encode("fault_blob_encode")
-                  .decode("fault_blob_decode")
-                  .compare("fault_blob_compare")
-                  .build())
-
-        // Type operation VDFs for FAULT_BLOB
-        .func(make_type_encode<&fault_blob_encode>("fault_blob_encode",
-                                                   FAULT_BLOB))
-        .func(make_type_decode<&fault_blob_decode>("fault_blob_decode",
-                                                   FAULT_BLOB))
-        .func(make_type_compare<&fault_blob_compare>("fault_blob_compare",
-                                                     FAULT_BLOB))
-
+        .type(FAULT_BLOB)
         // Test VDF: exercises VEF_RESULT_WARNING vs VEF_RESULT_ERROR
         .func(make_func<&test_result_kind>("test_result_kind")
                   .returns(INT)


### PR DESCRIPTION
Introduces vsql::make_type<kName>(), an object-based type builder in the new ::vsql namespace. Types are defined as constexpr objects that carry their VDF names and implementations; passing the object to .type() on ExtensionBuilder registers the type and all embedded VDFs in one step, eliminating the manual string-matching between type descriptors and separately-registered VDFs.

Key changes:
- New headers <villagesql/vsql.h> and <villagesql/vsql/type_builder.h> provide the new API
- VDF names (e.g. COMPLEX::from_string) are auto-generated at compile time from the type-name NTTP — no manual string literals needed
- ExtensionBuilder::type() gains an overload accepting a TypeObject (with embedded VDFs), in addition to the existing TypeDescriptor overload
- Most test extensions and examples updated to use the new API
- Old villagesql::type_builder / villagesql::func_builder APIs are unchanged; both styles can coexist for now.  We will drop them later.

Note ImplicitDefault is not yet converted, because it is a work in progress
