### PR TITLE
InnoDB: Column storage - INSTANT  DDL

### DIFF
--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -1102,6 +1102,19 @@ enum_alter_inplace_result ha_innobase::check_if_supported_inplace_alter(
           /* In this case, it can't be instant because the table
           may not be empty. Have to fall back to INPLACE */
           break;
+        } else if (villagesql::innodb::Custom_column::
+                       alter_add_drop_with_extended_storage(ha_alter_info,
+                                                            table)) {
+          // TODO(villagesql-ga): Support INSTANT ALTER for custom columns with
+          // extended storage.
+          if (is_instant_requested) {
+            villagesql_error(
+                "ALGORITHM=INSTANT is not supported for columns "
+                "with extended storage.",
+                MYF(0));
+            return HA_ALTER_ERROR;
+          }
+          break;
         }
         [[fallthrough]];
       case Instant_Type::INSTANT_NO_CHANGE:

--- a/storage/innobase/villagesql/custom_column.cc
+++ b/storage/innobase/villagesql/custom_column.cc
@@ -15,11 +15,15 @@
  */
 #include "custom_column.h"
 
+#include <unordered_set>
+
+#include "sql/create_field.h"
 #include "sql/current_thd.h"
 #include "sql/dd/cache/dictionary_client.h"
 #include "sql/dd/types/column.h"
 #include "sql/dd/types/table.h"
 #include "sql/field.h"
+#include "sql/handler.h"
 #include "sql/table.h"
 #include "storage/innobase/include/btr0pcur.h"
 #include "storage/innobase/include/dict0dd.h"
@@ -46,6 +50,29 @@ namespace innodb {
 const std::optional<Custom_column::StorageIntf> &
 Custom_column::storage_interface() const {
   return type_context_->storage_intf();
+}
+
+bool Custom_column::alter_add_drop_with_extended_storage(
+    const Alter_inplace_info *ha_alter_info, const TABLE *table) {
+  auto has_extended = [](const TypeContext *tc) {
+    return tc != nullptr && tc->storage_intf().has_value();
+  };
+
+  // Build set of old Field* objects being kept; also check any added column.
+  std::unordered_set<const Field *> kept;
+  for (const Create_field &f : ha_alter_info->alter_info->create_list) {
+    if (f.field != nullptr)
+      kept.insert(f.field);
+    else if (has_extended(f.custom_type_context))
+      return true;  // ADD of extended-storage column
+  }
+
+  // Any old field absent from kept is being dropped.
+  for (uint i = 0; table->field[i]; i++) {
+    const Field *f = table->field[i];
+    if (!kept.count(f) && has_extended(f->get_type_context())) return true;
+  }
+  return false;
 }
 
 Custom_column::Info Custom_column::get_from_field(const dict_field_t *field) {

--- a/storage/innobase/villagesql/custom_column.h
+++ b/storage/innobase/villagesql/custom_column.h
@@ -35,7 +35,9 @@ struct dict_field_t;
 struct dfield_t;
 struct dtuple_t;
 struct upd_t;
+struct TABLE;
 
+class Alter_inplace_info;
 class Field;
 
 namespace dd {
@@ -85,6 +87,10 @@ class Custom_column {
 
   // Returns true if the column storage is managed by an extension.
   bool stored_by_extension() const { return storage_interface().has_value(); }
+
+  // Returns true if ha_alter_info adds or drops a column with extended storage.
+  static bool alter_add_drop_with_extended_storage(
+      const Alter_inplace_info *ha_alter_info, const TABLE *table);
 
   // Compare two values using the registered compare implementation.
   int compare(const unsigned char *data1, size_t len1,


### PR DESCRIPTION
## Description
Temporarily disable INSTANT ADD/DROP for extended storage
