### PR TITLE
Type disambiguation rule 2 (TD2)

### DIFF
--- a/villagesql/examples/vsql-tvector/src/tvector.cc
+++ b/villagesql/examples/vsql-tvector/src/tvector.cc
@@ -329,6 +329,70 @@ void tvector_dot_product(villagesql::CustomArgWith<TVectorParams> a,
   out.set(sum);
 }
 
+// Element-wise add: (TVECTOR, TVECTOR) -> TVECTOR
+// Vectors must have the same dimension and element type.
+void tvector_add(villagesql::CustomArgWith<TVectorParams> a,
+                 villagesql::CustomArgWith<TVectorParams> b,
+                 villagesql::CustomResultWith<TVectorParams> out) {
+  if (a.is_null() || b.is_null()) {
+    out.set_null();
+    return;
+  }
+  const TVectorParams &pa = a.params();
+  const TVectorParams &pb = b.params();
+  if (pa.dimension != pb.dimension || pa.bytes_per_elem != pb.bytes_per_elem) {
+    out.error("tvector_add: vectors must have the same dimension and type");
+    return;
+  }
+  auto buf = out.buffer();
+  size_t byte_size = static_cast<size_t>(pa.dimension) * pa.bytes_per_elem;
+  if (buf.size() < byte_size) {
+    out.error("tvector_add: output buffer too small");
+    return;
+  }
+  const unsigned char *da = a.value().data();
+  const unsigned char *db = b.value().data();
+  for (int64_t i = 0; i < pa.dimension; i++) {
+    if (pa.bytes_per_elem == 8) {
+      double v = load_double(da + i * 8) + load_double(db + i * 8);
+      store_double(buf.data() + i * 8, v);
+    } else {
+      float v = load_float(da + i * 4) + load_float(db + i * 4);
+      store_float(buf.data() + i * 4, v);
+    }
+  }
+  out.set_length(byte_size);
+}
+
+// Scalar multiply: (TVECTOR, REAL) -> TVECTOR
+void tvector_scale(villagesql::CustomArgWith<TVectorParams> a,
+                   villagesql::RealArg scalar,
+                   villagesql::CustomResultWith<TVectorParams> out) {
+  if (a.is_null() || scalar.is_null()) {
+    out.set_null();
+    return;
+  }
+  const TVectorParams &pa = a.params();
+  double s = scalar.value();
+  auto buf = out.buffer();
+  size_t byte_size = static_cast<size_t>(pa.dimension) * pa.bytes_per_elem;
+  if (buf.size() < byte_size) {
+    out.error("tvector_scale: output buffer too small");
+    return;
+  }
+  const unsigned char *da = a.value().data();
+  for (int64_t i = 0; i < pa.dimension; i++) {
+    if (pa.bytes_per_elem == 8) {
+      double v = load_double(da + i * 8) * s;
+      store_double(buf.data() + i * 8, v);
+    } else {
+      float v = load_float(da + i * 4) * static_cast<float>(s);
+      store_float(buf.data() + i * 4, v);
+    }
+  }
+  out.set_length(byte_size);
+}
+
 static constexpr const char kTVectorTypeName[] = "TVECTOR";
 
 constexpr auto TVECTOR = vsql::make_type<kTVectorTypeName>()
@@ -354,5 +418,17 @@ VEF_GENERATE_ENTRY_POINTS(
                   .returns(REAL)
                   .param(TVECTOR)
                   .param(TVECTOR)
+                  .deterministic()
+                  .build())
+        .func(make_func<&tvector_add>("tvector_add")
+                  .returns(TVECTOR)
+                  .param(TVECTOR)
+                  .param(TVECTOR)
+                  .deterministic()
+                  .build())
+        .func(make_func<&tvector_scale>("tvector_scale")
+                  .returns(TVECTOR)
+                  .param(TVECTOR)
+                  .param(REAL)
                   .deterministic()
                   .build()))

--- a/villagesql/examples/vsql-tvector/test/r/tvector_errors.result
+++ b/villagesql/examples/vsql-tvector/test/r/tvector_errors.result
@@ -13,4 +13,15 @@ CREATE TABLE t_err (v TVECTOR('dimension=0'));
 ERROR 42000: TVECTOR: dimension must be a positive integer near 'TVECTOR('dimension=0'))' at line 1
 CREATE TABLE t_err (v TVECTOR('unknown_key=5'));
 ERROR 42000: TVECTOR: dimension must be a positive integer near 'TVECTOR('unknown_key=5'))' at line 1
+SELECT vsql_tvector.tvector_dot_product('[1,2,3]', '[4,5,6]');
+ERROR HY000: Cannot initialize function 'tvector_dot_product': cannot determine type parameters for vsql_tvector.TVECTOR in argument 1
+CREATE TABLE t_dim3 (v TVECTOR(3));
+CREATE TABLE t_dim4 (v TVECTOR(4));
+INSERT INTO t_dim3 (v) VALUES ('[1,2,3]');
+INSERT INTO t_dim4 (v) VALUES ('[1,2,3,4]');
+SELECT vsql_tvector.tvector_dot_product(
+(SELECT v FROM t_dim3 LIMIT 1),
+(SELECT v FROM t_dim4 LIMIT 1));
+ERROR HY000: Cannot initialize function 'tvector_dot_product': conflicting type parameters for vsql_tvector.TVECTOR in arguments 1 and 2
+DROP TABLE t_dim3, t_dim4;
 UNINSTALL EXTENSION vsql_tvector;

--- a/villagesql/examples/vsql-tvector/test/r/tvector_vdf.result
+++ b/villagesql/examples/vsql-tvector/test/r/tvector_vdf.result
@@ -59,5 +59,42 @@ SELECT vsql_tvector.tvector_dot_product(
 (SELECT v FROM t_nulls WHERE id=2)) AS dot_null_both;
 dot_null_both
 NULL
+SELECT vsql_tvector.tvector_add(
+(SELECT v FROM t WHERE id=1),
+'[4,5,6]') AS add_col_str;
+add_col_str
+[5,7,9]
+SELECT vsql_tvector.tvector_add(
+(SELECT v FROM t WHERE id=1),
+(SELECT v FROM t WHERE id=2)) AS add_col_col;
+add_col_col
+[5,7,9]
+SELECT vsql_tvector.tvector_add(
+'[10,20,30]',
+(SELECT v FROM t WHERE id=1)) AS add_str_col;
+add_str_col
+[11,22,33]
+SELECT vsql_tvector.tvector_add(
+(SELECT v FROM t_nulls WHERE id=1),
+(SELECT v FROM t_nulls WHERE id=2)) AS add_null;
+add_null
+NULL
+SELECT vsql_tvector.tvector_scale(
+(SELECT v FROM t WHERE id=1),
+2.0) AS scale_2x;
+scale_2x
+[2,4,6]
+SELECT vsql_tvector.tvector_scale(
+(SELECT v FROM t_nulls WHERE id=2),
+2.0) AS scale_null;
+scale_null
+NULL
+SELECT vsql_tvector.tvector_add(
+vsql_tvector.tvector_scale(
+(SELECT v FROM t WHERE id=1),
+2.0),
+'[1,1,1]') AS chain_scale_add;
+chain_scale_add
+[3,5,7]
 DROP TABLE t, t_double, t_nulls;
 UNINSTALL EXTENSION vsql_tvector;

--- a/villagesql/examples/vsql-tvector/test/t/tvector_errors.test
+++ b/villagesql/examples/vsql-tvector/test/t/tvector_errors.test
@@ -66,6 +66,33 @@ CREATE TABLE t_err (v TVECTOR('unknown_key=5'));
 
 ########################################################################
 #
+# Test: VDF with two string constants - no type params can be inferred
+#
+########################################################################
+
+--error ER_VILLAGESQL_GENERIC_ERROR
+SELECT vsql_tvector.tvector_dot_product('[1,2,3]', '[4,5,6]');
+
+########################################################################
+#
+# Test: VDF with conflicting dimensions from table columns
+#
+########################################################################
+
+CREATE TABLE t_dim3 (v TVECTOR(3));
+CREATE TABLE t_dim4 (v TVECTOR(4));
+INSERT INTO t_dim3 (v) VALUES ('[1,2,3]');
+INSERT INTO t_dim4 (v) VALUES ('[1,2,3,4]');
+
+--error ER_VILLAGESQL_GENERIC_ERROR
+SELECT vsql_tvector.tvector_dot_product(
+    (SELECT v FROM t_dim3 LIMIT 1),
+    (SELECT v FROM t_dim4 LIMIT 1));
+
+DROP TABLE t_dim3, t_dim4;
+
+########################################################################
+#
 # Clean up
 #
 ########################################################################

--- a/villagesql/examples/vsql-tvector/test/t/tvector_vdf.test
+++ b/villagesql/examples/vsql-tvector/test/t/tvector_vdf.test
@@ -85,6 +85,59 @@ SELECT vsql_tvector.tvector_dot_product(
 
 ########################################################################
 #
+# Test: tvector_add - element-wise addition
+#
+########################################################################
+
+# Column + string constant
+SELECT vsql_tvector.tvector_add(
+    (SELECT v FROM t WHERE id=1),
+    '[4,5,6]') AS add_col_str;
+
+# Both args from table columns
+SELECT vsql_tvector.tvector_add(
+    (SELECT v FROM t WHERE id=1),
+    (SELECT v FROM t WHERE id=2)) AS add_col_col;
+
+# String constant + column
+SELECT vsql_tvector.tvector_add(
+    '[10,20,30]',
+    (SELECT v FROM t WHERE id=1)) AS add_str_col;
+
+# NULL handling
+SELECT vsql_tvector.tvector_add(
+    (SELECT v FROM t_nulls WHERE id=1),
+    (SELECT v FROM t_nulls WHERE id=2)) AS add_null;
+
+########################################################################
+#
+# Test: tvector_scale - scalar multiplication
+#
+########################################################################
+
+SELECT vsql_tvector.tvector_scale(
+    (SELECT v FROM t WHERE id=1),
+    2.0) AS scale_2x;
+
+# NULL handling
+SELECT vsql_tvector.tvector_scale(
+    (SELECT v FROM t_nulls WHERE id=2),
+    2.0) AS scale_null;
+
+########################################################################
+#
+# Test: chained VDFs
+#
+########################################################################
+
+SELECT vsql_tvector.tvector_add(
+    vsql_tvector.tvector_scale(
+        (SELECT v FROM t WHERE id=1),
+        2.0),
+    '[1,1,1]') AS chain_scale_add;
+
+########################################################################
+#
 # Clean up
 #
 ########################################################################

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -1254,7 +1254,8 @@ void ClearAlterCustomFields(THD *thd) {
 bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
                                     const LEX_STRING &extension_name,
                                     uint arg_count, Item **args,
-                                    const vef_signature_t *signature) {
+                                    const vef_signature_t *signature,
+                                    TypeParameters *out_return_params) {
   // Validate argument count matches signature
   if (arg_count != signature->param_count) {
     villagesql_error(
@@ -1277,6 +1278,7 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
     uint arg_index;
   };
   std::map<std::string, KnownEntry> known_params;
+  const std::string ext_name(extension_name.str, extension_name.length);
 
   for (uint i = 0; i < arg_count; i++) {
     const vef_type_t &expected_type = signature->params[i];
@@ -1284,9 +1286,8 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
     if (args[i]->type() == Item::NULL_ITEM) continue;
 
     assert(expected_type.custom_type != nullptr);
-    const std::string expected_qbn = make_qualified_base_name(
-        std::string(extension_name.str, extension_name.length),
-        expected_type.custom_type);
+    const std::string expected_qbn =
+        make_qualified_base_name(ext_name, expected_type.custom_type);
 
     auto *tc = args[i]->get_type_context();
     if (tc == nullptr) continue;  // String constants handled in pass 2
@@ -1328,9 +1329,8 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
     if (args[i]->type() == Item::NULL_ITEM) continue;
 
     assert(expected_type.custom_type != nullptr);
-    const std::string expected_qbn = make_qualified_base_name(
-        std::string(extension_name.str, extension_name.length),
-        expected_type.custom_type);
+    const std::string expected_qbn =
+        make_qualified_base_name(ext_name, expected_type.custom_type);
 
     auto *tc = args[i]->get_type_context();
 
@@ -1420,12 +1420,26 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
     return true;
   }
 
+  // Type disambiguation rule 2 (TD2): If the return type is a parameterized
+  // custom type, infer its params from args of the same type.
+  if (out_return_params != nullptr &&
+      signature->return_type.id == VEF_TYPE_CUSTOM &&
+      signature->return_type.custom_type != nullptr) {
+    const std::string return_qbn =
+        make_qualified_base_name(ext_name, signature->return_type.custom_type);
+    auto it = known_params.find(return_qbn);
+    if (it != known_params.end()) {
+      *out_return_params = *it->second.params;
+    }
+  }
+
   return false;
 }
 
 void SetVDFReturnTypeContext(THD *thd, const LEX_STRING &extension_name,
                              const vef_signature_t *signature,
-                             Item *result_item) {
+                             Item *result_item,
+                             const TypeParameters *return_params) {
   const char *return_type_name = signature->return_type.custom_type;
   if (return_type_name == nullptr) {
     return;
@@ -1435,10 +1449,13 @@ void SetVDFReturnTypeContext(THD *thd, const LEX_STRING &extension_name,
   lex_return_type.str = const_cast<char *>(return_type_name);
   lex_return_type.length = strlen(return_type_name);
 
+  TypeParameters params;
+  if (return_params != nullptr) {
+    params = *return_params;
+  }
+
   const TypeContext *return_type_ctx = nullptr;
-  // TODO(villagesql-beta): pass real TypeParameters for parameterized types
-  TypeParameters empty_params;
-  if (!ResolveTypeToContext(extension_name, lex_return_type, empty_params,
+  if (!ResolveTypeToContext(extension_name, lex_return_type, params,
                             *thd->mem_root, return_type_ctx) &&
       return_type_ctx != nullptr) {
     result_item->set_type_context(return_type_ctx);

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -1449,13 +1449,9 @@ void SetVDFReturnTypeContext(THD *thd, const LEX_STRING &extension_name,
   lex_return_type.str = const_cast<char *>(return_type_name);
   lex_return_type.length = strlen(return_type_name);
 
-  TypeParameters params;
-  if (return_params != nullptr) {
-    params = *return_params;
-  }
-
   const TypeContext *return_type_ctx = nullptr;
-  if (!ResolveTypeToContext(extension_name, lex_return_type, params,
+  if (!ResolveTypeToContext(extension_name, lex_return_type,
+                            return_params ? *return_params : TypeParameters{},
                             *thd->mem_root, return_type_ctx) &&
       return_type_ctx != nullptr) {
     result_item->set_type_context(return_type_ctx);

--- a/villagesql/types/util.h
+++ b/villagesql/types/util.h
@@ -368,19 +368,26 @@ extern bool TryImplicitCastToCustom(Item *item, const TypeContext &tc);
 // Returns false on success, true on error (with my_error already called)
 extern bool CheckCustomTypeUsage(Item *item, THD *thd);
 
-
 // Validate VDF arguments against function signature and convert string
-// constants to custom types where appropriate. Returns false on success, true
-// on error.
+// constants to custom types where appropriate. Applies type disambiguation
+// rules to the arguments (args of the same custom type share params) to resolve
+// unknown type parameters. If out_return_params is non-null and the return type
+// is a parameterized custom type, writes the resolved TypeParameters for the
+// return type (inferred from args via the rule that the return parameters are
+// the same as those matching arguements of the same abstract type). Returns
+// false on success, true on error.
 extern bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
                                            const LEX_STRING &extension_name,
                                            uint arg_count, Item **args,
-                                           const vef_signature_t *signature);
+                                           const vef_signature_t *signature,
+                                           TypeParameters *out_return_params);
 
 // Set the return type_context on a VDF result Item if it returns a custom type.
+// If return_params is non-null, uses those params instead of empty ones.
 extern void SetVDFReturnTypeContext(THD *thd, const LEX_STRING &extension_name,
                                     const vef_signature_t *signature,
-                                    Item *result_item);
+                                    Item *result_item,
+                                    const TypeParameters *return_params);
 
 // Acquire a client-managed reference to a TypeContext.
 // Returns a shared_ptr that the caller is responsible for releasing.

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -91,11 +91,15 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
     m_vdf_args.values_v1 = m_invalues_v1;
   }
 
-  // Validate and convert VDF arguments (custom type handling)
+  // Validate and convert VDF arguments (custom type handling).
+  // We resolve unknown type params from sibling args by default; we then infer
+  // return type params from the args, as written into return_params.
   const vef_signature_t *signature = m_udf->vdf_func_desc->signature;
-  if (signature != nullptr && villagesql::ValidateAndConvertVDFArguments(
-                                  thd, m_udf->name.str, m_udf->extension_name,
-                                  arg_count, m_args, signature)) {
+  villagesql::TypeParameters return_params;
+  if (signature != nullptr &&
+      villagesql::ValidateAndConvertVDFArguments(
+          thd, m_udf->name.str, m_udf->extension_name, arg_count, m_args,
+          signature, &return_params)) {
     return true;
   }
 
@@ -163,10 +167,12 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
     }
   }
 
-  // Set return type_context if this VDF returns a custom type
+  // Set return type_context if this VDF returns a custom type. Pass the
+  // return_params inferred from args via the call to
+  // ValidateAndConvertVDFArguments.
   if (signature != nullptr && signature->return_type.id == VEF_TYPE_CUSTOM) {
     villagesql::SetVDFReturnTypeContext(thd, m_udf->extension_name, signature,
-                                        func);
+                                        func, &return_params);
     m_return_type_context = func->get_type_context();
   }
 


### PR DESCRIPTION
If the return type of a VDF is unknown, then if that (abstract) type shows up in any argument, the parameters are used for the return type as well.

Add tests.

Closes #399 
Closes #371 