### PR TITLE
Mark vsql-cube as abi=dev only 

### DIFF
--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -13,7 +13,7 @@
 # Comments and blank lines are ignored.
 https://github.com/villagesql/vsql-ai main
 https://github.com/villagesql/vsql-crypto main
-https://github.com/villagesql/vsql-cube main
+https://github.com/villagesql/vsql-cube main abi=dev
 https://github.com/villagesql/vsql-http main
 https://github.com/villagesql/vsql-network-address main
 https://github.com/villagesql/vsql-uuid main


### PR DESCRIPTION
## Description
vsql-cube uses the Protocol 2 typed API (vsql.h), which only exists in the dev SDK include path. Restrict it to the dev-ABI slot in the extension compat matrix so the stable-ABI job does not attempt to build it.

AI=CLAUDE

## Related Issue
requires #426 to merge before this PR will have any impact

## How was this tested?
matches format in 426. only testable in ci after merge, though.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
