### PR TITLE
drop LEX_STRING from VDF arg/return

### DIFF
--- a/villagesql/schema/systable/helpers.h
+++ b/villagesql/schema/systable/helpers.h
@@ -52,9 +52,9 @@ std::string normalize_extension_name(const std::string &name);
 std::string normalize_type_name(const std::string &name);
 
 // Build a qualified base name string "extension_name.type_name".
-inline std::string make_qualified_base_name(const std::string &extension_name,
-                                            const std::string &type_name) {
-  return extension_name + "." + type_name;
+inline std::string make_qualified_base_name(std::string_view extension_name,
+                                            std::string_view type_name) {
+  return std::string(extension_name) + "." + std::string(type_name);
 }
 
 // Returns true if name is a qualified custom type name (contains a dot),

--- a/villagesql/schema/systable/helpers.h
+++ b/villagesql/schema/systable/helpers.h
@@ -54,7 +54,12 @@ std::string normalize_type_name(const std::string &name);
 // Build a qualified base name string "extension_name.type_name".
 inline std::string make_qualified_base_name(std::string_view extension_name,
                                             std::string_view type_name) {
-  return std::string(extension_name) + "." + std::string(type_name);
+  std::string result;
+  result.reserve(extension_name.size() + 1 + type_name.size());
+  result.append(extension_name);
+  result.push_back('.');
+  result.append(type_name);
+  return result;
 }
 
 // Returns true if name is a qualified custom type name (contains a dot),

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -1251,7 +1251,7 @@ void ClearAlterCustomFields(THD *thd) {
 }
 
 bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
-                                    const LEX_STRING &extension_name,
+                                    std::string_view extension_name,
                                     uint arg_count, Item **args,
                                     const vef_signature_t *signature,
                                     TypeParameters *out_return_params) {
@@ -1277,7 +1277,6 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
     uint arg_index;
   };
   std::map<std::string, KnownEntry> known_params;
-  const std::string ext_name(extension_name.str, extension_name.length);
 
   for (uint i = 0; i < arg_count; i++) {
     const vef_type_t &expected_type = signature->params[i];
@@ -1286,7 +1285,7 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
 
     assert(expected_type.custom_type != nullptr);
     const std::string expected_qbn =
-        make_qualified_base_name(ext_name, expected_type.custom_type);
+        make_qualified_base_name(extension_name, expected_type.custom_type);
 
     auto *tc = args[i]->get_type_context();
     if (tc == nullptr) continue;  // String constants handled in pass 2
@@ -1329,7 +1328,7 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
 
     assert(expected_type.custom_type != nullptr);
     const std::string expected_qbn =
-        make_qualified_base_name(ext_name, expected_type.custom_type);
+        make_qualified_base_name(extension_name, expected_type.custom_type);
 
     auto *tc = args[i]->get_type_context();
 
@@ -1343,7 +1342,7 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
       auto it = known_params.find(expected_qbn);
       if (it != known_params.end()) {
         const TypeContext *resolved_tc = nullptr;
-        if (ResolveTypeToContext(ext_name, expected_type.custom_type,
+        if (ResolveTypeToContext(extension_name, expected_type.custom_type,
                                  *it->second.params, *thd->mem_root,
                                  resolved_tc)) {
           return true;
@@ -1374,7 +1373,7 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
       }
 
       const TypeContext *type_ctx = nullptr;
-      if (ResolveTypeToContext(ext_name, expected_type.custom_type,
+      if (ResolveTypeToContext(extension_name, expected_type.custom_type,
                                resolved_params, *thd->mem_root, type_ctx)) {
         return true;
       }
@@ -1417,7 +1416,7 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
       signature->return_type.id == VEF_TYPE_CUSTOM &&
       signature->return_type.custom_type != nullptr) {
     const std::string return_qbn =
-        make_qualified_base_name(ext_name, signature->return_type.custom_type);
+        make_qualified_base_name(extension_name, signature->return_type.custom_type);
     auto it = known_params.find(return_qbn);
     if (it != known_params.end()) {
       *out_return_params = *it->second.params;
@@ -1427,7 +1426,7 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
   return false;
 }
 
-void SetVDFReturnTypeContext(THD *thd, const LEX_STRING &extension_name,
+void SetVDFReturnTypeContext(THD *thd, std::string_view extension_name,
                              const vef_signature_t *signature,
                              Item *result_item,
                              const TypeParameters *return_params) {
@@ -1437,7 +1436,7 @@ void SetVDFReturnTypeContext(THD *thd, const LEX_STRING &extension_name,
   }
 
   const TypeContext *return_type_ctx = nullptr;
-  if (!ResolveTypeToContext(to_string_view(extension_name), return_type_name,
+  if (!ResolveTypeToContext(extension_name, return_type_name,
                             return_params ? *return_params : TypeParameters{},
                             *thd->mem_root, return_type_ctx) &&
       return_type_ctx != nullptr) {

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -1415,8 +1415,8 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
   if (out_return_params != nullptr &&
       signature->return_type.id == VEF_TYPE_CUSTOM &&
       signature->return_type.custom_type != nullptr) {
-    const std::string return_qbn =
-        make_qualified_base_name(extension_name, signature->return_type.custom_type);
+    const std::string return_qbn = make_qualified_base_name(
+        extension_name, signature->return_type.custom_type);
     auto it = known_params.find(return_qbn);
     if (it != known_params.end()) {
       *out_return_params = *it->second.params;

--- a/villagesql/types/util.h
+++ b/villagesql/types/util.h
@@ -378,14 +378,14 @@ extern bool CheckCustomTypeUsage(Item *item, THD *thd);
 // the same as those matching arguements of the same abstract type). Returns
 // false on success, true on error.
 extern bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
-                                           const LEX_STRING &extension_name,
+                                           std::string_view extension_name,
                                            uint arg_count, Item **args,
                                            const vef_signature_t *signature,
                                            TypeParameters *out_return_params);
 
 // Set the return type_context on a VDF result Item if it returns a custom type.
 // If return_params is non-null, uses those params instead of empty ones.
-extern void SetVDFReturnTypeContext(THD *thd, const LEX_STRING &extension_name,
+extern void SetVDFReturnTypeContext(THD *thd, std::string_view extension_name,
                                     const vef_signature_t *signature,
                                     Item *result_item,
                                     const TypeParameters *return_params);

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -172,7 +172,8 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
   // return_params inferred from args via the call to
   // ValidateAndConvertVDFArguments.
   if (signature != nullptr && signature->return_type.id == VEF_TYPE_CUSTOM) {
-    villagesql::SetVDFReturnTypeContext(thd, to_string_view(m_udf->extension_name),
+    villagesql::SetVDFReturnTypeContext(thd,
+                                        to_string_view(m_udf->extension_name),
                                         signature, func, &return_params);
     m_return_type_context = func->get_type_context();
   }

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -17,6 +17,7 @@
 
 #include <type_traits>
 
+#include "lex_string.h"
 #include "my_sys.h"
 #include "mysql/strings/m_ctype.h"
 #include "sql/current_thd.h"
@@ -98,8 +99,8 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
   villagesql::TypeParameters return_params;
   if (signature != nullptr &&
       villagesql::ValidateAndConvertVDFArguments(
-          thd, m_udf->name.str, m_udf->extension_name, arg_count, m_args,
-          signature, &return_params)) {
+          thd, m_udf->name.str, to_string_view(m_udf->extension_name),
+          arg_count, m_args, signature, &return_params)) {
     return true;
   }
 
@@ -171,8 +172,8 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
   // return_params inferred from args via the call to
   // ValidateAndConvertVDFArguments.
   if (signature != nullptr && signature->return_type.id == VEF_TYPE_CUSTOM) {
-    villagesql::SetVDFReturnTypeContext(thd, m_udf->extension_name, signature,
-                                        func, &return_params);
+    villagesql::SetVDFReturnTypeContext(thd, to_string_view(m_udf->extension_name),
+                                        signature, func, &return_params);
     m_return_type_context = func->get_type_context();
   }
 


### PR DESCRIPTION
## Description
- Change `ValidateAndConvertVDFArguments` and `SetVDFReturnTypeContext`'s `extension_name` param from `const LEX_STRING&` to `std::string_view`.
- Drop the `const std::string ext_name(extension_name.str, extension_name.length)` local at `util.cc:1280` — it existed only to satisfy `make_qualified_base_name` and `ResolveTypeToContext`, both of which now take `string_view`.
- Drop the inner `to_string_view(extension_name)` wrap at `util.cc:1440` — push the conversion outward to the caller boundary.
- Update both call sites in `villagesql/vdf/vdf_handler.cc:100, 174` to use `to_string_view(m_udf->extension_name)` from `include/lex_string.h:58`.
- No behavior change.
<!-- What does this PR do? Briefly describe the change. -->

## Related Issue
Closes #415. Follow-up to #412; surfaced in @malone-at-work review on #257. Same shape as #412 — a function that converts at the inner boundary, where pushing the conversion out to the caller eliminates a `std::string` allocation per VDF arg-validation pass.

Depends on #419 landing first. Without it, `make_qualified_base_name(extension_name, ...)` would need a temporary `std::string(extension_name)` — exactly what this PR removes. The branch carries #419's commit until it merges; will rebase onto main after.
<!-- Link the GitHub issue this PR addresses, e.g. Fixes #123 -->

## How was this tested?
- [x] Debug build clean (`-DWITH_DEBUG=1`)
- [x] `villint.sh --commit upstream/main` clean on the changed files
- [x] `ctest -L villagesql` — 7/7 villagesql unit tests pass
- [x] MTR `--do-suite=village --nounit-tests --parallel=auto` — 552 tests pass, 8 skipped, 0 failures
- [x] Maintainer-mode build: not verified locally (same pre-existing macOS clang `-Werror` issues as #412; trusting upstream CI)
<!-- Describe how you verified your changes. Include test commands you ran. -->

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4