### PR TITLE
Contribution routing in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,20 @@ Open source software only succeeds with a strong community. We are excited you a
 
 As a general rule, any change that breaks compatibility with upstream MySQL will not be accepted. Similarly, any change that impacts the long-term maintainability of the VillageSQL fork will also be rejected. If you want to make changes that introduces non-compatible changes, please consider authoring an extension instead.
 
+## Where Does My Contribution Belong?
+
+**Building new functionality** (custom functions, custom types, integrations, exporters, etc.):
+Build a VEF extension in your own repository. Clone or fork
+[vsql-extension-template](https://github.com/villagesql/vsql-extension-template) to get started.
+See [Extensions or Plugins and Components](https://villagesql.com/docs/mysql-8.4/0.0.3/extensions-or-plugins)
+for guidance on when to use VEF versus MySQL's native plugin and component interfaces.
+
+**Improving VEF itself** (new hook types, SDK capabilities):
+Submit a PR to this repo. If a hook you need isn't supported yet, file an issue or upvote an existing one.
+
+**Server bug fixes and MySQL compatibility**:
+File an issue and follow the process below.
+
 To contribute to VillageSQL, please follow this process:
 
 1. File a Github [issue](./issues) for any improvement or feature request


### PR DESCRIPTION
## Description
Adds a "Where Does My Contribution Belong?" section to CONTRIBUTING.md that routes contributors away from submitting  
  new functionality (custom functions, types, integrations, exporters) directly to the server repo. The section directs
  them to build a VEF extension in their own repository using vsql-extension-template, and links to the new             
  https://villagesql.com/docs/mysql-8.4/0.0.3/extensions-or-plugins doc page for fuller guidance. It also clarifies that
   VEF framework improvements (new hook types, SDK capabilities) are welcome as PRs here.

AI=CLAUDE

## Related Issue
n/a

## How was this tested?
Documentation-only change to CONTRIBUTING.md. No code or tests modified.                                              

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
