### PR TITLE
sdk: prerun+varargs

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_simple_type_usage.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_simple_type_usage.result
@@ -68,6 +68,45 @@ FROM test_bytearray t1, test_bytearray t2
 WHERE t1.id = 1 AND t2.id = 2;
 concatenated
 'hello   world123'
+# Test ba_len function (zero-arity)
+SELECT vsql_simple.ba_len() as len;
+len
+8
+# Test ba_len rejects arguments
+SELECT vsql_simple.ba_len(1);
+ERROR HY000: Cannot initialize function 'ba_len': wrong number of arguments (expected 0, got 1)
+# Test ba_concat rejects wrong argument count
+SELECT vsql_simple.ba_concat(t1.data) FROM test_bytearray t1 WHERE t1.id = 1;
+ERROR HY000: Cannot initialize function 'ba_concat': wrong number of arguments (expected 2, got 1)
+# Test ba_concat_all function (varargs, uses prerun escape hatch)
+# Single argument
+SELECT CONCAT("'", vsql_simple.ba_concat_all(t1.data), "'") as result
+FROM test_bytearray t1 WHERE t1.id = 1;
+result
+'hello   '
+# Two arguments (same as ba_concat)
+SELECT CONCAT("'", vsql_simple.ba_concat_all(t1.data, t2.data), "'") as result
+FROM test_bytearray t1, test_bytearray t2
+WHERE t1.id = 1 AND t2.id = 2;
+result
+'hello   world123'
+# Three arguments
+SELECT CONCAT("'", vsql_simple.ba_concat_all(t1.data, t2.data, t3.data), "'") as result
+FROM test_bytearray t1, test_bytearray t2, test_bytearray t3
+WHERE t1.id = 1 AND t2.id = 2 AND t3.id = 3;
+result
+'hello   world123abcdefgh'
+# NULL handling: any NULL argument returns NULL
+SELECT vsql_simple.ba_concat_all(t1.data, NULL) as result
+FROM test_bytearray t1 WHERE t1.id = 1;
+result
+NULL
+# ba_concat_all rejects zero arguments
+SELECT vsql_simple.ba_concat_all();
+ERROR HY000: Can't initialize function 'ba_concat_all'; ba_concat_all requires at least one argument
+# ba_concat_all rejects non-BYTEARRAY arguments (INT)
+SELECT vsql_simple.ba_concat_all(1, 2);
+ERROR HY000: Can't initialize function 'ba_concat_all'; ba_concat_all: argument 0 must be BYTEARRAY
 # Clean up
 DROP TABLE test_bytearray;
 # Uninstall the extension

--- a/mysql-test/suite/villagesql/extension/t/extension_simple_type_usage.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_simple_type_usage.test
@@ -44,6 +44,44 @@ SELECT CONCAT("'", vsql_simple.ba_concat(t1.data, t2.data), "'") as concatenated
 FROM test_bytearray t1, test_bytearray t2
 WHERE t1.id = 1 AND t2.id = 2;
 
+--echo # Test ba_len function (zero-arity)
+SELECT vsql_simple.ba_len() as len;
+
+--echo # Test ba_len rejects arguments
+--error ER_VILLAGESQL_GENERIC_ERROR
+SELECT vsql_simple.ba_len(1);
+
+--echo # Test ba_concat rejects wrong argument count
+--error ER_VILLAGESQL_GENERIC_ERROR
+SELECT vsql_simple.ba_concat(t1.data) FROM test_bytearray t1 WHERE t1.id = 1;
+
+--echo # Test ba_concat_all function (varargs, uses prerun escape hatch)
+--echo # Single argument
+SELECT CONCAT("'", vsql_simple.ba_concat_all(t1.data), "'") as result
+FROM test_bytearray t1 WHERE t1.id = 1;
+
+--echo # Two arguments (same as ba_concat)
+SELECT CONCAT("'", vsql_simple.ba_concat_all(t1.data, t2.data), "'") as result
+FROM test_bytearray t1, test_bytearray t2
+WHERE t1.id = 1 AND t2.id = 2;
+
+--echo # Three arguments
+SELECT CONCAT("'", vsql_simple.ba_concat_all(t1.data, t2.data, t3.data), "'") as result
+FROM test_bytearray t1, test_bytearray t2, test_bytearray t3
+WHERE t1.id = 1 AND t2.id = 2 AND t3.id = 3;
+
+--echo # NULL handling: any NULL argument returns NULL
+SELECT vsql_simple.ba_concat_all(t1.data, NULL) as result
+FROM test_bytearray t1 WHERE t1.id = 1;
+
+--echo # ba_concat_all rejects zero arguments
+--error ER_CANT_INITIALIZE_UDF
+SELECT vsql_simple.ba_concat_all();
+
+--echo # ba_concat_all rejects non-BYTEARRAY arguments (INT)
+--error ER_CANT_INITIALIZE_UDF
+SELECT vsql_simple.ba_concat_all(1, 2);
+
 --echo # Clean up
 DROP TABLE test_bytearray;
 

--- a/scripts/villint.sh
+++ b/scripts/villint.sh
@@ -433,8 +433,12 @@ if [ -z "$COMMIT_ISH" ]; then
   if is_jj_workspace; then
     # In jj workspace, use git.push config or default to "origin"
     # User can set: jj config set git.push "github"
+    # We diff against the fork point with main@<remote>, not the tip — so when
+    # upstream main is ahead of our branch's base, upstream commits do not
+    # appear as "reverse-modified" files in our changed-file set (which would
+    # otherwise cause villint to lint unrelated upstream-only files).
     VILLINT_REMOTE=$(jj config get git.push 2>/dev/null || echo "origin")
-    COMMIT_ISH="main@$VILLINT_REMOTE"
+    COMMIT_ISH="fork_point(@ | main@$VILLINT_REMOTE)"
     echo "Using jj workspace, comparing against: $COMMIT_ISH"
   else
     # Default: compare against merge-base with origin/main

--- a/villagesql/examples/vsql-simple/src/extension.cc
+++ b/villagesql/examples/vsql-simple/src/extension.cc
@@ -126,6 +126,57 @@ void ba_concat(CustomArg a, CustomArg b, StringResult out) {
   out.set_length(kBytearrayLen * 2);
 }
 
+// BA_LEN: return the fixed length of a BYTEARRAY (zero-arity constant function)
+void ba_len(IntResult out) { out.set(static_cast<long long>(kBytearrayLen)); }
+
+// BA_CONCAT_ALL: concatenate any number of bytearrays (returns STRING).
+//
+// This demonstrates the "Escape Hatch" pattern: ba_concat above uses the
+// typed Happy Path API (CustomArg, StringResult), but only supports exactly
+// two arguments. ba_concat_all drops down to the raw ABI to accept varargs,
+// using prerun to validate argument types and size the result buffer.
+
+// Prerun: validate that all arguments are BYTEARRAY and request a buffer
+// large enough to hold them all concatenated.
+void ba_concat_all_prerun(vef_context_t *, vef_prerun_args_t *args,
+                          vef_prerun_result_t *result) {
+  if (args->arg_count == 0) {
+    result->type = VEF_RESULT_ERROR;
+    snprintf(result->error_msg, VEF_MAX_ERROR_LEN,
+             "ba_concat_all requires at least one argument");
+    return;
+  }
+  for (unsigned int i = 0; i < args->arg_count; i++) {
+    // NULL literals appear as VEF_TYPE_STRING in prerun; skip type check for
+    // those and handle them at runtime.
+    vef_type_id id = args->arg_types[i].id;
+    if (id != VEF_TYPE_CUSTOM && id != VEF_TYPE_STRING) {
+      result->type = VEF_RESULT_ERROR;
+      snprintf(result->error_msg, VEF_MAX_ERROR_LEN,
+               "ba_concat_all: argument %u must be BYTEARRAY", i);
+      return;
+    }
+  }
+  result->result_buffer_size = args->arg_count * kBytearrayLen;
+}
+
+// Main function: raw ABI signature since we iterate over a variable number
+// of arguments.
+void ba_concat_all(vef_context_t *ctx, vef_vdf_args_t *args,
+                   vef_vdf_result_t *result) {
+  size_t total_len = args->value_count * kBytearrayLen;
+  for (unsigned int i = 0; i < args->value_count; i++) {
+    vef_invalue_t val = vsql::func_builder::get_invalue(ctx, args, i);
+    if (val.is_null) {
+      result->type = VEF_RESULT_NULL;
+      return;
+    }
+    memcpy(result->str_buf + i * kBytearrayLen, val.bin_value, kBytearrayLen);
+  }
+  result->type = VEF_RESULT_VALUE;
+  result->actual_len = total_len;
+}
+
 static constexpr const char kBytearrayTypeName[] = "bytearray";
 
 constexpr auto BYTEARRAY = vsql::make_type<kBytearrayTypeName>()
@@ -136,22 +187,29 @@ constexpr auto BYTEARRAY = vsql::make_type<kBytearrayTypeName>()
                                .compare<&bytearray_compare>()
                                .build();
 
-VEF_GENERATE_ENTRY_POINTS(make_extension()
-                              .type(BYTEARRAY)
-                              .func(make_func<&rot13>("rot13")
-                                        .returns(BYTEARRAY)
-                                        .param(BYTEARRAY)
-                                        .build())
-                              .func(make_func<&even_chars>("even_chars")
-                                        .returns(BYTEARRAY)
-                                        .param(BYTEARRAY)
-                                        .build())
-                              .func(make_func<&odd_chars>("odd_chars")
-                                        .returns(BYTEARRAY)
-                                        .param(BYTEARRAY)
-                                        .build())
-                              .func(make_func<&ba_concat>("ba_concat")
-                                        .returns(STRING)
-                                        .param(BYTEARRAY)
-                                        .param(BYTEARRAY)
-                                        .build()))
+VEF_GENERATE_ENTRY_POINTS(
+    make_extension()
+        .type(BYTEARRAY)
+        .func(make_func<&rot13>("rot13")
+                  .returns(BYTEARRAY)
+                  .param(BYTEARRAY)
+                  .build())
+        .func(make_func<&even_chars>("even_chars")
+                  .returns(BYTEARRAY)
+                  .param(BYTEARRAY)
+                  .build())
+        .func(make_func<&odd_chars>("odd_chars")
+                  .returns(BYTEARRAY)
+                  .param(BYTEARRAY)
+                  .build())
+        .func(make_func<&ba_concat>("ba_concat")
+                  .returns(STRING)
+                  .param(BYTEARRAY)
+                  .param(BYTEARRAY)
+                  .build())
+        .func(make_func<&ba_len>("ba_len").returns(INT).param().build())
+        .func(make_func<&ba_concat_all>("ba_concat_all")
+                  .returns(STRING)
+                  .varargs()
+                  .prerun<&ba_concat_all_prerun>()
+                  .build()))

--- a/villagesql/sdk/include/villagesql/abi/types.h
+++ b/villagesql/sdk/include/villagesql/abi/types.h
@@ -17,6 +17,7 @@
 #ifndef VILLAGESQL_ABI_TYPES_H_
 #define VILLAGESQL_ABI_TYPES_H_
 
+#include <limits.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -498,6 +499,11 @@ typedef struct {
   // defined in this extension.
   const char *custom_type;
 } vef_type_t;
+
+// Sentinel value for vef_signature_t::param_count indicating that the function
+// accepts a variable number of arguments. When set, the framework skips
+// argument count validation and delegates to the prerun function instead.
+#define VEF_PARAM_VARARGS UINT_MAX
 
 typedef struct {
   unsigned int param_count;

--- a/villagesql/sdk/include/villagesql/detail/vef_register.h
+++ b/villagesql/sdk/include/villagesql/detail/vef_register.h
@@ -55,7 +55,10 @@ __attribute__((visibility("hidden"))) vef_func_desc_t *materialize_func_desc(
   static vef_func_desc_t desc;
 
   signature.param_count = static_cast<unsigned int>(func_data.num_params());
-  signature.params = func_data.num_params() > 0 ? func_data.params() : nullptr;
+  signature.params = (func_data.num_params() > 0 &&
+                      func_data.num_params() != VEF_PARAM_VARARGS)
+                         ? func_data.params()
+                         : nullptr;
   signature.return_type = func_data.return_type();
 
   desc.protocol = VEF_PROTOCOL_2;

--- a/villagesql/sdk/include/villagesql/vsql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_builder.h
@@ -179,6 +179,7 @@ struct FuncWithMetadata {
         num_params(0),
         buffer_size(0),
         deterministic(false),
+        is_varargs(false),
         check_params_cache_bound(nullptr) {}
 
   ExtFunc f;
@@ -191,6 +192,7 @@ struct FuncWithMetadata {
   size_t num_params;
   size_t buffer_size;
   bool deterministic;
+  bool is_varargs;
   bool (*check_params_cache_bound)();
 };
 
@@ -779,6 +781,7 @@ struct StaticFuncDesc {
   vef_vdf_accumulate_func_t accumulate_;
   size_t buffer_size_;
   bool deterministic_;
+  bool is_varargs_;
   bool (*check_params_cache_bound_)();
 
   constexpr StaticFuncDesc(const char *name, const FuncWithMetadata &meta)
@@ -792,6 +795,7 @@ struct StaticFuncDesc {
         accumulate_(meta.accumulate),
         buffer_size_(meta.buffer_size),
         deterministic_(meta.deterministic),
+        is_varargs_(meta.is_varargs),
         check_params_cache_bound_(meta.check_params_cache_bound) {
     for (size_t i = 0; i < NumParams && i < meta.num_params; ++i) {
       params_[i] = meta.param_types[i];
@@ -799,7 +803,9 @@ struct StaticFuncDesc {
   }
 
   constexpr const char *name() const { return name_; }
-  constexpr size_t num_params() const { return NumParams; }
+  constexpr size_t num_params() const {
+    return is_varargs_ ? VEF_PARAM_VARARGS : NumParams;
+  }
   constexpr const vef_type_t *params() const { return params_; }
   constexpr vef_type_t return_type() const { return return_type_; }
   constexpr ExtFunc vdf() const { return vdf_; }
@@ -884,7 +890,9 @@ struct apply_params_cache_checker<std::tuple<Ps...>>
 // FuncBuilder
 // =============================================================================
 
-template <auto Func, size_t NumParams>
+enum class ParamMode { kUnset, kFixed, kVarargs };
+
+template <auto Func, size_t NumParams, ParamMode Mode = ParamMode::kUnset>
 struct FuncBuilder {
   constexpr FuncBuilder()
       : name_(nullptr),
@@ -903,13 +911,20 @@ struct FuncBuilder {
   vef_postrun_func_t postrun_;
   bool deterministic_;
 
-  constexpr FuncBuilder<Func, NumParams> &returns(const char *t) {
+  constexpr FuncBuilder<Func, NumParams, Mode> &returns(const char *t) {
     return_type_ = t;
     return *this;
   }
 
-  constexpr FuncBuilder<Func, NumParams + 1> param(const char *t) const {
-    FuncBuilder<Func, NumParams + 1> next;
+  // Add a typed parameter. Mutually exclusive with .param() and .varargs().
+  constexpr FuncBuilder<Func, NumParams + 1, ParamMode::kFixed> param(
+      const char *t) const {
+    static_assert(Mode != ParamMode::kVarargs,
+                  ".param(TYPE) and .varargs() are mutually exclusive");
+    static_assert(Mode != ParamMode::kFixed || NumParams > 0,
+                  ".param(TYPE) and .param() (zero-arity) are mutually "
+                  "exclusive");
+    FuncBuilder<Func, NumParams + 1, ParamMode::kFixed> next;
     next.name_ = name_;
     next.return_type_ = return_type_;
     next.buffer_size_ = buffer_size_;
@@ -923,24 +938,60 @@ struct FuncBuilder {
     return next;
   }
 
-  constexpr FuncBuilder<Func, NumParams> &buffer_size(size_t s) {
+  // Explicitly declare zero-arity (takes no arguments).
+  // Mutually exclusive with .param(TYPE) and .varargs().
+  constexpr FuncBuilder<Func, 0, ParamMode::kFixed> param() const {
+    static_assert(NumParams == 0,
+                  ".param() (zero-arity) and .param(TYPE) are mutually "
+                  "exclusive");
+    static_assert(Mode != ParamMode::kVarargs,
+                  ".param() (zero-arity) and .varargs() are mutually "
+                  "exclusive");
+    FuncBuilder<Func, 0, ParamMode::kFixed> next;
+    next.name_ = name_;
+    next.return_type_ = return_type_;
+    next.buffer_size_ = buffer_size_;
+    next.prerun_ = prerun_;
+    next.postrun_ = postrun_;
+    next.deterministic_ = deterministic_;
+    return next;
+  }
+
+  // Declare that this function accepts a variable number of arguments.
+  // Requires a prerun function to validate arguments at call time.
+  // Mutually exclusive with .param() and .param(TYPE).
+  constexpr FuncBuilder<Func, 0, ParamMode::kVarargs> varargs() const {
+    static_assert(Mode != ParamMode::kFixed,
+                  ".varargs() is mutually exclusive with .param() and "
+                  ".param(TYPE)");
+    FuncBuilder<Func, 0, ParamMode::kVarargs> next;
+    next.name_ = name_;
+    next.return_type_ = return_type_;
+    next.buffer_size_ = buffer_size_;
+    next.prerun_ = prerun_;
+    next.postrun_ = postrun_;
+    next.deterministic_ = deterministic_;
+    return next;
+  }
+
+  constexpr FuncBuilder<Func, NumParams, Mode> &buffer_size(size_t s) {
     buffer_size_ = s;
     return *this;
   }
 
-  constexpr FuncBuilder<Func, NumParams> &deterministic(bool d = true) {
+  constexpr FuncBuilder<Func, NumParams, Mode> &deterministic(bool d = true) {
     deterministic_ = d;
     return *this;
   }
 
   template <vef_prerun_func_t Hook>
-  constexpr FuncBuilder<Func, NumParams> &prerun() {
+  constexpr FuncBuilder<Func, NumParams, Mode> &prerun() {
     prerun_ = Hook;
     return *this;
   }
 
   template <vef_postrun_func_t Hook>
-  constexpr FuncBuilder<Func, NumParams> &postrun() {
+  constexpr FuncBuilder<Func, NumParams, Mode> &postrun() {
     postrun_ = Hook;
     return *this;
   }
@@ -953,13 +1004,20 @@ struct FuncBuilder {
     using UniquePTuple = typename unique_params_types<AllParams>::type;
 
     FuncWithMetadata meta{};
-    meta.f = &Wrapper<Func, NumParams>::invoke;
+    if constexpr (std::is_same_v<decltype(Func), vef_vdf_func_t>) {
+      // Varargs escape hatch: the user supplied a raw ABI function, so we
+      // bypass the typed Wrapper and dispatch directly.
+      meta.f = Func;
+    } else {
+      meta.f = &Wrapper<Func, NumParams>::invoke;
+    }
     meta.prerun = prerun_;
     meta.postrun = postrun_;
     meta.return_type = to_vef_type(return_type_);
     meta.num_params = NumParams;
     meta.buffer_size = buffer_size_;
     meta.deterministic = deterministic_;
+    meta.is_varargs = (Mode == ParamMode::kVarargs);
     for (size_t i = 0; i < NumParams; ++i) {
       meta.param_types[i] = to_vef_type(param_types_[i]);
     }
@@ -1128,11 +1186,11 @@ template <auto Func>
 constexpr FuncBuilder<Func, 0> make_func(const char *name) {
   using AllParams = typename FuncParamTypes<decltype(Func)>::type;
   static_assert(
-      std::tuple_size_v<AllParams> == 0 ||
+      std::is_same_v<decltype(Func), vef_vdf_func_t> ||
+          std::tuple_size_v<AllParams> == 0 ||
           !is_context_param<std::tuple_element_t<0, AllParams>>::value,
       "vsql make_func: deprecated vef_context_t* first parameter not "
-      "supported; use a typed function or make_aggregate_func (see "
-      "extension.h)");
+      "supported; write a typed function without the context parameter");
   FuncBuilder<Func, 0> builder;
   builder.name_ = name;
   return builder;

--- a/villagesql/system_views/extension_registration.cc
+++ b/villagesql/system_views/extension_registration.cc
@@ -101,11 +101,15 @@ static std::string registration_to_json(const vef_registration_t *r) {
       w.Key("return_type");
       write_type(w, f->signature->return_type);
       w.Key("params");
-      w.StartArray();
-      for (unsigned int j = 0; j < f->signature->param_count; j++) {
-        write_type(w, f->signature->params[j]);
+      if (f->signature->param_count == VEF_PARAM_VARARGS) {
+        w.String("varargs");
+      } else {
+        w.StartArray();
+        for (unsigned int j = 0; j < f->signature->param_count; j++) {
+          write_type(w, f->signature->params[j]);
+        }
+        w.EndArray();
       }
-      w.EndArray();
     }
     if (f->protocol >= VEF_PROTOCOL_2) {
       w.Key("deterministic");

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -1255,6 +1255,11 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
                                     uint arg_count, Item **args,
                                     const vef_signature_t *signature,
                                     TypeParameters *out_return_params) {
+  // For varargs functions, type validation is delegated to prerun.
+  if (signature->param_count == VEF_PARAM_VARARGS) {
+    return false;
+  }
+
   // Validate argument count matches signature
   if (arg_count != signature->param_count) {
     villagesql_error(

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -233,8 +233,30 @@ static void marshal_args_typed(const vef_signature_t *sig, uint value_count,
                                InvalueType *invalues) {
   for (unsigned int i = 0; i < value_count; i++) {
     Item *arg_item = args[i];
-    vef_type_id param_type =
-        (i < sig->param_count) ? sig->params[i].id : VEF_TYPE_STRING;
+    vef_type_id param_type;
+    if (sig->params != nullptr && i < sig->param_count) {
+      param_type = sig->params[i].id;
+    } else {
+      // Varargs: infer type from the Item. For fixed-arity functions,
+      // ValidateAndConvertVDFArguments already rejects wrong arg counts,
+      // so this branch only runs for varargs functions.
+      auto *tc = arg_item->get_type_context();
+      if (tc != nullptr) {
+        param_type = VEF_TYPE_CUSTOM;
+      } else {
+        switch (arg_item->result_type()) {
+          case REAL_RESULT:
+            param_type = VEF_TYPE_REAL;
+            break;
+          case INT_RESULT:
+            param_type = VEF_TYPE_INT;
+            break;
+          default:
+            param_type = VEF_TYPE_STRING;
+            break;
+        }
+      }
+    }
     invalues[i].type = param_type;
 
     switch (param_type) {


### PR DESCRIPTION
It appears we accidentally blocked varargs functions. Even though we could set a prerun, the calls (or lack of) to .params would still be checked and throw an error.

