### PR TITLE
sdk: fix column_storage

### DIFF
--- a/villagesql/sdk/include/villagesql/vsql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/type_builder.h
@@ -384,6 +384,12 @@ class TypeBuilder {
     return *this;
   }
 
+  constexpr TypeBuilder &column_storage(const vef_type_storage_intf_t &intf) {
+    state_.desc.storage_intf = intf;
+    state_.desc.vef_desc.storage_intf = &state_.desc.storage_intf;
+    return *this;
+  }
+
   // -------------------------------------------------------------------------
   // build() — finalize to TypeObject<EFT>
   // -------------------------------------------------------------------------


### PR DESCRIPTION
Sorry, this was dropped during the refactor.  I will add a test for storage interface, so we catch this sooner.

Also - we should add the vector plugin to the tested extensions; curtrently in villagesql/dev_server/bundled_extensions.tx