### PR TITLE
InnoDB: Column storage err handling

### DIFF
--- a/storage/innobase/ddl/ddl0ddl.cc
+++ b/storage/innobase/ddl/ddl0ddl.cc
@@ -1,6 +1,7 @@
 /*****************************************************************************
 
 Copyright (c) 2005, 2025, Oracle and/or its affiliates.
+Copyright (c) 2026 VillageSQL Contributors
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License, version 2.0, as published by the
@@ -217,6 +218,15 @@ dict_index_t *create_index(trx_t *trx, dict_table_t *table,
       }
     } else {
       name = table->get_col_name(ifield->m_col_no);
+      dict_col_t *col = table->get_col(ifield->m_col_no);
+      if (col->stored_by_extn()) {
+        trx->error_state = DB_VILLAGE_ERROR;
+        trx_set_detailed_error(
+            trx,
+            "InnoDB: Indexing for types with column storage is not"
+            " supported.");
+        return nullptr;
+      }
     }
 
     index->add_field(name, ifield->m_prefix_len, ifield->m_is_ascending);

--- a/storage/innobase/ddl/ddl0ddl.cc
+++ b/storage/innobase/ddl/ddl0ddl.cc
@@ -220,7 +220,7 @@ dict_index_t *create_index(trx_t *trx, dict_table_t *table,
       name = table->get_col_name(ifield->m_col_no);
       dict_col_t *col = table->get_col(ifield->m_col_no);
       if (col->stored_by_extn()) {
-        trx->error_state = DB_VILLAGE_ERROR;
+        trx->error_state = DB_VILLAGESQL_ERROR;
         trx_set_detailed_error(
             trx,
             "InnoDB: Indexing for types with column storage is not"

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -2278,7 +2278,7 @@ int convert_error_code_to_mysql(dberr_t error, uint32_t flags, THD *thd) {
     case DB_IO_NO_PUNCH_HOLE_FS:
     case DB_IO_NO_PUNCH_HOLE_TABLESPACE:
       return HA_ERR_UNSUPPORTED;
-    case DB_VILLAGE_ERROR:
+    case DB_VILLAGESQL_ERROR:
       if (thd) {
         villagesql_error(
             "InnoDB: Custom type operation failed. See server"

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -199,6 +199,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "ut0test.h"
 #include "ut0ut.h"
 #include "villagesql/custom_column.h"
+#include "villagesql/include/error.h"
 #include "villagesql/schema/util.h"
 #else
 #include <typelib.h>
@@ -2277,6 +2278,14 @@ int convert_error_code_to_mysql(dberr_t error, uint32_t flags, THD *thd) {
     case DB_IO_NO_PUNCH_HOLE_FS:
     case DB_IO_NO_PUNCH_HOLE_TABLESPACE:
       return HA_ERR_UNSUPPORTED;
+    case DB_VILLAGE_ERROR:
+      if (thd) {
+        villagesql_error(
+            "InnoDB: Custom type operation failed. See server"
+            " error log for details.",
+            MYF(0));
+      }
+      return HA_ERR_GENERIC;
   }
 }
 
@@ -12357,6 +12366,16 @@ inline int create_index(
     Field *field = form->field[key_part->field->field_index()];
     if (field == nullptr) ut_error;
 
+    // TODO(villagesql-indexing): Support indexing for types with column store.
+    if (field->has_type_context() &&
+        field->get_type_context()->storage_intf()) {
+      villagesql_error(
+          "InnoDB: Indexing for types with column storage is not supported.",
+          MYF(0));
+      error = ER_VILLAGESQL_GENERIC_ERROR;
+      goto do_cleanup;
+    }
+
     const char *field_name = key_part->field->field_name;
     if (handler != nullptr && handler->is_intrinsic()) {
       ut_ad(!innobase_is_v_fld(key_part->field));
@@ -12436,6 +12455,7 @@ inline int create_index(
     dd_table_close(new_table, nullptr, nullptr, false);
   }
 
+do_cleanup:
   if (error && handler != nullptr) {
     priv->unregister_table_handler(table_name);
   }

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -425,7 +425,7 @@ static UNIV_COLD void my_error_innodb(
     case DB_TABLESPACE_EXISTS:
       my_error(ER_TABLESPACE_EXISTS, MYF(0), table);
       break;
-    case DB_VILLAGE_ERROR:
+    case DB_VILLAGESQL_ERROR:
       villagesql_error(
           "InnoDB: Custom type operation failed. See server"
           " error log for details.",
@@ -5157,8 +5157,8 @@ error_handling:
     case DB_UNSUPPORTED:
       my_error(ER_TABLE_CANT_HANDLE_SPKEYS, MYF(0));
       break;
-    case DB_VILLAGE_ERROR:
-      ut_ad(ctx->trx->error_state == DB_VILLAGE_ERROR);
+    case DB_VILLAGESQL_ERROR:
+      ut_ad(ctx->trx->error_state == DB_VILLAGESQL_ERROR);
       villagesql_error("%s", MYF(0), ctx->trx->detailed_error);
       break;
     default:

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -110,6 +110,7 @@ this program; if not, write to the Free Software Foundation, Inc.,
 #include "ut0new.h"
 #include "ut0stage.h"
 #include "villagesql/custom_column.h"
+#include "villagesql/include/error.h"
 
 /* For supporting Native InnoDB Partitioning. */
 #include "ha_innopart.h"
@@ -424,7 +425,12 @@ static UNIV_COLD void my_error_innodb(
     case DB_TABLESPACE_EXISTS:
       my_error(ER_TABLESPACE_EXISTS, MYF(0), table);
       break;
-
+    case DB_VILLAGE_ERROR:
+      villagesql_error(
+          "InnoDB: Custom type operation failed. See server"
+          " error log for details.",
+          MYF(0));
+      break;
 #ifdef UNIV_DEBUG
     case DB_SUCCESS:
     case DB_DUPLICATE_KEY:
@@ -1280,6 +1286,12 @@ enum_alter_inplace_result ha_innobase::check_if_supported_inplace_alter(
   if (ha_alter_info->handler_flags & Alter_inplace_info::ADD_SPATIAL_INDEX) {
     ha_alter_info->unsupported_reason =
         innobase_get_err_msg(ER_ALTER_OPERATION_NOT_SUPPORTED_REASON_GIS);
+    online = false;
+  }
+
+  // Extended custom column storage holds DML operations during table rebuild.
+  // TODO(villagesql): Enable online row logging for column storage.
+  if (m_prebuilt->table->has_extended_storage) {
     online = false;
   }
 
@@ -5144,6 +5156,10 @@ error_handling:
       break;
     case DB_UNSUPPORTED:
       my_error(ER_TABLE_CANT_HANDLE_SPKEYS, MYF(0));
+      break;
+    case DB_VILLAGE_ERROR:
+      ut_ad(ctx->trx->error_state == DB_VILLAGE_ERROR);
+      villagesql_error("%s", MYF(0), ctx->trx->detailed_error);
       break;
     default:
       my_error_innodb(error, table_name, user_table->flags);

--- a/storage/innobase/include/db0err.h
+++ b/storage/innobase/include/db0err.h
@@ -210,7 +210,7 @@ enum dberr_t {
 
   // TODO(villagesql-rebase): check this enum value for conflict.
   // VillageSQL error code for InnoDB
-  DB_VILLAGE_ERROR = 500,
+  DB_VILLAGESQL_ERROR = 500,
 
   /* The following are partial failure codes */
 

--- a/storage/innobase/include/db0err.h
+++ b/storage/innobase/include/db0err.h
@@ -1,6 +1,7 @@
 /*****************************************************************************
 
 Copyright (c) 1996, 2025, Oracle and/or its affiliates.
+Copyright (c) 2026 VillageSQL Contributors
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License, version 2.0, as published by the
@@ -206,6 +207,10 @@ enum dberr_t {
   DB_DATA_NOT_SORTED,
   /** The record size is too big for LOAD BULK DATA operation. */
   DB_BULK_TOO_BIG_RECORD,
+
+  // TODO(villagesql-rebase): check this enum value for conflict.
+  // VillageSQL error code for InnoDB
+  DB_VILLAGE_ERROR = 500,
 
   /* The following are partial failure codes */
 

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -678,7 +678,7 @@ handle_new_error:
         break;
       }
       [[fallthrough]];
-    case DB_ERROR:
+    case DB_VILLAGE_ERROR:
     case DB_DUPLICATE_KEY:
     case DB_FOREIGN_DUPLICATE_KEY:
     case DB_TOO_BIG_RECORD:

--- a/storage/innobase/row/row0mysql.cc
+++ b/storage/innobase/row/row0mysql.cc
@@ -678,7 +678,7 @@ handle_new_error:
         break;
       }
       [[fallthrough]];
-    case DB_VILLAGE_ERROR:
+    case DB_VILLAGESQL_ERROR:
     case DB_DUPLICATE_KEY:
     case DB_FOREIGN_DUPLICATE_KEY:
     case DB_TOO_BIG_RECORD:

--- a/storage/innobase/ut/ut0ut.cc
+++ b/storage/innobase/ut/ut0ut.cc
@@ -1,6 +1,7 @@
 /*****************************************************************************
 
 Copyright (c) 1994, 2025, Oracle and/or its affiliates.
+Copyright (c) 2026 VillageSQL Contributors
 
 This program is free software; you can redistribute it and/or modify it under
 the terms of the GNU General Public License, version 2.0, as published by the
@@ -488,6 +489,8 @@ const char *ut_strerr(dberr_t num) {
       return "Data is not sorted.";
     case DB_BULK_TOO_BIG_RECORD:
       return "Row is too big for LOAD BULK DATA operation.";
+    case DB_VILLAGE_ERROR:
+      return "VillageSQL: Error in custom type operation.";
     case DB_ERROR_UNSET:;
       /* Fall through. */
 

--- a/storage/innobase/ut/ut0ut.cc
+++ b/storage/innobase/ut/ut0ut.cc
@@ -489,7 +489,7 @@ const char *ut_strerr(dberr_t num) {
       return "Data is not sorted.";
     case DB_BULK_TOO_BIG_RECORD:
       return "Row is too big for LOAD BULK DATA operation.";
-    case DB_VILLAGE_ERROR:
+    case DB_VILLAGESQL_ERROR:
       return "VillageSQL: Error in custom type operation.";
     case DB_ERROR_UNSET:;
       /* Fall through. */

--- a/storage/innobase/villagesql/custom_column.cc
+++ b/storage/innobase/villagesql/custom_column.cc
@@ -282,7 +282,7 @@ static dberr_t create_column_storage(const dict_col_t *col, mem_heap_t *heap,
   if (failed) {
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Error creating custom column store: " << error_msg;
-    return DB_ERROR;
+    return DB_VILLAGE_ERROR;
   }
   custom_column->set_storage_ctx(ctx);
   return DB_SUCCESS;
@@ -313,7 +313,7 @@ static dberr_t drop_column_storage(const dict_col_t *col, trx_id_t trx_id) {
   if (!custom_column->storage_ctx()) {
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Drop: Uninitialized custom column store";
-    return DB_ERROR;
+    return DB_VILLAGE_ERROR;
   }
   const auto &intf = custom_column->storage_interface();
   char error_msg[Custom_column::ERROR_MSG_SIZE] = {};
@@ -326,7 +326,7 @@ static dberr_t drop_column_storage(const dict_col_t *col, trx_id_t trx_id) {
   if (failed) {
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Error dropping custom column store: " << error_msg;
-    return DB_ERROR;
+    return DB_VILLAGE_ERROR;
   }
   return DB_SUCCESS;
 }
@@ -364,14 +364,14 @@ static dberr_t insert_in_column_store(const dict_col_t *col, mtr_t *mtr,
   if (!col_data.data || col_data.length == 0) {
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Insert: Invalid custom column data";
-    return DB_ERROR;
+    return DB_VILLAGE_ERROR;
   }
 
   auto &custom_column = col->custom_column;
   if (!custom_column->storage_ctx()) {
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Insert: Uninitialized custom column store";
-    return DB_ERROR;
+    return DB_VILLAGE_ERROR;
   }
 
   const auto &intf = custom_column->storage_interface();
@@ -387,7 +387,7 @@ static dberr_t insert_in_column_store(const dict_col_t *col, mtr_t *mtr,
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Error inserting data into custom column store: "
         << error_msg;
-    return DB_ERROR;
+    return DB_VILLAGE_ERROR;
   }
   return DB_SUCCESS;
 }
@@ -499,7 +499,7 @@ static dberr_t mark_in_column_store(dict_col_t *col, mtr_t *mtr,
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: " << (del_mark ? "Delete" : "Un-Delete")
         << ": Uninitialized custom column store.";
-    return DB_ERROR;
+    return DB_VILLAGE_ERROR;
   }
   const auto &intf = custom_column->storage_interface();
   char error_msg[Custom_column::ERROR_MSG_SIZE] = {};
@@ -514,7 +514,7 @@ static dberr_t mark_in_column_store(dict_col_t *col, mtr_t *mtr,
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: " << (del_mark ? "Delete" : "Un-Delete")
         << ": Error marking data in custom column store: " << error_msg;
-    return DB_ERROR;
+    return DB_VILLAGE_ERROR;
   }
   return DB_SUCCESS;
 }
@@ -540,7 +540,7 @@ static dberr_t mark_impl(const dict_index_t *index, uint32_t index_field_num,
   if (ref_val == Custom_column::EMPTY_REF) {
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Delete: Invalid custom column reference.";
-    return DB_ERROR;
+    return DB_VILLAGE_ERROR;
   }
   dberr_t error = mark_in_column_store(col, &mtr, trx_id, ref_val, del_mark);
   mtr_commit(&mtr);
@@ -627,7 +627,7 @@ static dberr_t purge_in_column_store(const dict_col_t *col, mtr_t *mtr,
   if (!custom_column->storage_ctx()) {
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Purge: Uninitialized custom column store.";
-    return DB_ERROR;
+    return DB_VILLAGE_ERROR;
   }
   const auto &intf = custom_column->storage_interface();
   char error_msg[Custom_column::ERROR_MSG_SIZE] = {};
@@ -641,7 +641,7 @@ static dberr_t purge_in_column_store(const dict_col_t *col, mtr_t *mtr,
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Purge: Error freeing data in custom column store: "
         << error_msg;
-    return DB_ERROR;
+    return DB_VILLAGE_ERROR;
   }
   return DB_SUCCESS;
 }
@@ -890,7 +890,7 @@ dberr_t Custom_column::fetch(const dict_table_t *table, const dict_col_t *col,
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Fetch: Uninitialized custom column store.";
     memset(dest, 0, dest_len);
-    return DB_ERROR;
+    return DB_VILLAGE_ERROR;
   }
   bool deleted = false;
   Custom_column::TrxRef trx_ref = 0;
@@ -920,10 +920,13 @@ dberr_t Custom_column::fetch(const dict_table_t *table, const dict_col_t *col,
 
   if (failed) {
     mtr_commit(&mtr);
+    ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
+        << "InnoDB: Error fetching data from custom column store: "
+        << error_msg;
     log_extended_error("Fetch", table, nullptr, col->ind);
 
     memset(dest, 0, dest_len);
-    return DB_ERROR;
+    return DB_VILLAGE_ERROR;
   }
   memcpy(dest, col_data.data, col_data.length);
 
@@ -948,7 +951,7 @@ dberr_t Custom_column::allocate_fetch(const dict_table_t *table,
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Fetch: Failed to allocate " << new_len << " bytes";
     log_extended_error("Fetch", table, nullptr, col->ind);
-    return DB_ERROR;
+    return DB_VILLAGE_ERROR;
   }
 
   // Copy the extended column data reference

--- a/storage/innobase/villagesql/custom_column.cc
+++ b/storage/innobase/villagesql/custom_column.cc
@@ -282,7 +282,7 @@ static dberr_t create_column_storage(const dict_col_t *col, mem_heap_t *heap,
   if (failed) {
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Error creating custom column store: " << error_msg;
-    return DB_VILLAGE_ERROR;
+    return DB_VILLAGESQL_ERROR;
   }
   custom_column->set_storage_ctx(ctx);
   return DB_SUCCESS;
@@ -313,7 +313,7 @@ static dberr_t drop_column_storage(const dict_col_t *col, trx_id_t trx_id) {
   if (!custom_column->storage_ctx()) {
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Drop: Uninitialized custom column store";
-    return DB_VILLAGE_ERROR;
+    return DB_VILLAGESQL_ERROR;
   }
   const auto &intf = custom_column->storage_interface();
   char error_msg[Custom_column::ERROR_MSG_SIZE] = {};
@@ -326,7 +326,7 @@ static dberr_t drop_column_storage(const dict_col_t *col, trx_id_t trx_id) {
   if (failed) {
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Error dropping custom column store: " << error_msg;
-    return DB_VILLAGE_ERROR;
+    return DB_VILLAGESQL_ERROR;
   }
   return DB_SUCCESS;
 }
@@ -364,14 +364,14 @@ static dberr_t insert_in_column_store(const dict_col_t *col, mtr_t *mtr,
   if (!col_data.data || col_data.length == 0) {
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Insert: Invalid custom column data";
-    return DB_VILLAGE_ERROR;
+    return DB_VILLAGESQL_ERROR;
   }
 
   auto &custom_column = col->custom_column;
   if (!custom_column->storage_ctx()) {
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Insert: Uninitialized custom column store";
-    return DB_VILLAGE_ERROR;
+    return DB_VILLAGESQL_ERROR;
   }
 
   const auto &intf = custom_column->storage_interface();
@@ -387,7 +387,7 @@ static dberr_t insert_in_column_store(const dict_col_t *col, mtr_t *mtr,
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Error inserting data into custom column store: "
         << error_msg;
-    return DB_VILLAGE_ERROR;
+    return DB_VILLAGESQL_ERROR;
   }
   return DB_SUCCESS;
 }
@@ -499,7 +499,7 @@ static dberr_t mark_in_column_store(dict_col_t *col, mtr_t *mtr,
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: " << (del_mark ? "Delete" : "Un-Delete")
         << ": Uninitialized custom column store.";
-    return DB_VILLAGE_ERROR;
+    return DB_VILLAGESQL_ERROR;
   }
   const auto &intf = custom_column->storage_interface();
   char error_msg[Custom_column::ERROR_MSG_SIZE] = {};
@@ -514,7 +514,7 @@ static dberr_t mark_in_column_store(dict_col_t *col, mtr_t *mtr,
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: " << (del_mark ? "Delete" : "Un-Delete")
         << ": Error marking data in custom column store: " << error_msg;
-    return DB_VILLAGE_ERROR;
+    return DB_VILLAGESQL_ERROR;
   }
   return DB_SUCCESS;
 }
@@ -540,7 +540,7 @@ static dberr_t mark_impl(const dict_index_t *index, uint32_t index_field_num,
   if (ref_val == Custom_column::EMPTY_REF) {
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Delete: Invalid custom column reference.";
-    return DB_VILLAGE_ERROR;
+    return DB_VILLAGESQL_ERROR;
   }
   dberr_t error = mark_in_column_store(col, &mtr, trx_id, ref_val, del_mark);
   mtr_commit(&mtr);
@@ -627,7 +627,7 @@ static dberr_t purge_in_column_store(const dict_col_t *col, mtr_t *mtr,
   if (!custom_column->storage_ctx()) {
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Purge: Uninitialized custom column store.";
-    return DB_VILLAGE_ERROR;
+    return DB_VILLAGESQL_ERROR;
   }
   const auto &intf = custom_column->storage_interface();
   char error_msg[Custom_column::ERROR_MSG_SIZE] = {};
@@ -641,7 +641,7 @@ static dberr_t purge_in_column_store(const dict_col_t *col, mtr_t *mtr,
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Purge: Error freeing data in custom column store: "
         << error_msg;
-    return DB_VILLAGE_ERROR;
+    return DB_VILLAGESQL_ERROR;
   }
   return DB_SUCCESS;
 }
@@ -890,7 +890,7 @@ dberr_t Custom_column::fetch(const dict_table_t *table, const dict_col_t *col,
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Fetch: Uninitialized custom column store.";
     memset(dest, 0, dest_len);
-    return DB_VILLAGE_ERROR;
+    return DB_VILLAGESQL_ERROR;
   }
   bool deleted = false;
   Custom_column::TrxRef trx_ref = 0;
@@ -926,7 +926,7 @@ dberr_t Custom_column::fetch(const dict_table_t *table, const dict_col_t *col,
     log_extended_error("Fetch", table, nullptr, col->ind);
 
     memset(dest, 0, dest_len);
-    return DB_VILLAGE_ERROR;
+    return DB_VILLAGESQL_ERROR;
   }
   memcpy(dest, col_data.data, col_data.length);
 
@@ -951,7 +951,7 @@ dberr_t Custom_column::allocate_fetch(const dict_table_t *table,
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Fetch: Failed to allocate " << new_len << " bytes";
     log_extended_error("Fetch", table, nullptr, col->ind);
-    return DB_VILLAGE_ERROR;
+    return DB_VILLAGESQL_ERROR;
   }
 
   // Copy the extended column data reference


### PR DESCRIPTION
- Disable online DML operation during DDL
- Disable index creation
- Introduce DB_VILLAGE_ERROR for consistent error reporting

## Description

<!-- What does this PR do? Briefly describe the change. -->

## Related Issue

<!-- Link the GitHub issue this PR addresses, e.g. Fixes #123 -->

## How was this tested?

<!-- Describe how you verified your changes. Include test commands you ran. -->

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
