### PR TITLE
vef: refactor registration for testing

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_vdf_aggregate_validation.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_vdf_aggregate_validation.result
@@ -1,18 +1,18 @@
 call mtr.add_suppression("Orphaned expansion directory found but not removed");
 call mtr.add_suppression("Failed to load VEF extension");
-call mtr.add_suppression("Aggregate VDF.*must provide both clear and accumulate");
+call mtr.add_suppression("must provide both clear and accumulate");
 # restart: --veb-dir=MYSQLTEST_VARDIR/veb
 Creating extension agg_accumulate_only using SDK...
 Created agg_accumulate_only.veb
 INSTALL EXTENSION agg_accumulate_only;
-ERROR HY000: Failed to register VDFs for extension 'agg_accumulate_only'
+ERROR HY000: Failed to install extension 'agg_accumulate_only': VDF 'bad_agg' must provide both clear and accumulate callbacks, or neither
 SELECT COUNT(*) FROM INFORMATION_SCHEMA.EXTENSIONS WHERE EXTENSION_NAME = 'agg_accumulate_only';
 COUNT(*)
 0
 Creating extension agg_clear_only using SDK...
 Created agg_clear_only.veb
 INSTALL EXTENSION agg_clear_only;
-ERROR HY000: Failed to register VDFs for extension 'agg_clear_only'
+ERROR HY000: Failed to install extension 'agg_clear_only': VDF 'bad_agg' must provide both clear and accumulate callbacks, or neither
 SELECT COUNT(*) FROM INFORMATION_SCHEMA.EXTENSIONS WHERE EXTENSION_NAME = 'agg_clear_only';
 COUNT(*)
 0

--- a/mysql-test/suite/villagesql/extension/r/type_method_name_validation.result
+++ b/mysql-test/suite/villagesql/extension/r/type_method_name_validation.result
@@ -1,13 +1,13 @@
 call mtr.add_suppression("Orphaned expansion directory found but not removed");
 call mtr.add_suppression("uses '::' but prefix");
 call mtr.add_suppression("is not a valid type method");
-call mtr.add_suppression("Failed to register types for extension");
+call mtr.add_suppression("Failed to install extension");
 # restart: --veb-dir=MYSQLTEST_VARDIR/veb
 # Test 1: bad prefix — WRONGTYPE::encode for type MYTYPE
 Creating extension bad_colon_prefix using SDK...
 Created bad_colon_prefix.veb
 INSTALL EXTENSION bad_colon_prefix;
-ERROR HY000: Failed to register types for extension 'bad_colon_prefix'
+ERROR HY000: Failed to install extension 'bad_colon_prefix': type 'MYTYPE' failed validation
 # Verify extension was NOT installed
 SELECT * FROM INFORMATION_SCHEMA.EXTENSIONS;
 EXTENSION_NAME	EXTENSION_VERSION
@@ -15,7 +15,7 @@ EXTENSION_NAME	EXTENSION_VERSION
 Creating extension bad_colon_suffix using SDK...
 Created bad_colon_suffix.veb
 INSTALL EXTENSION bad_colon_suffix;
-ERROR HY000: Failed to register types for extension 'bad_colon_suffix'
+ERROR HY000: Failed to install extension 'bad_colon_suffix': type 'MYTYPE' failed validation
 # Verify extension was NOT installed
 SELECT * FROM INFORMATION_SCHEMA.EXTENSIONS;
 EXTENSION_NAME	EXTENSION_VERSION

--- a/mysql-test/suite/villagesql/extension/t/extension_vdf_aggregate_validation.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_vdf_aggregate_validation.test
@@ -7,7 +7,7 @@
 
 call mtr.add_suppression("Orphaned expansion directory found but not removed");
 call mtr.add_suppression("Failed to load VEF extension");
-call mtr.add_suppression("Aggregate VDF.*must provide both clear and accumulate");
+call mtr.add_suppression("must provide both clear and accumulate");
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
 --let $restart_parameters = restart: --veb-dir=$veb_dir
 --source include/restart_mysqld.inc

--- a/mysql-test/suite/villagesql/extension/t/type_method_name_validation.test
+++ b/mysql-test/suite/villagesql/extension/t/type_method_name_validation.test
@@ -8,7 +8,7 @@
 call mtr.add_suppression("Orphaned expansion directory found but not removed");
 call mtr.add_suppression("uses '::' but prefix");
 call mtr.add_suppression("is not a valid type method");
-call mtr.add_suppression("Failed to register types for extension");
+call mtr.add_suppression("Failed to install extension");
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
 --let $restart_parameters = restart: --veb-dir=$veb_dir
 --source include/restart_mysqld.inc

--- a/unittest/gunit/villagesql/CMakeLists.txt
+++ b/unittest/gunit/villagesql/CMakeLists.txt
@@ -22,6 +22,7 @@ SET(VILLAGESQL_UNIT_TESTS
   semver-t
   type_context-t
   type_descriptor-t
+  validate-t
   victionary_client-t
 )
 
@@ -63,6 +64,7 @@ ADD_VILLAGESQL_TEST(abi_v2_check-t)
 ADD_VILLAGESQL_TEST(semver-t)
 ADD_VILLAGESQL_TEST(type_context-t)
 ADD_VILLAGESQL_TEST(type_descriptor-t)
+ADD_VILLAGESQL_TEST(validate-t)
 ADD_VILLAGESQL_TEST(victionary_client-t)
 
 # Custom target to build all VillageSQL unit tests

--- a/unittest/gunit/villagesql/validate-t.cc
+++ b/unittest/gunit/villagesql/validate-t.cc
@@ -1,0 +1,320 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Unit tests for validate_extension_registration().
+//
+// These tests exercise the pure validation path — no THD, no VictionaryClient,
+// no .so loading — by constructing vef_registration_t structs directly.
+
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <string>
+
+#include "unittest/gunit/test_utils.h"
+#include "villagesql/sdk/include/villagesql/abi/types.h"
+#include "villagesql/veb/validate.h"
+#include "villagesql/veb/veb_file.h"
+
+namespace villagesql_unittest {
+
+// Minimal stub function pointers — they are never called during validation,
+// only stored in the resulting descriptors.
+static bool stub_encode(unsigned char *, size_t, const char *, size_t,
+                        size_t *) {
+  return false;
+}
+static bool stub_decode(const unsigned char *, size_t, char *, size_t,
+                        size_t *) {
+  return false;
+}
+static int stub_compare(const unsigned char *, size_t, const unsigned char *,
+                        size_t) {
+  return 0;
+}
+static void stub_vdf(vef_context_t *, vef_vdf_args_t *, vef_vdf_result_t *) {}
+static void stub_clear(vef_context_t *, vef_vdf_args_t *) {}
+static void stub_accumulate(vef_context_t *, vef_vdf_args_t *,
+                            vef_vdf_result_t *) {}
+
+class ValidateExtensionRegistrationTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    villagesql::test_set_lower_case_table_names(0);
+    system_charset_info = &my_charset_utf8mb4_0900_ai_ci;
+  }
+
+  // Build an ExtensionRegistration wrapping a raw vef_registration_t.
+  // dlhandle and unregister_func are irrelevant for validation.
+  static villagesql::veb::ExtensionRegistration make_ext_reg(
+      vef_registration_t *reg, vef_protocol_t protocol) {
+    villagesql::veb::ExtensionRegistration ext_reg;
+    ext_reg.registration = reg;
+    ext_reg.negotiated_protocol = protocol;
+    ext_reg.dlhandle = nullptr;
+    ext_reg.unregister_func = nullptr;
+    return ext_reg;
+  }
+
+  // Minimal valid v1 type descriptor.
+  static vef_type_desc_t make_v1_type(const char *name,
+                                      int64_t max_decode_buffer_length = 256) {
+    vef_type_desc_t td = {};
+    td.protocol = VEF_PROTOCOL_1;
+    td.name = name;
+    td.persisted_length = 16;
+    td.max_decode_buffer_length = max_decode_buffer_length;
+    td.encode_func = stub_encode;
+    td.decode_func = stub_decode;
+    td.compare_func = stub_compare;
+    return td;
+  }
+
+  // Minimal valid scalar func descriptor.
+  static vef_func_desc_t make_scalar_func(const char *name,
+                                          vef_signature_t *sig) {
+    vef_func_desc_t fd = {};
+    fd.protocol = VEF_PROTOCOL_1;
+    fd.name = name;
+    fd.signature = sig;
+    fd.vdf = stub_vdf;
+    return fd;
+  }
+};
+
+// A valid registration with one type and one func produces the right
+// descriptor count and names.
+TEST_F(ValidateExtensionRegistrationTest, ValidV1TypeAndFunc) {
+  vef_type_desc_t td = make_v1_type("MYTYPE");
+  vef_type_desc_t *types[] = {&td};
+
+  vef_type_t ret = {VEF_TYPE_STRING, nullptr};
+  vef_signature_t sig = {0, nullptr, ret};
+  vef_func_desc_t fd = make_scalar_func("my_func", &sig);
+  vef_func_desc_t *funcs[] = {&fd};
+
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_1;
+  reg.extension_name = "my_ext";
+  reg.type_count = 1;
+  reg.types = types;
+  reg.func_count = 1;
+  reg.funcs = funcs;
+
+  std::string error;
+  auto result = villagesql::veb::validate_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_1), "my_ext", "1.0.0", error);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(error.empty());
+  ASSERT_EQ(result->types.size(), 1u);
+  ASSERT_EQ(result->funcs.size(), 1u);
+  EXPECT_EQ(result->types[0].type_name(), "MYTYPE");
+  EXPECT_EQ(result->types[0].extension_name(), "my_ext");
+  EXPECT_EQ(result->types[0].extension_version(), "1.0.0");
+  EXPECT_EQ(result->funcs[0].function_name(), "my_func");
+  EXPECT_EQ(result->funcs[0].extension_name(), "my_ext");
+}
+
+// A registration with no types or funcs produces an empty
+// ValidatedRegistration.
+TEST_F(ValidateExtensionRegistrationTest, EmptyRegistration) {
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_1;
+  reg.extension_name = "empty_ext";
+
+  std::string error;
+  auto result = villagesql::veb::validate_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_1), "empty_ext", "1.0.0", error);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->types.empty());
+  EXPECT_TRUE(result->funcs.empty());
+}
+
+// A null registration pointer (extension registered nothing) is allowed.
+TEST_F(ValidateExtensionRegistrationTest, NullRegistrationPointer) {
+  std::string error;
+  auto result = villagesql::veb::validate_extension_registration(
+      make_ext_reg(nullptr, VEF_PROTOCOL_1), "my_ext", "1.0.0", error);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result->types.empty());
+  EXPECT_TRUE(result->funcs.empty());
+}
+
+// A null pointer in the types array fails with a descriptive error.
+TEST_F(ValidateExtensionRegistrationTest, NullTypeDescriptor) {
+  vef_type_desc_t *types[] = {nullptr};
+
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_1;
+  reg.extension_name = "my_ext";
+  reg.type_count = 1;
+  reg.types = types;
+
+  std::string error;
+  auto result = villagesql::veb::validate_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_1), "my_ext", "1.0.0", error);
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_NE(error.find("NULL"), std::string::npos);
+}
+
+// A type with max_decode_buffer_length <= 0 fails with a descriptive error.
+TEST_F(ValidateExtensionRegistrationTest, ZeroMaxDecodeBufferLength) {
+  vef_type_desc_t td = make_v1_type("MYTYPE", 0);
+  vef_type_desc_t *types[] = {&td};
+
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_1;
+  reg.extension_name = "my_ext";
+  reg.type_count = 1;
+  reg.types = types;
+
+  std::string error;
+  auto result = villagesql::veb::validate_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_1), "my_ext", "1.0.0", error);
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_NE(error.find("max_decode_buffer_length"), std::string::npos);
+  EXPECT_NE(error.find("MYTYPE"), std::string::npos);
+}
+
+// A null pointer in the funcs array fails with a descriptive error.
+TEST_F(ValidateExtensionRegistrationTest, NullFuncDescriptor) {
+  vef_func_desc_t *funcs[] = {nullptr};
+
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_1;
+  reg.extension_name = "my_ext";
+  reg.func_count = 1;
+  reg.funcs = funcs;
+
+  std::string error;
+  auto result = villagesql::veb::validate_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_1), "my_ext", "1.0.0", error);
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_NE(error.find("NULL"), std::string::npos);
+}
+
+// Setting clear without accumulate (protocol 2) fails.
+TEST_F(ValidateExtensionRegistrationTest, ClearWithoutAccumulate) {
+  vef_type_t ret = {VEF_TYPE_INT, nullptr};
+  vef_signature_t sig = {0, nullptr, ret};
+  vef_func_desc_t fd = make_scalar_func("bad_agg", &sig);
+  fd.protocol = VEF_PROTOCOL_2;
+  fd.clear = stub_clear;
+  fd.accumulate = nullptr;
+  vef_func_desc_t *funcs[] = {&fd};
+
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_2;
+  reg.extension_name = "my_ext";
+  reg.func_count = 1;
+  reg.funcs = funcs;
+
+  std::string error;
+  auto result = villagesql::veb::validate_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_2), "my_ext", "1.0.0", error);
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_NE(error.find("bad_agg"), std::string::npos);
+  EXPECT_NE(error.find("clear"), std::string::npos);
+  EXPECT_NE(error.find("accumulate"), std::string::npos);
+}
+
+// Setting accumulate without clear (protocol 2) fails.
+TEST_F(ValidateExtensionRegistrationTest, AccumulateWithoutClear) {
+  vef_type_t ret = {VEF_TYPE_INT, nullptr};
+  vef_signature_t sig = {0, nullptr, ret};
+  vef_func_desc_t fd = make_scalar_func("bad_agg", &sig);
+  fd.protocol = VEF_PROTOCOL_2;
+  fd.clear = nullptr;
+  fd.accumulate = stub_accumulate;
+  vef_func_desc_t *funcs[] = {&fd};
+
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_2;
+  reg.extension_name = "my_ext";
+  reg.func_count = 1;
+  reg.funcs = funcs;
+
+  std::string error;
+  auto result = villagesql::veb::validate_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_2), "my_ext", "1.0.0", error);
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_NE(error.find("bad_agg"), std::string::npos);
+}
+
+// clear/accumulate asymmetry is not checked for protocol-1 extensions
+// (those fields weren't defined yet).
+TEST_F(ValidateExtensionRegistrationTest,
+       ClearWithoutAccumulateProtocol1Ignored) {
+  vef_type_t ret = {VEF_TYPE_INT, nullptr};
+  vef_signature_t sig = {0, nullptr, ret};
+  vef_func_desc_t fd = make_scalar_func("my_func", &sig);
+  fd.clear = stub_clear;
+  fd.accumulate = nullptr;
+  vef_func_desc_t *funcs[] = {&fd};
+
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_1;
+  reg.extension_name = "my_ext";
+  reg.func_count = 1;
+  reg.funcs = funcs;
+
+  std::string error;
+  auto result = villagesql::veb::validate_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_1), "my_ext", "1.0.0", error);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->funcs.size(), 1u);
+}
+
+// Multiple types and funcs are all validated and returned.
+TEST_F(ValidateExtensionRegistrationTest, MultipleTypesAndFuncs) {
+  vef_type_desc_t td1 = make_v1_type("TYPE_A");
+  vef_type_desc_t td2 = make_v1_type("TYPE_B");
+  vef_type_desc_t *types[] = {&td1, &td2};
+
+  vef_type_t ret = {VEF_TYPE_STRING, nullptr};
+  vef_signature_t sig = {0, nullptr, ret};
+  vef_func_desc_t fd1 = make_scalar_func("func_one", &sig);
+  vef_func_desc_t fd2 = make_scalar_func("func_two", &sig);
+  vef_func_desc_t fd3 = make_scalar_func("func_three", &sig);
+  vef_func_desc_t *funcs[] = {&fd1, &fd2, &fd3};
+
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_1;
+  reg.extension_name = "my_ext";
+  reg.type_count = 2;
+  reg.types = types;
+  reg.func_count = 3;
+  reg.funcs = funcs;
+
+  std::string error;
+  auto result = villagesql::veb::validate_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_1), "my_ext", "2.0.0", error);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result->types.size(), 2u);
+  EXPECT_EQ(result->funcs.size(), 3u);
+}
+
+}  // namespace villagesql_unittest

--- a/villagesql/veb/CMakeLists.txt
+++ b/villagesql/veb/CMakeLists.txt
@@ -14,7 +14,9 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 SET(VILLAGESQL_VEB_SOURCES
+  register.cc
   sql_extension.cc
+  validate.cc
   veb_file.cc
   veb_register_type_v1.cc
   veb_register_type_v2.cc

--- a/villagesql/veb/register.cc
+++ b/villagesql/veb/register.cc
@@ -1,0 +1,92 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "villagesql/veb/register.h"
+
+#include "sql/sql_class.h"
+#include "villagesql/include/error.h"
+#include "villagesql/schema/descriptor/func_descriptor.h"
+#include "villagesql/schema/descriptor/type_descriptor.h"
+#include "villagesql/schema/victionary_client.h"
+
+namespace villagesql {
+namespace veb {
+
+bool register_validated_extension(THD &thd, ValidatedRegistration validated,
+                                  std::string &error_out) {
+  auto &victionary = VictionaryClient::instance();
+  victionary.assert_write_lock_held();
+
+  for (auto &descriptor : validated.types) {
+    std::string type_name = descriptor.type_name();
+    std::string ext_name = descriptor.extension_name();
+
+    LogVSQL(INFORMATION_LEVEL, "Registering type '%s' from extension '%s'",
+            type_name.c_str(), ext_name.c_str());
+
+    const TypeDescriptor *existing =
+        victionary.type_descriptors().get_committed(descriptor.key());
+    if (existing) {
+      error_out = "type '" + type_name + "' already exists";
+      LogVSQL(ERROR_LEVEL, "Extension '%s': %s", ext_name.c_str(),
+              error_out.c_str());
+      return true;
+    }
+
+    if (victionary.type_descriptors().MarkForInsertion(thd,
+                                                       std::move(descriptor))) {
+      error_out = "failed to register type '" + type_name + "'";
+      LogVSQL(ERROR_LEVEL, "Extension '%s': %s", ext_name.c_str(),
+              error_out.c_str());
+      return true;
+    }
+
+    LogVSQL(INFORMATION_LEVEL, "Successfully registered type '%s'",
+            type_name.c_str());
+  }
+
+  for (auto &descriptor : validated.funcs) {
+    std::string func_name = descriptor.function_name();
+    std::string ext_name = descriptor.extension_name();
+
+    LogVSQL(INFORMATION_LEVEL, "Registering VDF '%s' from extension '%s'",
+            func_name.c_str(), ext_name.c_str());
+
+    const FuncDescriptor *existing =
+        victionary.funcs().get_committed(descriptor.key());
+    if (existing) {
+      error_out = "VDF '" + func_name + "' already exists";
+      LogVSQL(ERROR_LEVEL, "Extension '%s': %s", ext_name.c_str(),
+              error_out.c_str());
+      return true;
+    }
+
+    if (victionary.funcs().MarkForInsertion(thd, std::move(descriptor))) {
+      error_out = "failed to register VDF '" + func_name + "'";
+      LogVSQL(ERROR_LEVEL, "Extension '%s': %s", ext_name.c_str(),
+              error_out.c_str());
+      return true;
+    }
+
+    LogVSQL(INFORMATION_LEVEL, "Successfully registered VDF '%s'",
+            func_name.c_str());
+  }
+
+  return false;
+}
+
+}  // namespace veb
+}  // namespace villagesql

--- a/villagesql/veb/register.h
+++ b/villagesql/veb/register.h
@@ -1,0 +1,46 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Registers a ValidatedRegistration into the victionary.
+//
+// register_validated_extension() inserts pre-validated TypeDescriptors and
+// FuncDescriptors into the victionary.  The caller must hold the victionary
+// write lock and supply a ValidatedRegistration produced by
+// validate_extension_registration().
+
+#ifndef VILLAGESQL_VEB_REGISTER_H_
+#define VILLAGESQL_VEB_REGISTER_H_
+
+#include <string>
+
+#include "villagesql/veb/validate.h"
+
+class THD;
+
+namespace villagesql {
+namespace veb {
+
+// Registers the validated types and funcs into the victionary.
+// REQUIRES: Caller must hold victionary write lock.
+// Returns false on success, true on error; error_out is set to a descriptive
+// message.
+bool register_validated_extension(THD &thd, ValidatedRegistration validated,
+                                  std::string &error_out);
+
+}  // namespace veb
+}  // namespace villagesql
+
+#endif  // VILLAGESQL_VEB_REGISTER_H_

--- a/villagesql/veb/sql_extension.cc
+++ b/villagesql/veb/sql_extension.cc
@@ -53,6 +53,8 @@
 #include "villagesql/schema/victionary_client.h"
 #include "villagesql/services/sys_vars.h"
 #include "villagesql/sql/metadata_modifier.h"
+#include "villagesql/veb/register.h"
+#include "villagesql/veb/validate.h"
 #include "villagesql/veb/veb_file.h"
 
 // Global variables for VEB directory configuration
@@ -206,27 +208,31 @@ bool Sql_cmd_install_extension::execute(THD *thd) {
     return end_transaction(thd, true);
   }
 
+  std::string reg_error;
+  std::optional<villagesql::veb::ValidatedRegistration> validated =
+      villagesql::veb::validate_extension_registration(
+          registration, extension_name, version, reg_error);
+  if (!validated) {
+    villagesql_error("Failed to install extension '%s': %s", MYF(0),
+                     extension_name.c_str(), reg_error.c_str());
+    return end_transaction(thd, true);
+  }
+
   bool mark_success = true;
   {
     auto write_lock = victionary.get_write_lock();
 
-    if (villagesql::veb::register_types_from_extension(*thd, extension_name,
-                                                       version, registration)) {
-      villagesql_error("Failed to register types for extension '%s'", MYF(0),
-                       extension_name.c_str());
+    if (villagesql::veb::register_validated_extension(
+            *thd, std::move(*validated), reg_error)) {
+      villagesql_error("Failed to install extension '%s': %s", MYF(0),
+                       extension_name.c_str(), reg_error.c_str());
       // Rollback should be done after releasing the victionary lock.
-      mark_success = false;
-
-    } else if (villagesql::veb::register_funcs_from_extension(
-                   *thd, extension_name, version, registration)) {
-      villagesql_error("Failed to register VDFs for extension '%s'", MYF(0),
-                       extension_name.c_str());
       mark_success = false;
 
     } else if (villagesql::services::register_sys_vars_from_extension(
                    extension_name, registration)) {
-      villagesql_error("Failed to register system variables for extension '%s'", MYF(0),
-                       extension_name.c_str());
+      villagesql_error("Failed to register system variables for extension '%s'",
+                       MYF(0), extension_name.c_str());
       mark_success = false;
 
     } else if (victionary.extension_descriptors().MarkForInsertion(

--- a/villagesql/veb/validate.cc
+++ b/villagesql/veb/validate.cc
@@ -1,0 +1,137 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "villagesql/veb/validate.h"
+
+#include <optional>
+#include <string>
+
+#include "sql/field.h"
+#include "villagesql/include/error.h"
+#include "villagesql/schema/descriptor/func_descriptor.h"
+#include "villagesql/schema/descriptor/type_descriptor.h"
+#include "villagesql/sdk/include/villagesql/abi/types.h"
+#include "villagesql/veb/veb_file.h"
+#include "villagesql/veb/veb_register_type.h"
+
+namespace villagesql {
+namespace veb {
+
+static Item_result vef_type_to_item_result(const vef_type_t &type) {
+  switch (type.id) {
+    case VEF_TYPE_STRING:
+      return STRING_RESULT;
+    case VEF_TYPE_REAL:
+      return REAL_RESULT;
+    case VEF_TYPE_INT:
+      return INT_RESULT;
+    case VEF_TYPE_CUSTOM:
+      // Custom types are passed as binary strings
+      return STRING_RESULT;
+    default:
+      return STRING_RESULT;
+  }
+}
+
+std::optional<ValidatedRegistration> validate_extension_registration(
+    const ExtensionRegistration &ext_reg, const std::string &extension_name,
+    const std::string &extension_version, std::string &error_out) {
+  ValidatedRegistration result;
+  const vef_registration_t *reg = ext_reg.registration;
+
+  if (reg != nullptr && reg->type_count > 0) {
+    LogVSQL(INFORMATION_LEVEL,
+            "Validating %d types from extension '%s' version '%s'",
+            reg->type_count, extension_name.c_str(), extension_version.c_str());
+
+    for (unsigned int i = 0; i < reg->type_count; i++) {
+      const vef_type_desc_t *td = reg->types[i];
+      if (td == nullptr || td->name == nullptr) {
+        error_out = "NULL type descriptor at index " + std::to_string(i);
+        LogVSQL(ERROR_LEVEL, "Extension '%s': %s", extension_name.c_str(),
+                error_out.c_str());
+        return std::nullopt;
+      }
+
+      std::string type_name(td->name);
+
+      if (td->max_decode_buffer_length <= 0) {
+        error_out =
+            "type '" + type_name + "' must set max_decode_buffer_length";
+        LogVSQL(ERROR_LEVEL, "Extension '%s': %s", extension_name.c_str(),
+                error_out.c_str());
+        return std::nullopt;
+      }
+
+      bool is_v2 = td->protocol >= VEF_PROTOCOL_2 &&
+                   ext_reg.negotiated_protocol >= VEF_PROTOCOL_2;
+      std::optional<TypeDescriptor> maybe_descriptor =
+          is_v2 ? build_type_descriptor_v2(td, *reg, type_name, extension_name,
+                                           extension_version)
+                : build_type_descriptor_v1(td, type_name, extension_name,
+                                           extension_version);
+      if (!maybe_descriptor.has_value()) {
+        error_out = "type '" + type_name + "' failed validation";
+        return std::nullopt;
+      }
+      result.types.push_back(std::move(*maybe_descriptor));
+    }
+  }
+
+  if (reg != nullptr && reg->func_count > 0) {
+    LogVSQL(INFORMATION_LEVEL, "Validating %d VDFs from extension '%s'",
+            reg->func_count, extension_name.c_str());
+
+    for (unsigned int i = 0; i < reg->func_count; i++) {
+      const vef_func_desc_t *func_desc = reg->funcs[i];
+      if (func_desc == nullptr || func_desc->name == nullptr) {
+        error_out = "NULL VDF descriptor at index " + std::to_string(i);
+        LogVSQL(ERROR_LEVEL, "Extension '%s': %s", extension_name.c_str(),
+                error_out.c_str());
+        return std::nullopt;
+      }
+
+      std::string func_name(func_desc->name);
+
+      // clear/accumulate fields were added in PROTOCOL_2; older extensions
+      // don't initialize them so we must not read them.
+      if (ext_reg.negotiated_protocol >= VEF_PROTOCOL_2) {
+        bool has_clear = (func_desc->clear != nullptr);
+        bool has_accumulate = (func_desc->accumulate != nullptr);
+        if (has_clear != has_accumulate) {
+          error_out = "VDF '" + func_name +
+                      "' must provide both clear and accumulate callbacks, or "
+                      "neither";
+          LogVSQL(ERROR_LEVEL, "Extension '%s': %s", extension_name.c_str(),
+                  error_out.c_str());
+          return std::nullopt;
+        }
+      }
+
+      Item_result return_type =
+          vef_type_to_item_result(func_desc->signature->return_type);
+      FuncKey key(func_name, extension_name);
+      result.funcs.push_back(FuncDescriptor(key, extension_version, func_desc,
+                                            ext_reg.negotiated_protocol,
+                                            return_type));
+    }
+  }
+
+  return result;
+}
+
+}  // namespace veb
+}  // namespace villagesql

--- a/villagesql/veb/validate.h
+++ b/villagesql/veb/validate.h
@@ -1,0 +1,55 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Validates a raw VEF ExtensionRegistration (ABI structs from a loaded .so)
+// into a ValidatedRegistration containing typed C++ descriptors.
+//
+// validate_extension_registration() has no side effects and no dependency on
+// the victionary or THD, making it independently testable.
+
+#ifndef VILLAGESQL_VEB_VALIDATE_H_
+#define VILLAGESQL_VEB_VALIDATE_H_
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "villagesql/schema/descriptor/func_descriptor.h"
+#include "villagesql/schema/descriptor/type_descriptor.h"
+
+namespace villagesql {
+namespace veb {
+
+struct ExtensionRegistration;
+
+// The result of validating a raw ExtensionRegistration.
+// Contains validated, ready-to-register C++ descriptors for types and funcs.
+struct ValidatedRegistration {
+  std::vector<TypeDescriptor> types;
+  std::vector<FuncDescriptor> funcs;
+};
+
+// Validates the raw ABI registration and builds C++ descriptors.
+// No THD, no VictionaryClient — purely operates on the ExtensionRegistration.
+// Returns nullopt on error; error_out is set to a descriptive message.
+std::optional<ValidatedRegistration> validate_extension_registration(
+    const ExtensionRegistration &ext_reg, const std::string &extension_name,
+    const std::string &extension_version, std::string &error_out);
+
+}  // namespace veb
+}  // namespace villagesql
+
+#endif  // VILLAGESQL_VEB_VALIDATE_H_

--- a/villagesql/veb/veb_file.cc
+++ b/villagesql/veb/veb_file.cc
@@ -32,7 +32,6 @@
 #include "scope_guard.h"
 #include "sha2.h"
 #include "sql/auth/auth_common.h"
-#include "sql/field.h"
 #include "sql/iterators/row_iterator.h"
 #include "sql/mysqld.h"
 #include "sql/sql_base.h"
@@ -43,13 +42,12 @@
 #include "sql_string.h"
 #include "villagesql/include/error.h"
 #include "villagesql/include/version.h"
-#include "villagesql/schema/descriptor/func_descriptor.h"
-#include "villagesql/schema/descriptor/type_descriptor.h"
 #include "villagesql/schema/victionary_client.h"
 #include "villagesql/services/keyring.h"
 #include "villagesql/services/sys_vars.h"
+#include "villagesql/veb/register.h"
 #include "villagesql/veb/sql_extension.h"
-#include "villagesql/veb/veb_register_type.h"
+#include "villagesql/veb/validate.h"
 
 #include <archive.h>
 #include <archive_entry.h>
@@ -672,17 +670,20 @@ bool load_installed_extensions(THD *thd) {
         return true;
       }
 
-      if (register_types_from_extension(*thd, extension_name, expected_version,
-                                        registration)) {
-        LogVSQL(ERROR_LEVEL, "Failed to register types for extension '%s'",
-                extension_name.c_str());
+      std::string reg_error;
+      std::optional<ValidatedRegistration> validated =
+          validate_extension_registration(registration, extension_name,
+                                          expected_version, reg_error);
+      if (!validated) {
+        LogVSQL(ERROR_LEVEL, "Failed to validate extension '%s': %s",
+                extension_name.c_str(), reg_error.c_str());
         return true;
       }
 
-      if (register_funcs_from_extension(*thd, extension_name, expected_version,
-                                        registration)) {
-        LogVSQL(ERROR_LEVEL, "Failed to register VDFs for extension '%s'",
-                extension_name.c_str());
+      if (register_validated_extension(*thd, std::move(*validated),
+                                       reg_error)) {
+        LogVSQL(ERROR_LEVEL, "Failed to register extension '%s': %s",
+                extension_name.c_str(), reg_error.c_str());
         return true;
       }
 
@@ -789,172 +790,6 @@ void cleanup_orphaned_expansion_directories(
   } else {
     LogVSQL(INFORMATION_LEVEL, "No orphaned expansion directories found");
   }
-}
-
-bool register_types_from_extension(THD &thd, const std::string &extension_name,
-                                   const std::string &extension_version,
-                                   const ExtensionRegistration &ext_reg) {
-  auto &victionary = VictionaryClient::instance();
-  victionary.assert_write_lock_held();
-
-  if (ext_reg.registration == nullptr ||
-      ext_reg.registration->type_count == 0) {
-    LogVSQL(INFORMATION_LEVEL, "No types to register for extension '%s'",
-            extension_name.c_str());
-    return false;
-  }
-
-  const vef_registration_t &reg = *ext_reg.registration;
-
-  LogVSQL(INFORMATION_LEVEL,
-          "Registering %d types from extension '%s' version '%s'",
-          reg.type_count, extension_name.c_str(), extension_version.c_str());
-
-  for (unsigned int i = 0; i < reg.type_count; i++) {
-    const vef_type_desc_t *td = reg.types[i];
-    if (td == nullptr || td->name == nullptr) {
-      LogVSQL(ERROR_LEVEL,
-              "Extension '%s' has NULL type descriptor at index %u",
-              extension_name.c_str(), i);
-      return true;
-    }
-
-    std::string type_name(td->name);
-
-    if (td->max_decode_buffer_length <= 0) {
-      LogVSQL(ERROR_LEVEL,
-              "Type '%s' in extension '%s' must set max_decode_buffer_length",
-              type_name.c_str(), extension_name.c_str());
-      return true;
-    }
-
-    LogVSQL(INFORMATION_LEVEL, "Registering type '%s' from extension '%s'",
-            type_name.c_str(), extension_name.c_str());
-
-    // Dispatch to protocol-specific builder.
-    bool is_v2 = td->protocol >= VEF_PROTOCOL_2 &&
-                 ext_reg.negotiated_protocol >= VEF_PROTOCOL_2;
-    std::optional<TypeDescriptor> maybe_descriptor =
-        is_v2 ? build_type_descriptor_v2(td, reg, type_name, extension_name,
-                                         extension_version)
-              : build_type_descriptor_v1(td, type_name, extension_name,
-                                         extension_version);
-    if (!maybe_descriptor.has_value()) return true;
-    TypeDescriptor descriptor = std::move(*maybe_descriptor);
-
-    const TypeDescriptor *existing =
-        victionary.type_descriptors().get_committed(descriptor.key());
-    if (existing) {
-      LogVSQL(ERROR_LEVEL, "Type '%s' from extension '%s' already exists",
-              type_name.c_str(), extension_name.c_str());
-      return true;
-    }
-
-    if (victionary.type_descriptors().MarkForInsertion(thd,
-                                                       std::move(descriptor))) {
-      LogVSQL(ERROR_LEVEL, "Failed to mark type descriptor '%s' for insertion",
-              type_name.c_str());
-      return true;
-    }
-
-    LogVSQL(INFORMATION_LEVEL, "Successfully registered type '%s'",
-            type_name.c_str());
-  }
-
-  return false;
-}
-
-// Convert VEF type to MySQL Item_result
-static Item_result vef_type_to_item_result(const vef_type_t &type) {
-  switch (type.id) {
-    case VEF_TYPE_STRING:
-      return STRING_RESULT;
-    case VEF_TYPE_REAL:
-      return REAL_RESULT;
-    case VEF_TYPE_INT:
-      return INT_RESULT;
-    case VEF_TYPE_CUSTOM:
-      // Custom types are passed as binary strings
-      return STRING_RESULT;
-    default:
-      return STRING_RESULT;
-  }
-}
-
-bool register_funcs_from_extension(THD &thd, const std::string &extension_name,
-                                   const std::string &extension_version,
-                                   const ExtensionRegistration &ext_reg) {
-  auto &victionary = VictionaryClient::instance();
-  victionary.assert_write_lock_held();
-
-  if (ext_reg.registration == nullptr ||
-      ext_reg.registration->func_count == 0) {
-    LogVSQL(INFORMATION_LEVEL, "No VDFs to register for extension '%s'",
-            extension_name.c_str());
-    return false;
-  }
-
-  const vef_registration_t &reg = *ext_reg.registration;
-
-  LogVSQL(INFORMATION_LEVEL, "Registering %d VDFs from extension '%s'",
-          reg.func_count, extension_name.c_str());
-
-  for (unsigned int i = 0; i < reg.func_count; i++) {
-    const vef_func_desc_t *func_desc = reg.funcs[i];
-    if (func_desc == nullptr || func_desc->name == nullptr) {
-      LogVSQL(ERROR_LEVEL,
-              "Extension '%s' has NULL func descriptor at index %u",
-              extension_name.c_str(), i);
-      return true;
-    }
-
-    std::string func_name(func_desc->name);
-
-    // clear/accumulate fields were added in PROTOCOL_2; older extensions
-    // don't initialize them so we must not read them.
-    if (ext_reg.negotiated_protocol >= VEF_PROTOCOL_2) {
-      bool has_clear = (func_desc->clear != nullptr);
-      bool has_accumulate = (func_desc->accumulate != nullptr);
-      if (has_clear != has_accumulate) {
-        LogVSQL(ERROR_LEVEL,
-                "Aggregate VDF '%s' in extension '%s' must provide both clear "
-                "and accumulate callbacks, or neither",
-                func_name.c_str(), extension_name.c_str());
-        return true;
-      }
-    }
-
-    LogVSQL(INFORMATION_LEVEL, "Registering VDF '%s' from extension '%s'",
-            func_desc->name, extension_name.c_str());
-
-    FuncKey key(func_name, extension_name);
-
-    // Check if VDF already exists
-    const FuncDescriptor *existing = victionary.funcs().get_committed(key);
-    if (existing) {
-      LogVSQL(ERROR_LEVEL, "VDF '%s' from extension '%s' already exists",
-              func_name.c_str(), extension_name.c_str());
-      return true;
-    }
-
-    // Convert return type from VEF signature
-    Item_result return_type =
-        vef_type_to_item_result(func_desc->signature->return_type);
-
-    FuncDescriptor descriptor(key, extension_version, func_desc,
-                              ext_reg.negotiated_protocol, return_type);
-
-    if (victionary.funcs().MarkForInsertion(thd, std::move(descriptor))) {
-      LogVSQL(ERROR_LEVEL, "Failed to mark VDF '%s' for insertion",
-              func_name.c_str());
-      return true;
-    }
-
-    LogVSQL(INFORMATION_LEVEL, "Successfully registered VDF '%s'",
-            func_desc->name);
-  }
-
-  return false;
 }
 
 static std::string format_dlerror() {

--- a/villagesql/veb/veb_file.h
+++ b/villagesql/veb/veb_file.h
@@ -97,22 +97,6 @@ struct ExtensionRegistration {
   vef_unregister_func_t unregister_func;
 };
 
-// Register type descriptors from an extension. This creates
-// TypeDescriptors in the victionary for each type defined by the
-// extension.
-// REQUIRES: Caller must hold victionary write lock.
-// Returns false on success, true on error.
-bool register_types_from_extension(THD &thd, const std::string &extension_name,
-                                   const std::string &extension_version,
-                                   const ExtensionRegistration &ext_reg);
-
-// Register VDFs (VillageSQL Defined Functions) from an extension.
-// REQUIRES: Caller must hold victionary write lock.
-// Returns false on success, true on error.
-bool register_funcs_from_extension(THD &thd, const std::string &extension_name,
-                                   const std::string &extension_version,
-                                   const ExtensionRegistration &ext_reg);
-
 // Load a VEF extension from a .so file and get the registration.
 //
 // The caller is responsible for calling unload_vef_extension() when done.


### PR DESCRIPTION
Extract the ABI validation and descriptor-building logic from `register_types_from_extension` / `register_funcs_from_extension` into a new `validate_extension_registration()` function (veb/validate.cc) that operates purely on the raw `ExtensionRegistration` — no THD, no victionary. The victionary insertion step moves to register_validated_extension() (veb/register.cc). Both old functions are deleted.

This separation makes the validation logic independently testable, and in the INSTALL EXTENSION path allows validation to happen before the victionary write lock is acquired. Error messages are improved throughout: failures now carry the specific type or VDF name that caused them all the way to the client error.

Adds a unit test (validate-t.cc) covering valid registrations, null descriptors, zero max_decode_buffer_length, and clear/accumulate asymmetry.
