### PR TITLE
ci: cancel superseded runs; skip docs PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,20 @@ name: Build and Test
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'Docs/**'
   pull_request:
     branches: [ main ]
+    paths-ignore:
+      - '**.md'
+      - 'Docs/**'
+
+# Cancel superseded runs on the same PR branch. main pushes are not cancelled
+# so each merged commit gets its own pass.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-and-test:

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -9,6 +9,10 @@ on:
     - reopened
     - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     name: Validate PR


### PR DESCRIPTION
## Description
Two workflow tweaks aimed at the partial-miss tier (~10-13min) build that dominates everyday PR iteration:

1. Concurrency cancellation - in-progress runs on the same PR branch are cancelled when a new push arrives. main pushes are not cancelled (cancel-in-progress is gated on github.event_name == 'pull_request') so each merged commit still gets its own verification pass.

2. paths-ignore on the Build and Test trigger - PRs that touch only markdown files or Docs/ skip the full build/test cycle entirely. PR Validation (villint) keeps its current trigger so doc PRs still pass through linting.

If 'Build and Test VillageSQL' is configured as a required status check on main, doc-only PRs may report it as missing rather than passing - will need a no-op fallback job in that case.
<!-- What does this PR do? Briefly describe the change. -->

## Related Issue

<!-- Link the GitHub issue this PR addresses, e.g. Fixes #123 -->

## How was this tested?

<!-- Describe how you verified your changes. Include test commands you ran. -->

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
