### PR TITLE
make_qualified_base_name: qbn string view

### DIFF
--- a/villagesql/schema/systable/helpers.h
+++ b/villagesql/schema/systable/helpers.h
@@ -52,9 +52,9 @@ std::string normalize_extension_name(const std::string &name);
 std::string normalize_type_name(const std::string &name);
 
 // Build a qualified base name string "extension_name.type_name".
-inline std::string make_qualified_base_name(const std::string &extension_name,
-                                            const std::string &type_name) {
-  return extension_name + "." + type_name;
+inline std::string make_qualified_base_name(std::string_view extension_name,
+                                            std::string_view type_name) {
+  return std::string(extension_name) + "." + std::string(type_name);
 }
 
 // Returns true if name is a qualified custom type name (contains a dot),

--- a/villagesql/schema/systable/helpers.h
+++ b/villagesql/schema/systable/helpers.h
@@ -54,7 +54,12 @@ std::string normalize_type_name(const std::string &name);
 // Build a qualified base name string "extension_name.type_name".
 inline std::string make_qualified_base_name(std::string_view extension_name,
                                             std::string_view type_name) {
-  return std::string(extension_name) + "." + std::string(type_name);
+  std::string result;
+  result.reserve(extension_name.size() + 1 + type_name.size());
+  result.append(extension_name);
+  result.push_back('.');
+  result.append(type_name);
+  return result;
 }
 
 // Returns true if name is a qualified custom type name (contains a dot),


### PR DESCRIPTION
## Description
`make_qualified_base_name` (`villagesql/schema/systable/helpers.h:55`) takes `const std::string&`, but its callers in `util.cc:1289, 1332, 1420` pass `(const std::string ext_name, const char *)` — the `const char *` is silently wrapped in a temporary `std::string` to satisfy the signature. Switching to `std::string_view` lets all current callers pass through unchanged (`std::string` and `const char *` both convert implicitly) while removing those hidden allocations.

Two other callers — `type_descriptor.h:156` and `dd/dd_routine.cc:89` — pass `(const std::string&, const std::string&)` from accessor methods; those also remain unchanged.

<!-- What does this PR do? Briefly describe the change. -->

## Related Issue
Closes #416.

<!-- Link the GitHub issue this PR addresses, e.g. Fixes #123 -->

## How was this tested?
  - Debug build clean (`make -j12`)
  - `./scripts/villint.sh --commit upstream/main` clean
  - `ctest -L villagesql` — 7/7 villagesql unit tests pass
  - MTR `--do-suite=village --nounit-tests --parallel=auto` — 552 tests pass, 8 skipped, 0 failures
  - MTR `--suite=villagesql/examples/vsql-tvector` — 6/6 pass
  - MTR `--suite=villagesql/examples/vsql-complex` — 7/7 pass
<!-- Describe how you verified your changes. Include test commands you ran. -->

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
