### PR TITLE
Add vsql-cube to bundled extensions

### DIFF
--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -13,6 +13,7 @@
 # Comments and blank lines are ignored.
 https://github.com/villagesql/vsql-ai main
 https://github.com/villagesql/vsql-crypto main
+https://github.com/villagesql/vsql-cube main
 https://github.com/villagesql/vsql-http main
 https://github.com/villagesql/vsql-network-address main
 https://github.com/villagesql/vsql-uuid main


### PR DESCRIPTION
## Description
Add vsql-cube to bundled extensions

## Related Issue
n/a

## How was this tested?
CI will test it on merge

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
