### PR TITLE
drop LEX_STRING from ResolveTypeToContext

### DIFF
--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -130,8 +130,8 @@ class PT_custom_type : public PT_type {
     TypeParameters params(params_str);
 
     type_context = nullptr;
-    if (ResolveTypeToContext({extension_name.str, extension_name.length},
-                             {type_name.str, type_name.length}, params,
+    if (ResolveTypeToContext(to_string_view(extension_name),
+                             to_string_view(type_name), params,
                              *thd->mem_root, type_context)) {
       return true;
     }
@@ -145,8 +145,8 @@ class PT_custom_type : public PT_type {
                                 const char *length) {
     const TypeContext *type_context = nullptr;
     TypeParameters empty_params;
-    if (ResolveTypeToContext({extension_name.str, extension_name.length},
-                             {type_name.str, type_name.length}, empty_params,
+    if (ResolveTypeToContext(to_string_view(extension_name),
+                             to_string_view(type_name), empty_params,
                              *thd->mem_root, type_context)) {
       return nullptr;
     }
@@ -229,8 +229,8 @@ class PT_custom_type : public PT_type {
 
     const TypeContext *type_context = nullptr;
     TypeParameters empty_params;
-    if (ResolveTypeToContext({extension_name.str, extension_name.length},
-                             {type_name.str, type_name.length}, empty_params,
+    if (ResolveTypeToContext(to_string_view(extension_name),
+                             to_string_view(type_name), empty_params,
                              *thd->mem_root, type_context)) {
       return nullptr;
     }

--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -130,8 +130,9 @@ class PT_custom_type : public PT_type {
     TypeParameters params(params_str);
 
     type_context = nullptr;
-    if (ResolveTypeToContext(extension_name, type_name, params, *thd->mem_root,
-                             type_context)) {
+    if (ResolveTypeToContext({extension_name.str, extension_name.length},
+                             {type_name.str, type_name.length}, params,
+                             *thd->mem_root, type_context)) {
       return true;
     }
     return false;
@@ -144,7 +145,8 @@ class PT_custom_type : public PT_type {
                                 const char *length) {
     const TypeContext *type_context = nullptr;
     TypeParameters empty_params;
-    if (ResolveTypeToContext(extension_name, type_name, empty_params,
+    if (ResolveTypeToContext({extension_name.str, extension_name.length},
+                             {type_name.str, type_name.length}, empty_params,
                              *thd->mem_root, type_context)) {
       return nullptr;
     }
@@ -227,7 +229,8 @@ class PT_custom_type : public PT_type {
 
     const TypeContext *type_context = nullptr;
     TypeParameters empty_params;
-    if (ResolveTypeToContext(extension_name, type_name, empty_params,
+    if (ResolveTypeToContext({extension_name.str, extension_name.length},
+                             {type_name.str, type_name.length}, empty_params,
                              *thd->mem_root, type_context)) {
       return nullptr;
     }

--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -131,8 +131,8 @@ class PT_custom_type : public PT_type {
 
     type_context = nullptr;
     if (ResolveTypeToContext(to_string_view(extension_name),
-                             to_string_view(type_name), params,
-                             *thd->mem_root, type_context)) {
+                             to_string_view(type_name), params, *thd->mem_root,
+                             type_context)) {
       return true;
     }
     return false;

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -1437,8 +1437,7 @@ void SetVDFReturnTypeContext(THD *thd, const LEX_STRING &extension_name,
   }
 
   const TypeContext *return_type_ctx = nullptr;
-  if (!ResolveTypeToContext({extension_name.str, extension_name.length},
-                            return_type_name,
+  if (!ResolveTypeToContext(to_string_view(extension_name), return_type_name,
                             return_params ? *return_params : TypeParameters{},
                             *thd->mem_root, return_type_ctx) &&
       return_type_ctx != nullptr) {

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -191,8 +191,8 @@ bool MaybeInjectCustomType(THD *thd, TABLE_SHARE &share, Field *field) {
   return CheckFieldLengthMatchesType(field, tc);
 }
 
-bool ResolveTypeToContext(const LEX_STRING &extension_name,
-                          const LEX_STRING &type_name,
+bool ResolveTypeToContext(std::string_view extension_name,
+                          std::string_view type_name,
                           const TypeParameters &parameters, MEM_ROOT &mem_root,
                           const TypeContext *&result) {
   result = nullptr;
@@ -201,13 +201,12 @@ bool ResolveTypeToContext(const LEX_STRING &extension_name,
   if (should_assert_if_false(vclient.is_initialized())) {
     LogVSQL(ERROR_LEVEL,
             "Failed to resolve type %.*s; VictionaryClient not initialized",
-            static_cast<int>(type_name.length), type_name.str);
+            static_cast<int>(type_name.size()), type_name.data());
     return true;
   }
 
-  TypeDescriptorKeyPrefix prefix(
-      std::string(type_name.str, type_name.length),
-      std::string(extension_name.str, extension_name.length));
+  TypeDescriptorKeyPrefix prefix{std::string(type_name),
+                                 std::string(extension_name)};
 
   auto guard = vclient.get_write_lock();
   std::vector<const TypeDescriptor *> results =
@@ -215,7 +214,7 @@ bool ResolveTypeToContext(const LEX_STRING &extension_name,
 
   if (should_assert_if_true(results.size() > 1)) {
     LogVSQL(ERROR_LEVEL, "Found more than one entry for type %.*s",
-            static_cast<int>(type_name.length), type_name.str);
+            static_cast<int>(type_name.size()), type_name.data());
     return true;
   }
 
@@ -1343,12 +1342,8 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
     if (tc != nullptr && tc->is_unknown()) {
       auto it = known_params.find(expected_qbn);
       if (it != known_params.end()) {
-        LEX_STRING lex_type_name;
-        lex_type_name.str = const_cast<char *>(expected_type.custom_type);
-        lex_type_name.length = strlen(expected_type.custom_type);
-
         const TypeContext *resolved_tc = nullptr;
-        if (ResolveTypeToContext(extension_name, lex_type_name,
+        if (ResolveTypeToContext(ext_name, expected_type.custom_type,
                                  *it->second.params, *thd->mem_root,
                                  resolved_tc)) {
           return true;
@@ -1370,10 +1365,6 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
     // Case 3: Arg is a constant string — implicit conversion.
     if (args[i]->type() == Item::STRING_ITEM &&
         args[i]->const_for_execution()) {
-      LEX_STRING lex_type_name;
-      lex_type_name.str = const_cast<char *>(expected_type.custom_type);
-      lex_type_name.length = strlen(expected_type.custom_type);
-
       // Use known params from TD1 if available, otherwise empty (correct for
       // non-parameterized types).
       TypeParameters resolved_params;
@@ -1383,8 +1374,8 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
       }
 
       const TypeContext *type_ctx = nullptr;
-      if (ResolveTypeToContext(extension_name, lex_type_name, resolved_params,
-                               *thd->mem_root, type_ctx)) {
+      if (ResolveTypeToContext(ext_name, expected_type.custom_type,
+                               resolved_params, *thd->mem_root, type_ctx)) {
         return true;
       }
 
@@ -1445,12 +1436,9 @@ void SetVDFReturnTypeContext(THD *thd, const LEX_STRING &extension_name,
     return;
   }
 
-  LEX_STRING lex_return_type;
-  lex_return_type.str = const_cast<char *>(return_type_name);
-  lex_return_type.length = strlen(return_type_name);
-
   const TypeContext *return_type_ctx = nullptr;
-  if (!ResolveTypeToContext(extension_name, lex_return_type,
+  if (!ResolveTypeToContext({extension_name.str, extension_name.length},
+                            return_type_name,
                             return_params ? *return_params : TypeParameters{},
                             *thd->mem_root, return_type_ctx) &&
       return_type_ctx != nullptr) {

--- a/villagesql/types/util.h
+++ b/villagesql/types/util.h
@@ -20,6 +20,7 @@
 #include <stddef.h>
 #include <memory>
 #include <optional>
+#include <string_view>
 #include <vector>
 
 #include "lex_string.h"
@@ -91,8 +92,8 @@ extern void BuildQualifiedParamsString(THD *thd, enum_sp_type sp_type,
 // Returns false on success and true on failure. If the type isn't known the
 // function will return false (success), but the result will be nullptr. The
 // mem_root is used to scope the cleanup of the TypeContext.
-extern bool ResolveTypeToContext(const LEX_STRING &extension_name,
-                                 const LEX_STRING &type_name,
+extern bool ResolveTypeToContext(std::string_view extension_name,
+                                 std::string_view type_name,
                                  const TypeParameters &parameters,
                                  MEM_ROOT &mem_root,
                                  const TypeContext *&result);


### PR DESCRIPTION
## Summary

- Change `ResolveTypeToContext`'s first two params from `const LEX_STRING&` to `std::string_view`.
- Drop the six adapter blocks (3 in `util.cc`, 3 in `pt_custom_type.h`) that wrapped `const char*` / `LEX_STRING` into `LEX_STRING` just to satisfy the signature.
- No behavior change; the function body already coerced both params to `std::string` on entry.

## Context

Surfaced in maintainer review on #257. Tracked in #408. Scope intentionally narrow — `ValidateAndConvertVDFArguments` / `SetVDFReturnTypeContext` parameter signatures and `make_qualified_base_name` migration are deferred per the discussion in #257.

## Implementation notes

- `util.cc:1351, 1386` (the two `ValidateAndConvertVDFArguments` call sites) reuse the existing `const std::string ext_name` local at line 1281 — `std::string` converts to `string_view` implicitly, so the adapter block disappears entirely.
- `util.cc:1453` (`SetVDFReturnTypeContext`) has no such local, so the call uses an inline brace-init: `{extension_name.str, extension_name.length}`.
- `pt_custom_type.h:133, 147, 230` are parser-side; the parser legitimately produces `LEX_STRING`s, so those keep their `LEX_STRING` parameter types and brace-init at the call site.
- `TypeDescriptorKeyPrefix prefix{...}` uses brace-init to avoid a most-vexing-parse with single-arg `std::string(string_view)`.

Scope intentionally narrow per the discussion in #257 — `ValidateAndConvertVDFArguments` / `SetVDFReturnTypeContext` parameter signatures and `make_qualified_base_name` migration are deferred.

## Test plan

- [✅] Debug build clean (`-DWITH_DEBUG=1`)
- [✅] `villint.sh --commit upstream/main` clean on the changed files
- [✅] `ctest -L villagesql` — 7/7 villagesql unit tests pass (`type_context-t`, `type_descriptor-t`, `victionary_client-t`, etc.)
- [✅] MTR `--do-suite=village` — 552 tests pass, 8 skipped, 0 failures
- [✅] MTR `--suite=villagesql/examples/vsql-tvector` — 5 tests pass (covers TD1/TD2 paths through `util.cc:1351, 1386, 1453` and the parameterized DDL paths through `pt_custom_type.h`)
- [✅] MTR `--suite=villagesql/examples/vsql-complex` — 6 tests pass
- [ ] Maintainer-mode build (`-DMYSQL_MAINTAINER_MODE=ON`): not verified locally — pre-existing `-Werror` failures on macOS clang in upstream `include/mysql/psi/mysql_file.h` (`-Wuninitialized-const-pointer`) and `sql/sql_prepare.h` (`-Wunnecessary-virtual-specifier`) prevent a full build. The three changed files compile clean under maintainer flags individually; trusting upstream CI to confirm globally.

## Checklist

- [✅] I have signed the CLA
- [✅] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [✅] I have added or updated tests as appropriate
- [✅ ] My changes maintain compatibility with upstream MySQL 8.4
