### PR TITLE
ci: Nightly test of bundled extensions

### DIFF
--- a/.github/workflows/extension-compat.yml
+++ b/.github/workflows/extension-compat.yml
@@ -1,0 +1,289 @@
+name: Extension SDK Compatibility
+
+# Tests that bundled extensions build and pass their MTR suites against the
+# SDK at HEAD.  Runs automatically after a successful nightly build, and can
+# be triggered manually to test a single platform, extension, or ABI variant.
+#
+# Extension test convention: each extension repo must have a mysql-test/
+# directory at its root containing t/ and r/ subdirectories. This directory
+# is mounted as mysql-test/suite/<extension-name>/ in the dev server package.
+
+on:
+  workflow_run:
+    workflows: ["Nightly Build and Test"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: 'Single platform to test (linux-x86_64, linux-aarch64, macos-arm64), or leave empty for all'
+        required: false
+        default: ''
+      extension:
+        description: 'Single extension to test (e.g. vsql-ai), or leave empty for all'
+        required: false
+        default: ''
+      abi:
+        description: 'ABI variant to test (stable, dev), or leave empty for both'
+        required: false
+        default: ''
+      ref:
+        description: 'Branch, tag, or commit SHA to test, or leave empty for the default branch'
+        required: false
+        default: ''
+
+jobs:
+  # Reads bundled_extensions.txt and builds a cross-product matrix of
+  # (platform x extension x abi), filtered by any workflow_dispatch inputs.
+  prepare:
+    name: Prepare matrix
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    outputs:
+      matrix: ${{ steps.build-matrix.outputs.matrix }}
+      has-jobs: ${{ steps.build-matrix.outputs.has-jobs }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Build test matrix
+        id: build-matrix
+        env:
+          PLATFORM_FILTER: ${{ inputs.platform }}
+          EXTENSION_FILTER: ${{ inputs.extension }}
+          ABI_FILTER: ${{ inputs.abi }}
+        run: |
+          # Read entries from bundled_extensions.txt as {extension, url, branch} objects.
+          # Format per line: "url [branch-or-tag]" — branch is optional.
+          # "extension" is the last path segment of the url.
+          EXTS_JSON=$(grep -v '^[[:space:]]*#\|^[[:space:]]*$' \
+                        villagesql/dev_server/bundled_extensions.txt \
+                      | jq -R '
+                          split(" ") |
+                          {
+                            url:       (.[0] | rtrimstr("/")),
+                            branch:    (.[1] // ""),
+                            extension: (.[0] | rtrimstr("/") | split("/") | last)
+                          }' \
+                      | jq -sc .)
+
+          if [ -n "$EXTENSION_FILTER" ]; then
+            EXTS_JSON=$(echo "$EXTS_JSON" \
+              | jq --arg f "$EXTENSION_FILTER" '[.[] | select(.extension == $f)]')
+          fi
+
+          if [ "$(echo "$EXTS_JSON" | jq 'length')" -eq 0 ]; then
+            echo "has-jobs=false" >> "$GITHUB_OUTPUT"
+            echo 'matrix={"include":[]}' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          ALL_PLATFORMS='[
+            {"platform":"linux-x86_64","runner":["self-hosted","linux","x86_64"],"os":"linux"},
+            {"platform":"linux-aarch64","runner":"ubuntu-24.04-arm","os":"linux"},
+            {"platform":"macos-arm64","runner":"macos-latest","os":"macos"}
+          ]'
+
+          if [ -n "$PLATFORM_FILTER" ]; then
+            PLATFORMS=$(echo "$ALL_PLATFORMS" \
+              | jq --arg f "$PLATFORM_FILTER" '[.[] | select(.platform == $f)]')
+          else
+            PLATFORMS="$ALL_PLATFORMS"
+          fi
+
+          if [ -n "$ABI_FILTER" ]; then
+            ABIS="[\"$ABI_FILTER\"]"
+          else
+            ABIS='["stable","dev"]'
+          fi
+
+          # Cross-product: one matrix entry per (platform, extension, abi) triple
+          MATRIX=$(jq -n \
+            --argjson platforms "$PLATFORMS" \
+            --argjson extensions "$EXTS_JSON" \
+            --argjson abis "$ABIS" \
+            '{include: [$platforms[] as $p | $extensions[] as $e | $abis[] as $a | ($p + $e + {abi: $a})]}')
+
+          COUNT=$(echo "$MATRIX" | jq '.include | length')
+          echo "has-jobs=$([ "$COUNT" -gt 0 ] && echo true || echo false)" \
+            >> "$GITHUB_OUTPUT"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+  # Builds the server (for mysqld + MTR) and SDK (for extension compilation).
+  # One job per (platform, abi) pair; skips entries filtered out by prepare.
+  build-server:
+    name: Build Server (${{ matrix.platform }}, ${{ matrix.abi }} ABI)
+    needs: prepare
+    if: needs.prepare.outputs.has-jobs == 'true'
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: [self-hosted, linux, x86_64]
+            platform: linux-x86_64
+            os: linux
+            abi: stable
+          - runner: [self-hosted, linux, x86_64]
+            platform: linux-x86_64
+            os: linux
+            abi: dev
+          - runner: ubuntu-24.04-arm
+            platform: linux-aarch64
+            os: linux
+            abi: stable
+          - runner: ubuntu-24.04-arm
+            platform: linux-aarch64
+            os: linux
+            abi: dev
+          - runner: macos-latest
+            platform: macos-arm64
+            os: macos
+            abi: stable
+          - runner: macos-latest
+            platform: macos-arm64
+            os: macos
+            abi: dev
+
+    env:
+      BUILD_DIR: ${{ github.workspace }}/build
+      OUTPUT_DIR: ${{ github.workspace }}/output
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          path: source
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install dependencies (Linux)
+        if: matrix.os == 'linux'
+        run: sudo source/scripts/setup_linux_build_env.sh
+
+      - name: Install dependencies (macOS)
+        if: matrix.os == 'macos'
+        run: brew install bison cmake openssl
+
+      - name: Cache Boost
+        uses: actions/cache@v4
+        with:
+          path: /tmp/boost
+          key: boost-${{ runner.os }}-${{ runner.arch }}
+
+      - name: Build server and SDK
+        run: |
+          mkdir -p "$BUILD_DIR" "$OUTPUT_DIR"
+
+          EXTRA_FLAGS="-DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost"
+          if [ "${{ matrix.os }}" = "macos" ]; then
+            EXTRA_FLAGS="$EXTRA_FLAGS -DWITH_SSL=$(brew --prefix openssl)"
+          fi
+          if [ "${{ matrix.abi }}" = "dev" ]; then
+            EXTRA_FLAGS="$EXTRA_FLAGS -DVSQL_USE_DEV_ABI=ON"
+          fi
+
+          # Build without bundled extensions — each test-extension job builds
+          # its own extension against the SDK artifact from this job.
+          BUILD_DIR="$BUILD_DIR" \
+          OUTPUT_DIR="$OUTPUT_DIR" \
+          BUILD_BUNDLED_EXTENSIONS=0 \
+          CMAKE_EXTRA_FLAGS="$EXTRA_FLAGS" \
+            source/scripts/make_villagesql_dev_server.sh
+
+      - name: Upload dev server
+        uses: actions/upload-artifact@v4
+        with:
+          name: devserver-${{ matrix.platform }}-${{ matrix.abi }}
+          path: ${{ env.OUTPUT_DIR }}/*.tar.gz
+          retention-days: 3
+
+      - name: Upload SDK
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdk-${{ matrix.platform }}-${{ matrix.abi }}
+          path: ${{ env.BUILD_DIR }}/villagesql-extension-sdk-*.tar.gz
+          retention-days: 3
+
+  # Builds one extension and runs its MTR suite against the dev server.
+  # Matrix is the cross-product generated by prepare (platform x extension x abi).
+  test-extension:
+    name: Test ${{ matrix.extension }} (${{ matrix.platform }}, ${{ matrix.abi }} ABI)
+    needs: [prepare, build-server]
+    if: |
+      needs.prepare.outputs.has-jobs == 'true' &&
+      needs.build-server.result != 'failure' &&
+      needs.build-server.result != 'cancelled'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+
+    steps:
+      - name: Download dev server
+        uses: actions/download-artifact@v4
+        with:
+          name: devserver-${{ matrix.platform }}-${{ matrix.abi }}
+          path: artifacts/
+
+      - name: Download SDK
+        uses: actions/download-artifact@v4
+        with:
+          name: sdk-${{ matrix.platform }}-${{ matrix.abi }}
+          path: artifacts/
+
+      - name: Extract dev server and SDK
+        run: |
+          mkdir -p package sdk
+          tar xzf artifacts/villagesql-dev-server-*.tar.gz -C package
+          tar xzf artifacts/villagesql-extension-sdk-*.tar.gz -C sdk
+          echo "PACKAGE_DIR=$(echo "$PWD"/package/villagesql-dev-server-*)" >> "$GITHUB_ENV"
+          echo "SDK_DIR=$(echo "$PWD"/sdk/villagesql-extension-sdk-*)" >> "$GITHUB_ENV"
+
+      - name: Clone extension
+        run: |
+          CLONE_ARGS=(--depth=1)
+          [[ -n "${{ matrix.branch }}" ]] && CLONE_ARGS+=(--branch "${{ matrix.branch }}")
+          git clone "${CLONE_ARGS[@]}" ${{ matrix.url }} extension/
+
+      - name: Build extension VEB
+        run: |
+          NCORES=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo "4")
+          cmake -S extension/ -B ext-build/ \
+            -DCMAKE_PREFIX_PATH="$SDK_DIR" \
+            -DCMAKE_BUILD_TYPE=Release
+          cmake --build ext-build/ --parallel "$NCORES"
+
+          # Copy the built VEB into the dev server's extension directory
+          find ext-build/ -maxdepth 1 -name "*.veb" \
+            -exec cp {} "$PACKAGE_DIR/lib/veb/" \;
+
+      - name: Install extension test suite
+        run: |
+          if [ ! -d "extension/mysql-test" ]; then
+            echo "No mysql-test/ directory in ${{ matrix.extension }} — skipping suite install"
+            exit 0
+          fi
+          SUITE_DIR="$PACKAGE_DIR/mysql-test/suite/${{ matrix.extension }}"
+          mkdir -p "$SUITE_DIR"
+          cp -r extension/mysql-test/. "$SUITE_DIR/"
+
+      - name: Run MTR suite
+        run: |
+          if [ ! -d "extension/mysql-test" ]; then
+            echo "No test suite for ${{ matrix.extension }}, nothing to run."
+            exit 0
+          fi
+          cd "$PACKAGE_DIR"
+          ./mysql-test/mysql-test-run.pl \
+            --suite=${{ matrix.extension }} \
+            --parallel=auto \
+            --nounit-tests
+
+      - name: Upload MTR results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mtr-results-${{ matrix.extension }}-${{ matrix.platform }}-${{ matrix.abi }}
+          path: ${{ env.PACKAGE_DIR }}/mysql-test/var/log/

--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -1,0 +1,18 @@
+# Bundled extensions included in the dev server release tarball.
+# Also tested against the HEAD SDK in extension-compat.yml.
+#
+# Format: <url> [branch-or-tag]
+#   url:           Full URL or local filesystem path. git clone accepts both.
+#   branch-or-tag: Optional. Omit to clone the default branch.
+#
+# Examples:
+#   https://github.com/villagesql/vsql-ai
+#   https://github.com/villagesql/vsql-ai v1.2.0
+#   /Users/me/src/vsql-ai my-feature-branch
+#
+# Comments and blank lines are ignored.
+https://github.com/villagesql/vsql-ai main
+https://github.com/villagesql/vsql-crypto main
+https://github.com/villagesql/vsql-http main
+https://github.com/villagesql/vsql-network-address main
+https://github.com/villagesql/vsql-uuid main


### PR DESCRIPTION
The out-of tree bundled expressions are built for both the stable version, and the new dev release of the ABI.

The tests are run after the nightly tag, or can be manually triggered.

