### PR TITLE
ci: update build-ci.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       env:
         PARALLEL_JOBS: 16
         BUILD_TYPE: debug
-        CMAKE_EXTRA_FLAGS: -DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        CMAKE_EXTRA_FLAGS: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Evict stale ccache entries
       if: steps.check-paths.outputs.needed == 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,8 @@ jobs:
       run: ./scripts/build-ci.sh
       env:
         PARALLEL_JOBS: 16
+        BUILD_TYPE: debug
+        CMAKE_EXTRA_FLAGS: -DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Evict stale ccache entries
       if: steps.check-paths.outputs.needed == 'true'

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -56,6 +56,7 @@ jobs:
       env:
         PARALLEL_JOBS: 16
         BUILD_TYPE: ${{ inputs.build-type }}
+        CMAKE_EXTRA_FLAGS: -DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost
 
     - name: Run tests
       uses: ./source/.github/actions/run-tests

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -56,7 +56,7 @@ jobs:
       env:
         PARALLEL_JOBS: 16
         BUILD_TYPE: ${{ inputs.build-type }}
-        CMAKE_EXTRA_FLAGS: -DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost
+
 
     - name: Run tests
       uses: ./source/.github/actions/run-tests

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,6 +35,7 @@ jobs:
       run: ./scripts/build-ci.sh
       env:
         PARALLEL_JOBS: 16
+        CMAKE_EXTRA_FLAGS: -DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Show ccache statistics
       run: ccache -s

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -35,7 +35,7 @@ jobs:
       run: ./scripts/build-ci.sh
       env:
         PARALLEL_JOBS: 16
-        CMAKE_EXTRA_FLAGS: -DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+        CMAKE_EXTRA_FLAGS: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 
     - name: Show ccache statistics
       run: ccache -s

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -51,7 +51,7 @@ jobs:
       env:
         PARALLEL_JOBS: 16
         BUILD_TYPE: debug
-        CMAKE_EXTRA_FLAGS: -DWITH_VALGRIND=1
+        CMAKE_EXTRA_FLAGS: -DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost -DWITH_VALGRIND=1
 
     - name: Run Valgrind tests
       uses: ./source/.github/actions/run-tests

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -51,7 +51,7 @@ jobs:
       env:
         PARALLEL_JOBS: 16
         BUILD_TYPE: debug
-        CMAKE_EXTRA_FLAGS: -DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost -DWITH_VALGRIND=1
+        CMAKE_EXTRA_FLAGS: -DWITH_VALGRIND=1
 
     - name: Run Valgrind tests
       uses: ./source/.github/actions/run-tests

--- a/scripts/build-ci.sh
+++ b/scripts/build-ci.sh
@@ -1,60 +1,74 @@
 #!/bin/bash
+# Copyright (c) 2026 VillageSQL Contributors
+# Configure and build the VillageSQL server for CI.
+#
+# Env vars:
+#   BUILD_DIR          - build output directory (default: <source>/../build)
+#   SOURCE_DIR         - source root (default: parent of script dir)
+#   BUILD_TYPE         - debug or release (default: release, uses RelWithDebInfo)
+#   PARALLEL_JOBS      - parallel make jobs (default: auto-detected)
+#   CMAKE_EXTRA_FLAGS  - additional cmake flags appended verbatim
 
-# VillageSQL CI Build Script
-# Performs a clean build and basic validation for CI environments
+set -euo pipefail
 
-set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="${SOURCE_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+source "$SCRIPT_DIR/vsql_script_utils.sh"
 
-# Determine build type (default to debug)
-BUILD_TYPE="${BUILD_TYPE:-debug}"
+BUILD_DIR="${BUILD_DIR:-$(cd "$SOURCE_DIR/.." && pwd)/build}"
+BUILD_TYPE="${BUILD_TYPE:-release}"
+PARALLEL_JOBS="${PARALLEL_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo "4")}"
 
-echo "=== VillageSQL CI Build ==="
-echo "Build type: ${BUILD_TYPE}"
-echo "Available CPUs: $(nproc)"
-echo "Parallel jobs: ${PARALLEL_JOBS}"
-echo "Working directory: $(pwd)"
+log_step "VillageSQL CI Build"
+echo ""
 
-# Use SOURCE_DIR from environment, fallback to current directory
-SOURCE_DIR="${SOURCE_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
-
-# Use BUILD_DIR from environment, fallback to ../build relative to source
-BUILD_DIR="${BUILD_DIR:-${SOURCE_DIR}/../build}"
-
-# Create build directory
-echo "Creating build directory: ${BUILD_DIR}"
-mkdir -p "$BUILD_DIR"
-cd "$BUILD_DIR"
-
-# Configure CMake
-echo "=== CMake Configuration ==="
-
-# Set debug flag based on build type
-if [ "$BUILD_TYPE" = "debug" ]; then
-  WITH_DEBUG_FLAG="-DWITH_DEBUG=1"
-else
-  WITH_DEBUG_FLAG=""
+if [[ ! -d "$SOURCE_DIR" ]]; then
+    die "Source directory not found: $SOURCE_DIR"
+fi
+if [[ ! -f "$SOURCE_DIR/CMakeLists.txt" ]]; then
+    die "Source directory doesn't appear to be valid (no CMakeLists.txt): $SOURCE_DIR"
 fi
 
-cmake "$SOURCE_DIR" \
-  -DCMAKE_INSTALL_PREFIX=/tmp/villagesql-install \
-  $WITH_DEBUG_FLAG \
-  -DWITH_SSL=system \
-  -DMYSQL_MAINTAINER_MODE=OFF \
-  -DDOWNLOAD_BOOST=1 \
-  -DWITH_BOOST=/tmp/boost \
-  -DCMAKE_C_COMPILER_LAUNCHER=ccache \
-  -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
-  ${CMAKE_EXTRA_FLAGS}
+mkdir -p "$BUILD_DIR"
 
-echo "=== Build Information ==="
+log_info "Source Directory: $SOURCE_DIR"
+log_info "Build Directory:  $BUILD_DIR"
+log_info "Build Type:       $BUILD_TYPE"
+log_info "Parallel Jobs:    $PARALLEL_JOBS"
+echo ""
 
-# Build the project
-echo "=== Building VillageSQL ==="
-echo "Starting build with ${PARALLEL_JOBS} parallel jobs..."
-make -j"${PARALLEL_JOBS}"
+log_step "Step 1: Configuring build with CMake..."
+cd "$BUILD_DIR"
 
-echo "=== Building VillageSQL Unit Tests ==="
-make -j"${PARALLEL_JOBS}" villagesql-unit-tests
+CMAKE_FLAGS=(
+    "-DWITH_SSL=system"
+)
 
-echo "=== Build Success ==="
-echo "VillageSQL built successfully!"
+if [[ "$BUILD_TYPE" == "debug" ]]; then
+    CMAKE_FLAGS+=("-DCMAKE_BUILD_TYPE=Debug" "-DWITH_DEBUG=1")
+else
+    CMAKE_FLAGS+=("-DCMAKE_BUILD_TYPE=RelWithDebInfo")
+fi
+
+if [[ -n "${CMAKE_EXTRA_FLAGS:-}" ]]; then
+    CMAKE_FLAGS+=($CMAKE_EXTRA_FLAGS)
+fi
+
+log_info "CMake flags: ${CMAKE_FLAGS[*]}"
+cmake "$SOURCE_DIR" "${CMAKE_FLAGS[@]}" || die "CMake configuration failed"
+log_info "CMake configuration complete"
+
+log_step "Step 2: Building binaries..."
+log_info "Building with $PARALLEL_JOBS parallel jobs..."
+make -j"${PARALLEL_JOBS}" || die "Build failed"
+
+if [[ ! -x "$BUILD_DIR/runtime_output_directory/mysqld" ]]; then
+    die "mysqld not found in $BUILD_DIR/runtime_output_directory/ after build"
+fi
+log_info "Build complete"
+
+log_step "Step 3: Building unit tests..."
+make -j"${PARALLEL_JOBS}" villagesql-unit-tests || die "Unit test build failed"
+log_info "Unit tests built"
+
+log_step "Build succeeded: $BUILD_DIR/runtime_output_directory/mysqld"

--- a/scripts/make_villagesql_dev_server.sh
+++ b/scripts/make_villagesql_dev_server.sh
@@ -62,54 +62,15 @@ log_info "  - mysql-test framework (binaries only, no test/result files)"
 log_info "  - Support files and SQL scripts"
 echo ""
 
-# Step 1: Configure build with CMake
-log_step "Step 1: Configuring build with CMake..."
-cd "$BUILD_DIR"
+log_step "Step 1: Configure and build..."
+BUILD_DIR="$BUILD_DIR" SOURCE_DIR="$SOURCE_DIR" \
+    "$SCRIPT_DIR/build-ci.sh" || die "build-ci.sh failed"
 
-# Remove old cache to ensure clean configuration
-if [[ -f "CMakeCache.txt" ]]; then
-    log_info "Removing old CMakeCache.txt..."
-    rm -f CMakeCache.txt
-fi
-
-# Configure CMake with appropriate build flags
-# - CMAKE_BUILD_TYPE=RelWithDebInfo: Release optimizations with debug symbols
-# - WITH_SSL=system: Use system OpenSSL library
-CMAKE_FLAGS=(
-    "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
-    "-DWITH_SSL=system"
-)
-
-# Add any extra flags from environment
-if [[ -n "$CMAKE_EXTRA_FLAGS" ]]; then
-    CMAKE_FLAGS+=($CMAKE_EXTRA_FLAGS)
-fi
-
-log_info "CMake flags: ${CMAKE_FLAGS[*]}"
-cmake "$SOURCE_DIR" "${CMAKE_FLAGS[@]}" || die "CMake configuration failed"
-log_info "CMake configuration complete"
-
-# Step 2: Build binaries
-log_step "Step 2: Building binaries..."
-
-# Detect number of CPU cores for parallel build
-NCORES=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo "4")
-log_info "Building with $NCORES parallel jobs..."
-
-make -j${NCORES} || die "Build failed"
-log_info "Build complete"
-
-# Verify mysqld was built (CMake places it in runtime_output_directory before install)
-if [[ ! -x "$BUILD_DIR/runtime_output_directory/mysqld" ]]; then
-    die "mysqld not found in $BUILD_DIR/runtime_output_directory/ after build"
-fi
-
-# Step 2.5: Build and test bundled extensions (optional, enabled via BUILD_BUNDLED_EXTENSIONS=1)
-# TODO(villagesql): Extract build_server.sh and package_dev_server.sh as separate
-# scripts so that CI can run build → test → package as discrete steps rather than
+# TODO(villagesql): Extract package_dev_server.sh as a separate script so that
+# CI can run build → test → package as discrete steps rather than
 # embedding the test between two halves of this monolithic script.
 if [[ "${BUILD_BUNDLED_EXTENSIONS:-0}" == "1" ]]; then
-    log_step "Step 2.5: Building bundled extensions..."
+    log_step "Step 2: Building bundled extensions..."
     SDK_STAGING_DIR="$BUILD_DIR/villagesql-extension-sdk-${VSQL_VERSION}"
     [[ -d "$SDK_STAGING_DIR" ]] || die "SDK staging directory not found: $SDK_STAGING_DIR"
 
@@ -135,7 +96,6 @@ fi
 mkdir -p "$STAGING_DIR"
 cd "$BUILD_DIR"
 
-# Step 3: Generate package with CPack
 log_step "Step 3: Generating base package with CPack..."
 
 CPACK_COMPONENTS="Client;Server;Server_Scripts;SharedLibraries;SupportFiles;Readme;Info;ExampleVebs;Test;TestReadme"
@@ -158,7 +118,6 @@ fi
 ORIGINAL_SIZE=$(du -h "$BASE_TARBALL" | cut -f1)
 log_info "Base package size: $ORIGINAL_SIZE"
 
-# Step 4: Extract the base package
 log_step "Step 4: Extracting base package..."
 cd "$STAGING_DIR"
 
@@ -167,7 +126,6 @@ mkdir -p "$PACKAGE_NAME"
 cd "$PACKAGE_NAME"
 tar xzf "$BUILD_DIR/$BASE_TARBALL"
 
-# Step 4.5: Strip unnecessary test data (keep only villagesql tests and SSL certs)
 log_step "Step 4.5: Stripping unnecessary test data..."
 if [[ -d "mysql-test" ]]; then
         log_info "Removing unnecessary test data from std_data..."


### PR DESCRIPTION
Use build-ci.sh to build binaries everywhere in CI.

More flags are passed in, for each usage, but this lets us easily find where we are building in the CI, so we can keep it more consistent.

Future changes will continue to standardize the steps of "make_dev_server" so that we can run it as part of the release process.
