### PR TITLE
Fix deprecation warning

### DIFF
--- a/villagesql/test-extensions/vsql-storage-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-storage-test/src/extension.cc
@@ -329,5 +329,4 @@ constexpr auto STORED_INT =
 
 using namespace vsql;
 
-VEF_GENERATE_ENTRY_POINTS(
-    make_extension().type(STORED_INT))
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(STORED_INT))

--- a/villagesql/test-extensions/vsql-storage-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-storage-test/src/extension.cc
@@ -330,4 +330,4 @@ constexpr auto STORED_INT =
 using namespace vsql;
 
 VEF_GENERATE_ENTRY_POINTS(
-    make_extension("vsql_storage_test", "0.0.1").type(STORED_INT))
+    make_extension().type(STORED_INT))


### PR DESCRIPTION
Specify extension name and version in manifest.json only for vsql_storage_test extension.

## Description

<!-- What does this PR do? Briefly describe the change. -->

## Related Issue

<!-- Link the GitHub issue this PR addresses, e.g. Fixes #123 -->

## How was this tested?

<!-- Describe how you verified your changes. Include test commands you ran. -->

## Checklist

- [ ] I have signed the CLA
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I have added or updated tests as appropriate
- [ ] My changes maintain compatibility with upstream MySQL 8.4
