### PR TITLE
dev_server: fix errant error return code

### DIFF
--- a/scripts/make_villagesql_dev_server.sh
+++ b/scripts/make_villagesql_dev_server.sh
@@ -22,6 +22,7 @@ cleanup() {
         rm -rf "$STAGING_DIR"
     fi
     [[ -n "$_EXT_CLONES_DIR" ]] && rm -rf "$_EXT_CLONES_DIR"
+    return 0
 }
 
 trap cleanup EXIT


### PR DESCRIPTION
The cleanup function was ending with an expected error when $_EXT_CLONES_DIR is empty.

