### PR TITLE
aggregate vdfs state improvements

### DIFF
--- a/mysql-test/suite/villagesql/std_data/aggregate_vdf.cc
+++ b/mysql-test/suite/villagesql/std_data/aggregate_vdf.cc
@@ -78,6 +78,10 @@ long long vdf_count_result(const CountState &state) { return state; }
 // vdf_concat: aggregate that concatenates STRING values with commas.
 // Returns NULL for empty groups.
 
+// NOTE: std::optional<std::string> performs heap allocation for the string
+// data. For production use, prefer fixed-size state types to avoid allocations
+// during aggregation -- e.g., accumulate into a pre-sized char[] buffer and
+// track the length manually.
 using ConcatState = std::optional<std::string>;
 
 void vdf_concat_clear(ConcatState &state) { state = std::nullopt; }

--- a/villagesql/sdk/include/villagesql/abi/types.h
+++ b/villagesql/sdk/include/villagesql/abi/types.h
@@ -524,6 +524,21 @@ typedef void (*vef_vdf_accumulate_func_t)(vef_context_t *ctx,
                                           vef_vdf_result_t *result);
 
 // =============================================================================
+// State Lifecycle (data-driven aggregate state)
+// =============================================================================
+//
+// Used by .state<T>() in the SDK to declare aggregate state as data rather
+// than opaque prerun/postrun callbacks. The VEF allocates state_size bytes
+// and calls state_init to placement-construct the state; on cleanup it calls
+// state_destroy (destructor only) then frees the memory itself.
+
+// Placement-constructs state into a pre-allocated buffer of state_size bytes.
+typedef void (*vef_state_init_func_t)(void *buf);
+
+// Calls the state destructor. Must NOT free the buffer.
+typedef void (*vef_state_destroy_func_t)(void *buf);
+
+// =============================================================================
 // Function and Type Descriptors
 // =============================================================================
 
@@ -568,6 +583,14 @@ typedef struct {
   // It is an error to set exactly one of these; both must be present or absent.
   vef_vdf_clear_func_t clear;
   vef_vdf_accumulate_func_t accumulate;
+
+  // Data-driven aggregate state (alternative to prerun/postrun for state
+  // allocation). When state_size > 0, the VEF allocates the buffer, calls
+  // state_init to construct, and state_destroy + free on cleanup.
+  size_t state_size;
+  size_t state_align;
+  vef_state_init_func_t state_init;
+  vef_state_destroy_func_t state_destroy;
 } vef_func_desc_t;
 
 // =============================================================================

--- a/villagesql/sdk/include/villagesql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/func_builder.h
@@ -113,20 +113,16 @@ constexpr vef_type_t to_vef_type(const char *name);
 // explains what went wrong.
 void config_error__aggregate_must_set_both_clear_and_accumulate();
 
-// Auto-generated prerun/postrun for aggregate state management.
-// Use with .state<T>() on FuncBuilder to avoid writing boilerplate
-// prerun/postrun callbacks for simple aggregate state types.
+// Auto-generated state lifecycle for .state<T>().
+// The VEF allocates the buffer; these just construct/destruct in place.
 template <typename State>
-void auto_prerun(vef_context_t *, vef_prerun_args_t *,
-                 vef_prerun_result_t *result) {
-  result->user_data = new State{};
-  result->type = VEF_RESULT_VALUE;
+void auto_state_init(void *buf) {
+  new (buf) State{};
 }
 
 template <typename State>
-void auto_postrun(vef_context_t *, vef_postrun_args_t *args,
-                  vef_postrun_result_t *) {
-  delete static_cast<State *>(args->user_data);
+void auto_state_destroy(void *buf) {
+  static_cast<State *>(buf)->~State();
 }
 
 // =============================================================================
@@ -168,7 +164,11 @@ struct FuncWithMetadata {
         num_params(0),
         buffer_size(0),
         deterministic(false),
-        check_params_cache_bound(nullptr) {}
+        check_params_cache_bound(nullptr),
+        state_size(0),
+        state_align(0),
+        state_init(nullptr),
+        state_destroy(nullptr) {}
 
   ExtFunc f;
   vef_prerun_func_t prerun;
@@ -184,6 +184,10 @@ struct FuncWithMetadata {
   // function that returns true if the cache has been bound. Set by the cache
   // wrapper selection in make_type_encode/decode/compare/intrinsic_default.
   bool (*check_params_cache_bound)();
+  size_t state_size;
+  size_t state_align;
+  vef_state_init_func_t state_init;
+  vef_state_destroy_func_t state_destroy;
 };
 
 // =============================================================================
@@ -970,6 +974,10 @@ struct StaticFuncDesc {
   size_t buffer_size_;
   bool deterministic_;
   bool (*check_params_cache_bound_)();
+  size_t state_size_;
+  size_t state_align_;
+  vef_state_init_func_t state_init_;
+  vef_state_destroy_func_t state_destroy_;
 
   constexpr StaticFuncDesc(const char *name, const FuncWithMetadata &meta)
       : name_(name),
@@ -982,7 +990,11 @@ struct StaticFuncDesc {
         accumulate_(meta.accumulate),
         buffer_size_(meta.buffer_size),
         deterministic_(meta.deterministic),
-        check_params_cache_bound_(meta.check_params_cache_bound) {
+        check_params_cache_bound_(meta.check_params_cache_bound),
+        state_size_(meta.state_size),
+        state_align_(meta.state_align),
+        state_init_(meta.state_init),
+        state_destroy_(meta.state_destroy) {
     for (size_t i = 0; i < NumParams && i < meta.num_params; ++i) {
       params_[i] = meta.param_types[i];
     }
@@ -1002,6 +1014,12 @@ struct StaticFuncDesc {
   constexpr bool deterministic() const { return deterministic_; }
   constexpr auto check_params_cache_bound() const -> bool (*)() {
     return check_params_cache_bound_;
+  }
+  constexpr size_t state_size() const { return state_size_; }
+  constexpr size_t state_align() const { return state_align_; }
+  constexpr vef_state_init_func_t state_init() const { return state_init_; }
+  constexpr vef_state_destroy_func_t state_destroy() const {
+    return state_destroy_;
   }
 };
 
@@ -1034,6 +1052,10 @@ __attribute__((visibility("hidden"))) vef_func_desc_t *materialize_func_desc(
   desc.deterministic = func_data.deterministic();
   desc.clear = func_data.clear();
   desc.accumulate = func_data.accumulate();
+  desc.state_size = func_data.state_size();
+  desc.state_align = func_data.state_align();
+  desc.state_init = func_data.state_init();
+  desc.state_destroy = func_data.state_destroy();
 
   return &desc;
 }
@@ -1140,7 +1162,11 @@ struct FuncBuilder {
         postrun_(nullptr),
         clear_(nullptr),
         accumulate_(nullptr),
-        deterministic_(false) {}
+        deterministic_(false),
+        state_size_(0),
+        state_align_(0),
+        state_init_(nullptr),
+        state_destroy_(nullptr) {}
 
   const char *name_;
   const char *return_type_;
@@ -1151,6 +1177,10 @@ struct FuncBuilder {
   vef_vdf_clear_func_t clear_;
   vef_vdf_accumulate_func_t accumulate_;
   bool deterministic_;
+  size_t state_size_;
+  size_t state_align_;
+  vef_state_init_func_t state_init_;
+  vef_state_destroy_func_t state_destroy_;
 
   constexpr FuncBuilder<Func, NumParams> &returns(const char *t) {
     return_type_ = t;
@@ -1167,6 +1197,10 @@ struct FuncBuilder {
     next.clear_ = clear_;
     next.accumulate_ = accumulate_;
     next.deterministic_ = deterministic_;
+    next.state_size_ = state_size_;
+    next.state_align_ = state_align_;
+    next.state_init_ = state_init_;
+    next.state_destroy_ = state_destroy_;
     for (size_t i = 0; i < NumParams; ++i) {
       next.param_types_[i] = param_types_[i];
     }
@@ -1249,12 +1283,15 @@ struct FuncBuilder {
     return *this;
   }
 
-  // Set the aggregate state type. Automatically generates prerun (allocates
-  // State via value-initialization) and postrun (deletes State).
+  // Declare the aggregate state type as data. The VEF allocates and manages
+  // the state buffer; auto_state_init/auto_state_destroy handle construction
+  // and destruction in place.
   template <typename State>
   constexpr FuncBuilder<Func, NumParams> &state() {
-    prerun_ = &auto_prerun<State>;
-    postrun_ = &auto_postrun<State>;
+    state_size_ = sizeof(State);
+    state_align_ = alignof(State);
+    state_init_ = &auto_state_init<State>;
+    state_destroy_ = &auto_state_destroy<State>;
     return *this;
   }
 
@@ -1301,6 +1338,10 @@ struct FuncBuilder {
     meta.num_params = NumParams;
     meta.buffer_size = buffer_size_;
     meta.deterministic = deterministic_;
+    meta.state_size = state_size_;
+    meta.state_align = state_align_;
+    meta.state_init = state_init_;
+    meta.state_destroy = state_destroy_;
     for (size_t i = 0; i < NumParams; ++i) {
       meta.param_types[i] = to_vef_type(param_types_[i]);
     }

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -163,6 +163,19 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
     }
   }
 
+  // Data-driven state allocation (from .state<T>() in the SDK).
+  // The VEF owns the buffer; state_init/state_destroy handle construction
+  // and destruction in place.
+  if (m_udf->vdf_protocol >= VEF_PROTOCOL_2 &&
+      m_udf->vdf_func_desc->state_size > 0 && !m_vdf_args.user_data) {
+    void *buf = my_malloc(PSI_NOT_INSTRUMENTED,
+                          m_udf->vdf_func_desc->state_size, MYF(0));
+    if (!buf) return true;
+    m_udf->vdf_func_desc->state_init(buf);
+    m_vdf_args.user_data = buf;
+    m_state_data_driven = true;
+  }
+
   // Set return type_context if this VDF returns a custom type
   if (signature != nullptr && signature->return_type.id == VEF_TYPE_CUSTOM) {
     villagesql::SetVDFReturnTypeContext(thd, m_udf->extension_name, signature,
@@ -209,12 +222,19 @@ void vdf_handler::accumulate(bool *null_value) {
 }
 
 void vdf_handler::cleanup() {
-  // Call postrun if VDF was active and postrun exists
-  if (m_active && m_udf->vdf_func_desc->postrun) {
-    vef_postrun_args_t postrun_args{};
-    postrun_args.user_data = m_vdf_args.user_data;
-    vef_postrun_result_t postrun_result{};
-    m_udf->vdf_func_desc->postrun(&m_context, &postrun_args, &postrun_result);
+  if (m_active) {
+    if (m_state_data_driven) {
+      m_udf->vdf_func_desc->state_destroy(m_vdf_args.user_data);
+      my_free(m_vdf_args.user_data);
+      m_vdf_args.user_data = nullptr;
+      m_state_data_driven = false;
+    } else if (m_udf->vdf_func_desc->postrun) {
+      vef_postrun_args_t postrun_args{};
+      postrun_args.user_data = m_vdf_args.user_data;
+      vef_postrun_result_t postrun_result{};
+      m_udf->vdf_func_desc->postrun(&m_context, &postrun_args,
+                                     &postrun_result);
+    }
   }
   m_active = false;
 }

--- a/villagesql/vdf/vdf_handler.h
+++ b/villagesql/vdf/vdf_handler.h
@@ -74,6 +74,7 @@ class vdf_handler {
   size_t m_result_buffer_size{0};
   char *m_error_msg{nullptr};
   bool m_active{false};
+  bool m_state_data_driven{false};
   const villagesql::TypeContext *m_return_type_context{nullptr};
 
   // Marshal arguments into m_invalues array based on declared parameter types


### PR DESCRIPTION
## Description

Allow uses of FuncBuilder's .state<>() without creating prerun and postrun functions for simple cases.

Prerun and postrun functions are opaque, and so can preclude optimizations.

Instead, push more data about the state scheme through the ABI and handle them in the VEF instead of in the extension.

## Related Issue

## How was this tested?

Existing aggregate VDF tests still pass.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
