### PR TITLE
vsql-tvector: tvector_zeros TD1 case 2

### DIFF
--- a/sql/field.cc
+++ b/sql/field.cc
@@ -89,6 +89,7 @@
 #include "string_with_len.h"
 #include "template_utils.h"  // pointer_cast
 #include "typelib.h"
+#include "villagesql/include/error.h"
 #include "villagesql/types/util.h"
 
 namespace dd {
@@ -1245,6 +1246,11 @@ enum_field_types Field::field_type_merge(enum_field_types a,
 }
 
 void Field::add_to_cost(CostOfItem *cost) const { cost->AddFieldCost(); }
+
+void Field::set_type_context(const villagesql::TypeContext *tc) {
+  (void)should_assert_if_false(custom_type == nullptr);
+  custom_type = tc;
+}
 
 static Item_result field_types_result_type[FIELDTYPE_NUM] = {
     // MYSQL_TYPE_DECIMAL      MYSQL_TYPE_TINY

--- a/sql/field.h
+++ b/sql/field.h
@@ -1900,7 +1900,7 @@ class Field {
   const villagesql::TypeContext *get_type_context() const {
     return custom_type;
   }
-  void set_type_context(const villagesql::TypeContext *tc) { custom_type = tc; }
+  void set_type_context(const villagesql::TypeContext *tc);
   void update_type_context(const villagesql::TypeContext *tc) {
     custom_type = tc;
   }

--- a/sql/field.h
+++ b/sql/field.h
@@ -1901,6 +1901,9 @@ class Field {
     return custom_type;
   }
   void set_type_context(const villagesql::TypeContext *tc) { custom_type = tc; }
+  void update_type_context(const villagesql::TypeContext *tc) {
+    custom_type = tc;
+  }
   bool has_type_context() const { return nullptr != custom_type; }
 
   villagesql::TypeEncoder *get_type_encoder() const { return type_encoder_; }

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -234,6 +234,11 @@ bool Item::may_eval_const_item(const THD *thd) const {
   return !thd->lex->is_view_context_analysis() || basic_const_item();
 }
 
+void Item::set_type_context(const villagesql::TypeContext *tc) {
+  (void)should_assert_if_false(custom_type == nullptr);
+  custom_type = tc;
+}
+
 /**
   @todo
     Make this functions class dependent

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -3068,9 +3068,11 @@ void Item_field::set_field(Field *field_par) {
   decimals = field->decimals();
   unsigned_flag = field_par->is_flag_set(UNSIGNED_FLAG);
 
-  // Synchronize custom type context from Field
+  // Synchronize custom type context from Field. set_field is called from
+  // Item_field::fix_fields, which re-runs on the same Item across prepared-
+  // statement re-executions, so this is a re-set rather than a first-set.
   if (field_par->has_type_context()) {
-    this->set_type_context(field_par->get_type_context());
+    this->update_type_context(field_par->get_type_context());
     // VillageSQL: Mark that we found a custom type field during binding
     current_thd->lex->found_custom_type_in_context = true;
   }

--- a/sql/item.h
+++ b/sql/item.h
@@ -3763,7 +3763,7 @@ class Item : public Parse_tree_node {
   virtual const villagesql::TypeContext *get_type_context() const {
     return custom_type;
   }
-  void set_type_context(const villagesql::TypeContext *tc) { custom_type = tc; }
+  void set_type_context(const villagesql::TypeContext *tc);
   void update_type_context(const villagesql::TypeContext *tc) {
     custom_type = tc;
   }

--- a/sql/item.h
+++ b/sql/item.h
@@ -3764,6 +3764,9 @@ class Item : public Parse_tree_node {
     return custom_type;
   }
   void set_type_context(const villagesql::TypeContext *tc) { custom_type = tc; }
+  void update_type_context(const villagesql::TypeContext *tc) {
+    custom_type = tc;
+  }
   virtual bool has_type_context() const { return nullptr != custom_type; }
   villagesql::TypeEncoder *get_type_encoder() const { return type_encoder_; }
   void set_type_encoder(villagesql::TypeEncoder *encoder) {

--- a/sql/item.h
+++ b/sql/item.h
@@ -6977,7 +6977,7 @@ class Item_cache : public Item_basic_constant {
     add_accum_properties(item);
     // VillageSQL: Copy custom type context for proper formatting of custom
     // types
-    set_type_context(item->get_type_context());
+    update_type_context(item->get_type_context());
     if (item->type() == FIELD_ITEM) {
       cached_field = down_cast<Item_field *>(item);
       if (cached_field->table_ref != nullptr)

--- a/sql/item_func.cc
+++ b/sql/item_func.cc
@@ -7021,7 +7021,7 @@ bool Item_func_get_user_var::resolve_type(THD *thd) {
     // Override collation for all data types
     collation.set(var_entry->collation);
 
-    set_type_context(var_entry->type_context());
+    update_type_context(var_entry->type_context());
   } else {
     // Unknown user variable, assign expected type from context.
     null_value = true;

--- a/sql/sp_head.cc
+++ b/sql/sp_head.cc
@@ -1985,8 +1985,10 @@ Field *sp_head::create_result_field(THD *thd, size_t field_max_length,
 
   // VillageSQL: propagate custom type context so the result field decodes
   // correctly when the function return value is read (e.g. SELECT f1()).
+  // make_field() already sets TC from m_return_field_def.custom_type_context;
+  // this re-sets to the shared_ptr-owned ref kept alive by sp_head.
   if (m_return_type_context_ref) {
-    field->set_type_context(m_return_type_context_ref.get());
+    field->update_type_context(m_return_type_context_ref.get());
   }
 
   assert(field->pack_length() == m_return_field_def.pack_length());

--- a/sql/sql_tmp_table.cc
+++ b/sql/sql_tmp_table.cc
@@ -293,9 +293,11 @@ static Field *create_tmp_field_from_item(Item *item, TABLE *table) {
   new_field->init(table);
 
   // VillageSQL: Copy type_context for custom types so charset_for_protocol()
-  // works correctly in derived tables
+  // works correctly in derived tables. Some make_*_field paths (notably
+  // Item_sum::make_string_field) pre-set the TC on the fresh Field, so this
+  // is a re-set rather than a first-set.
   if (item->has_type_context()) {
-    new_field->set_type_context(item->get_type_context());
+    new_field->update_type_context(item->get_type_context());
   }
 
   if (item->type() == Item::NULL_ITEM)
@@ -438,7 +440,10 @@ Field *create_tmp_field(THD *thd, TABLE *table, Item *item, Item::Type type,
           item_field->set_result_field(result);
       }
       if (item->has_type_context()) {
-        result->set_type_context(item->get_type_context());
+        // create_tmp_field_from_field clones the source Field (which carries
+        // the TC); create_tmp_field_from_item also pre-sets it. This is a
+        // re-set sync point regardless of which path produced result.
+        result->update_type_context(item->get_type_context());
       }
       /*
         Fields that are used as arguments to the DEFAULT() function already have

--- a/villagesql/examples/vsql-tvector/src/tvector.cc
+++ b/villagesql/examples/vsql-tvector/src/tvector.cc
@@ -362,6 +362,25 @@ void tvector_add(vsql::CustomArgWith<TVectorParams> a,
   out.set_length(byte_size);
 }
 
+// Constant zeros: () -> TVECTOR
+// Returns a zero-valued vector. Takes no arguments, so TD2 cannot fill the
+// return type's parameters from siblings; the caller must supply context that
+// lets TD1 resolve them (e.g. a sibling argument of the same custom type in
+// an enclosing VDF call). Used to exercise the TD1 unknown -> known path
+// where an arg has a TypeContext with is_unknown()==true on entry to
+// ValidateAndConvertVDFArguments (Case 2 in villagesql/types/util.cc).
+void tvector_zeros(villagesql::CustomResultWith<TVectorParams> out) {
+  const TVectorParams &p = out.params();
+  auto buf = out.buffer();
+  size_t byte_size = static_cast<size_t>(p.dimension) * p.bytes_per_elem;
+  if (buf.size() < byte_size) {
+    out.error("tvector_zeros: output buffer too small");
+    return;
+  }
+  memset(buf.data(), 0, byte_size);
+  out.set_length(byte_size);
+}
+
 // Scalar multiply: (TVECTOR, REAL) -> TVECTOR
 void tvector_scale(vsql::CustomArgWith<TVectorParams> a, vsql::RealArg scalar,
                    vsql::CustomResultWith<TVectorParams> out) {
@@ -427,5 +446,9 @@ VEF_GENERATE_ENTRY_POINTS(
                   .returns(TVECTOR)
                   .param(TVECTOR)
                   .param(REAL)
+                  .deterministic()
+                  .build())
+        .func(make_func<&tvector_zeros>("tvector_zeros")
+                  .returns(TVECTOR)
                   .deterministic()
                   .build()))

--- a/villagesql/examples/vsql-tvector/src/tvector.cc
+++ b/villagesql/examples/vsql-tvector/src/tvector.cc
@@ -369,7 +369,7 @@ void tvector_add(vsql::CustomArgWith<TVectorParams> a,
 // an enclosing VDF call). Used to exercise the TD1 unknown -> known path
 // where an arg has a TypeContext with is_unknown()==true on entry to
 // ValidateAndConvertVDFArguments (Case 2 in villagesql/types/util.cc).
-void tvector_zeros(villagesql::CustomResultWith<TVectorParams> out) {
+void tvector_zeros(vsql::CustomResultWith<TVectorParams> out) {
   const TVectorParams &p = out.params();
   auto buf = out.buffer();
   size_t byte_size = static_cast<size_t>(p.dimension) * p.bytes_per_elem;

--- a/villagesql/examples/vsql-tvector/test/r/tvector_vdf.result
+++ b/villagesql/examples/vsql-tvector/test/r/tvector_vdf.result
@@ -96,5 +96,15 @@ vsql_tvector.tvector_scale(
 '[1,1,1]') AS chain_scale_add;
 chain_scale_add
 [3,5,7]
+SELECT vsql_tvector.tvector_add(
+vsql_tvector.tvector_zeros(),
+(SELECT v FROM t WHERE id=1)) AS td1_case2_zeros_plus_col;
+td1_case2_zeros_plus_col
+[1,2,3]
+SELECT vsql_tvector.tvector_add(
+(SELECT v FROM t WHERE id=2),
+vsql_tvector.tvector_zeros()) AS td1_case2_col_plus_zeros;
+td1_case2_col_plus_zeros
+[4,5,6]
 DROP TABLE t, t_double, t_nulls;
 UNINSTALL EXTENSION vsql_tvector;

--- a/villagesql/examples/vsql-tvector/test/t/tvector_vdf.test
+++ b/villagesql/examples/vsql-tvector/test/t/tvector_vdf.test
@@ -138,6 +138,26 @@ SELECT vsql_tvector.tvector_add(
 
 ########################################################################
 #
+# Test: TD1 Case 2 (unknown -> known via sibling)
+#
+# tvector_zeros() takes no args, so TD2 cannot fill its return type's
+# parameters from siblings; the inner VDF returns TVECTOR with
+# is_unknown()==true. The outer tvector_add resolves the inner's params
+# from its sibling typed column via TD1 (Case 2 in
+# villagesql/types/util.cc::ValidateAndConvertVDFArguments).
+#
+########################################################################
+
+SELECT vsql_tvector.tvector_add(
+    vsql_tvector.tvector_zeros(),
+    (SELECT v FROM t WHERE id=1)) AS td1_case2_zeros_plus_col;
+
+SELECT vsql_tvector.tvector_add(
+    (SELECT v FROM t WHERE id=2),
+    vsql_tvector.tvector_zeros()) AS td1_case2_col_plus_zeros;
+
+########################################################################
+#
 # Clean up
 #
 ########################################################################

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -1182,7 +1182,10 @@ static bool insert_tmp_metadata_for_thd(THD *thd, const ColumnKey &key,
   }
   if (field != nullptr) {
     const TypeContext *tc = tc_owner.get();
-    field->set_type_context(tc);
+    // The Field already has TC set from make_field() (sql/field.cc when the
+    // Create_field carries custom_type_context); we re-set with the
+    // shared_ptr-owned copy that lives in TmpMetadata.
+    field->update_type_context(tc);
     if (CheckFieldLengthMatchesType(field, tc)) return true;
   }
   if (!thd) return false;
@@ -1597,8 +1600,10 @@ bool InjectCustomSpParams(
       }
 
       // fields[i] can be null for unused variable slots in the var table.
+      // Field already carries TC from SP frame setup; this re-syncs to the
+      // shared_ptr-owned reference held in type_refs.
       if (fields[m.field_idx]) {
-        fields[m.field_idx]->set_type_context(tc_ref.get());
+        fields[m.field_idx]->update_type_context(tc_ref.get());
       }
 
       // Sync TypeContext into the Item wrapper so SP body statements
@@ -1609,7 +1614,7 @@ bool InjectCustomSpParams(
       // TODO(villagesql-ga): Once Item_field delegates set_type_context() to
       // its underlying Field, this call can be dropped for field-backed items.
       if (var_items.array() && var_items[m.field_idx]) {
-        var_items[m.field_idx]->set_type_context(tc_ref.get());
+        var_items[m.field_idx]->update_type_context(tc_ref.get());
       }
 
       // Transfer ownership to caller. sp_rcontext holds these shared_ptrs in

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -1349,7 +1349,7 @@ bool ValidateAndConvertVDFArguments(THD *thd, const char *func_name,
           return true;
         }
         if (resolved_tc != nullptr) {
-          args[i]->set_type_context(resolved_tc);
+          args[i]->update_type_context(resolved_tc);
         }
       } else {
         // No known params available for this type. Error.


### PR DESCRIPTION
## Description
- Add `tvector_zeros() -> TVECTOR` to vsql-tvector. Takes no arguments, so TD2 cannot fill its return type's parameters from siblings — the return `TypeContext` stays abstract (`is_unknown()==true`).
- Add two test cases nesting `tvector_zeros()` under `tvector_add` with a known `TVECTOR(3)` sibling. Exercises the TD1 Case 2 path at `villagesql/types/util.cc:1352` end-to-end.
<!-- What does this PR do? Briefly describe the change. -->

## Related Issue
Refs #409. Closes the TD1 Case 2 coverage gap noted in #409's discussion. TD1 the rule is already covered via the string-constant Case 3 path in the existing `tvector_add('[…]', col)` test (`tvector_vdf.test:103`); this PR adds the narrower Case 2 path where the "unknown" argchas a `TypeContext` with `is_unknown()==true` from an inner VDF return rather than just a missing TC from a string constant.

Stacked on #438. Without that branch's `update_type_context` migration of `util.cc:1352`, the strict `set_type_context` assert in debug would fire when this test runs.
<!-- Link the GitHub issue this PR addresses, e.g. Fixes #123 -->

## How was this tested?
- [x] vsql-tvector extension builds (`copy_vsql_tvector_veb`)
- [x] `--suite=villagesql/examples/vsql-tvector` — 2/2 pass
- [x] MTR `--do-suite=village --nounit-tests --parallel=auto` — 552 pass, 0 fail
- [x] Debug build: no `set_type_context` assert fires during the new test (verifies the `update_type_context` migration handles Case 2 correctly)
<!-- Describe how you verified your changes. Include test commands you ran. -->

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
