### PR TITLE
Fix extension-compat matrix output format

### DIFF
--- a/.github/workflows/extension-compat.yml
+++ b/.github/workflows/extension-compat.yml
@@ -100,7 +100,7 @@ jobs:
           fi
 
           # Cross-product: one matrix entry per (platform, extension, abi) triple
-          MATRIX=$(jq -n \
+          MATRIX=$(jq -cn \
             --argjson platforms "$PLATFORMS" \
             --argjson extensions "$EXTS_JSON" \
             --argjson abis "$ABIS" \


### PR DESCRIPTION
## Description
Fix the Extension SDK Compatibility workflow's prepare step, which was writing a multiline JSON matrix to             
  $GITHUB_OUTPUT. GitHub Actions parses that file line-by-line as key=value pairs, so jq's default pretty-printed output
   (314 lines) broke on line 2 with Invalid format ' "include": ['. Adding -c to the jq invocation emits the matrix as a
   single compact line.    

## Related Issue
n/a

## How was this tested?
Verified locally by running the jq command with and without -c:                                                       
  - Without: 314-line pretty-printed output
  - With: single-line compact JSON                                                                                      
                                  
The first four workflow runs showed green because bundled_extensions.txt was empty, causing the prepare step to hit an
   early-exit path that already wrote a hardcoded single-line {"include":[]}. Once the file was populated, every run has
   failed in the prepare step. After merging, trigger manually via workflow_dispatch to confirm build and test jobs run 
  for the first time.                                                                                                   

AI=CLAUDE          

## Checklist
- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
