### PR TITLE
sdk: add constexpr-safe column_storage

### DIFF
--- a/villagesql/sdk/include/villagesql/vsql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/type_builder.h
@@ -384,9 +384,17 @@ class TypeBuilder {
     return *this;
   }
 
-  constexpr TypeBuilder &column_storage(const vef_type_storage_intf_t &intf) {
-    state_.desc.storage_intf = intf;
-    state_.desc.vef_desc.storage_intf = &state_.desc.storage_intf;
+  // Constexpr-safe overload for use with a storage interface that has a fixed
+  // address (i.e., declared static constexpr at namespace scope). The address
+  // is supplied as a template argument so it is known at compile time, allowing
+  // vef_desc.storage_intf to be set directly without embedding a copy of the
+  // interface inside the TypeDescriptor. This keeps storage_intf.version == 0,
+  // so TypeDescriptor's copy constructor skips the self-referential assignment
+  // `vef_desc.storage_intf = &storage_intf` that GCC rejects in constexpr
+  // context.
+  template <const vef_type_storage_intf_t *Intf>
+  constexpr TypeBuilder &column_storage() {
+    state_.desc.vef_desc.storage_intf = Intf;
     return *this;
   }
 


### PR DESCRIPTION
The previous construct failed on some GCC compilers, because in a constexpr context it took the address of itself during construction.


