### PR TITLE
Fix feature_request template label name

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature Request
 about: Suggest an idea for feature for this project
 title: "[Feature Request]: "
 labels: ["feature"]
-assignees: 
+assignees:
   - villagesql-adam
 type: feature
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature Request
 about: Suggest an idea for feature for this project
 title: "[Feature Request]: "
-labels: ["feature request"]
+labels: ["feature"]
 assignees: 
   - villagesql-adam
 type: feature


### PR DESCRIPTION
## Description
Changes "feature request" to "feature" in template

## Related Issue
Related to GH update to use new labels and add more roadmap items

## How was this tested?
n/a - name change only

AI=CLAUDE

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
