### PR TITLE
from_string tracks output params

### DIFF
--- a/mysql-test/suite/villagesql/std_data/bad_type_funcs.cc
+++ b/mysql-test/suite/villagesql/std_data/bad_type_funcs.cc
@@ -23,18 +23,14 @@
 #include <string_view>
 
 // Generic FROM_STRING function
-bool f1_impl(std::string_view from, vsql::Span<unsigned char> buf,
-             size_t *length) {
+void f1_impl(std::string_view from, vsql::CustomResult out) {
   (void)from;
 
-  if (buf.size() < 16) {
-    *length = 0;
-    return true;
-  }
+  auto buf = out.buffer();
+  if (buf.size() < 16) return;  // wrapper default warning
 
   memset(buf.data(), 0, 16);
-  *length = 16;
-  return false;
+  out.set_length(16);
 }
 
 // Generic TO_STRING function

--- a/mysql-test/suite/villagesql/std_data/complex3_encode.cc
+++ b/mysql-test/suite/villagesql/std_data/complex3_encode.cc
@@ -26,18 +26,14 @@ static const size_t kComplex3Len = 16;
 
 // FROM_STRING: always returns 16 zero bytes
 // This is used to verify the VEF lookup mechanism works
-bool complex3_from_string(std::string_view from,
-                          vsql::Span<unsigned char> buf, size_t *length) {
+void complex3_from_string(std::string_view from, vsql::CustomResult out) {
   (void)from;  // Unused - we always return zeros
 
-  if (buf.size() < kComplex3Len) {
-    *length = 0;
-    return true;  // Error
-  }
+  auto buf = out.buffer();
+  if (buf.size() < kComplex3Len) return;  // wrapper default warning
 
   memset(buf.data(), 0, kComplex3Len);
-  *length = kComplex3Len;
-  return false;  // Success
+  out.set_length(kComplex3Len);
 }
 
 // TO_STRING: always return "(0,0)"

--- a/mysql-test/suite/villagesql/std_data/missing_params_fn.cc
+++ b/mysql-test/suite/villagesql/std_data/missing_params_fn.cc
@@ -36,7 +36,7 @@ struct FakeParams {
 // the SDK will route through the params cache. .params<FakeParams,
 // &FakeParams::parse>() is intentionally omitted from the type builder below.
 void faketype_encode(vsql::MaybeParams<FakeParams> &, std::string_view from,
-                     vsql::CustomResultWith<FakeParams> out) {
+                     vsql::CustomResult out) {
   auto buf = out.buffer();
   size_t n = from.size() < buf.size() ? from.size() : buf.size();
   memcpy(buf.data(), from.data(), n);

--- a/mysql-test/suite/villagesql/std_data/missing_params_fn.cc
+++ b/mysql-test/suite/villagesql/std_data/missing_params_fn.cc
@@ -32,15 +32,15 @@ struct FakeParams {
   }
 };
 
-// Parameterized encode: takes const FakeParams& as first argument, so the SDK
-// will route through the params cache. .params<FakeParams,
+// Parameterized encode: takes MaybeParams<FakeParams>& as first argument, so
+// the SDK will route through the params cache. .params<FakeParams,
 // &FakeParams::parse>() is intentionally omitted from the type builder below.
-bool faketype_encode(const FakeParams &, std::string_view from,
-                     vsql::Span<unsigned char> buf, size_t *length) {
+void faketype_encode(vsql::MaybeParams<FakeParams> &, std::string_view from,
+                     vsql::CustomResultWith<FakeParams> out) {
+  auto buf = out.buffer();
   size_t n = from.size() < buf.size() ? from.size() : buf.size();
   memcpy(buf.data(), from.data(), n);
-  *length = n;
-  return false;
+  out.set_length(n);
 }
 
 bool faketype_decode(vsql::Span<const unsigned char> data,

--- a/mysql-test/suite/villagesql/std_data/no_default_type.cc
+++ b/mysql-test/suite/villagesql/std_data/no_default_type.cc
@@ -27,19 +27,18 @@ static const int64_t kLen = 4;
 
 // Encode: only accepts "(N)" format. Empty string and other invalid inputs
 // fail.
-bool no_default_encode(std::string_view from,
-                       vsql::Span<unsigned char> buffer, size_t *length) {
+void no_default_encode(std::string_view from, vsql::CustomResult out) {
   unsigned int nn = 0;
   char tmp[64];
   size_t copy = from.size() < sizeof(tmp) - 1 ? from.size() : sizeof(tmp) - 1;
   memcpy(tmp, from.data(), copy);
   tmp[copy] = '\0';
-  if (sscanf(tmp, "(%u)", &nn) != 1) return true;
-  if (buffer.size() < static_cast<size_t>(kLen)) return true;
+  if (sscanf(tmp, "(%u)", &nn) != 1) return;
+  auto buffer = out.buffer();
+  if (buffer.size() < static_cast<size_t>(kLen)) return;
   buffer[0] = static_cast<unsigned char>(nn);
   buffer[1] = buffer[2] = buffer[3] = 0;
-  *length = static_cast<size_t>(kLen);
-  return false;
+  out.set_length(static_cast<size_t>(kLen));
 }
 
 bool no_default_decode(vsql::Span<const unsigned char> buffer,

--- a/mysql-test/suite/villagesql/std_data/testtype_full.cc
+++ b/mysql-test/suite/villagesql/std_data/testtype_full.cc
@@ -25,8 +25,7 @@
 
 static const size_t kTestTypeLen = 16;
 
-bool encode_testtype(std::string_view from, vsql::Span<unsigned char> to,
-                     size_t *length) {
+void encode_testtype(std::string_view from, vsql::CustomResult out) {
   double real = 0, imag = 0;
   char temp[256];
   size_t copy_len =
@@ -34,10 +33,10 @@ bool encode_testtype(std::string_view from, vsql::Span<unsigned char> to,
   memcpy(temp, from.data(), copy_len);
   temp[copy_len] = '\0';
   sscanf(temp, " ( %lf , %lf )", &real, &imag);
+  auto to = out.buffer();
   memcpy(to.data(), &real, 8);
   memcpy(to.data() + 8, &imag, 8);
-  *length = kTestTypeLen;
-  return false;
+  out.set_length(kTestTypeLen);
 }
 
 bool decode_testtype_full(vsql::Span<const unsigned char> from,

--- a/mysql-test/suite/villagesql/std_data/testtype_short.cc
+++ b/mysql-test/suite/villagesql/std_data/testtype_short.cc
@@ -25,8 +25,7 @@
 
 static const size_t kTestTypeLen = 16;
 
-bool encode_testtype(std::string_view from, vsql::Span<unsigned char> to,
-                     size_t *length) {
+void encode_testtype(std::string_view from, vsql::CustomResult out) {
   double real = 0, imag = 0;
   char temp[256];
   size_t copy_len =
@@ -34,10 +33,10 @@ bool encode_testtype(std::string_view from, vsql::Span<unsigned char> to,
   memcpy(temp, from.data(), copy_len);
   temp[copy_len] = '\0';
   sscanf(temp, " ( %lf , %lf )", &real, &imag);
+  auto to = out.buffer();
   memcpy(to.data(), &real, 8);
   memcpy(to.data() + 8, &imag, 8);
-  *length = kTestTypeLen;
-  return false;
+  out.set_length(kTestTypeLen);
 }
 
 bool decode_testtype_short(vsql::Span<const unsigned char> from,

--- a/villagesql/examples/vsql-complex/src/complex.cc
+++ b/villagesql/examples/vsql-complex/src/complex.cc
@@ -104,36 +104,33 @@ size_t fnv1a_hash(const unsigned char *data, size_t len) {
 
 // COMPLEX encode: "(real,imag)" -> 16 bytes (with canonicalization of -0.0)
 // STRING -> COMPLEX
-bool complex_from_string(std::string_view from, vsql::Span<unsigned char> buf,
-                         size_t *length) {
-  if (buf.size() < kComplexSize) return true;
+//
+// Early returns surface the wrapper's default "failed to encode '<input>'"
+// warning.
+void complex_from_string(std::string_view from, vsql::CustomResult out) {
+  auto buf = out.buffer();
+  if (buf.size() < kComplexSize) return;
   Complex cx;
   std::string from_str(from);
-  if (sscanf(from_str.c_str(), " ( %lg , %lg )", &cx.re, &cx.im) != 2) {
-    return true;
-  }
+  if (sscanf(from_str.c_str(), " ( %lg , %lg )", &cx.re, &cx.im) != 2) return;
   cx.canonicalize();
   store_complex(buf.data(), cx);
-  *length = kComplexSize;
-  return false;
+  out.set_length(kComplexSize);
 }
 
 // COMPLEX2 encode: "(real,imag)" -> 16 bytes (without canonicalization,
 // preserves -0.0 in binary form)
 // STRING -> COMPLEX2
-bool complex2_from_string(std::string_view from, vsql::Span<unsigned char> buf,
-                          size_t *length) {
-  if (buf.size() < kComplexSize) return true;
+void complex2_from_string(std::string_view from, vsql::CustomResult out) {
+  auto buf = out.buffer();
+  if (buf.size() < kComplexSize) return;
   Complex cx;
   std::string from_str(from);
-  if (sscanf(from_str.c_str(), " ( %lg , %lg )", &cx.re, &cx.im) != 2) {
-    return true;
-  }
+  if (sscanf(from_str.c_str(), " ( %lg , %lg )", &cx.re, &cx.im) != 2) return;
   // No canonicalization - -0.0 is preserved in binary representation.
   // The custom hash function will canonicalize on the fly.
   store_complex(buf.data(), cx);
-  *length = kComplexSize;
-  return false;
+  out.set_length(kComplexSize);
 }
 
 // Decode: 16 bytes -> "(real,imag)" string

--- a/villagesql/examples/vsql-simple/src/extension.cc
+++ b/villagesql/examples/vsql-simple/src/extension.cc
@@ -32,14 +32,13 @@ using namespace vsql;
 static const size_t kBytearrayLen = 8;
 
 // from_string: string -> binary (copy up to 8 bytes, space-pad)
-bool bytearray_from_string(std::string_view from, Span<unsigned char> buf,
-                           size_t *length) {
-  if (buf.size() < kBytearrayLen) return true;  // error
+void bytearray_from_string(std::string_view from, CustomResult out) {
+  auto buf = out.buffer();
+  if (buf.size() < kBytearrayLen) return;  // wrapper default warning
   memset(buf.data(), ' ', kBytearrayLen);
   size_t copy_len = from.size() < kBytearrayLen ? from.size() : kBytearrayLen;
   if (copy_len > 0) memcpy(buf.data(), from.data(), copy_len);
-  *length = kBytearrayLen;
-  return false;  // success
+  out.set_length(kBytearrayLen);
 }
 
 // to_string: binary -> string (copy 8 bytes)

--- a/villagesql/examples/vsql-tvector/src/tvector.cc
+++ b/villagesql/examples/vsql-tvector/src/tvector.cc
@@ -173,7 +173,6 @@ bool tvector_resolve_params(const std::map<std::string, std::string> &params,
   return false;
 }
 
-//
 // When p is known, dimension and element type are taken from p; the parsed
 // element count must match p.dimension. When p is unknown, the element count
 // from the string is used to set p.dimension, and bytes_per_elem defaults to 4
@@ -183,8 +182,7 @@ bool tvector_resolve_params(const std::map<std::string, std::string> &params,
 // The loop only checks against max_supportable (what the buffer can hold).
 // Mismatch with the expected dimension is checked once at the end.
 void tvector_from_string(vsql::MaybeParams<TVectorParams> &p,
-                         std::string_view from,
-                         vsql::CustomResultWith<TVectorParams> out) {
+                         std::string_view from, vsql::CustomResult out) {
   // strtof/strtod require a null-terminated string.
   std::string input(from);
   const char *s = input.c_str();

--- a/villagesql/examples/vsql-tvector/src/tvector.cc
+++ b/villagesql/examples/vsql-tvector/src/tvector.cc
@@ -173,55 +173,85 @@ bool tvector_resolve_params(const std::map<std::string, std::string> &params,
   return false;
 }
 
-// Encode: "[v1,v2,...,vN]" -> N * bpe bytes binary.
-// STRING -> TVECTOR
-// Dimension and element type are read from type parameters.
-bool tvector_from_string(const TVectorParams &p, std::string_view from,
-                         vsql::Span<unsigned char> buf, size_t *length) {
-  // Computed values could be cached in the TVectorParams
-  size_t byte_size = static_cast<size_t>(p.dimension) * p.bytes_per_elem;
-  if (buf.size() < byte_size) return true;
-
+//
+// When p is known, dimension and element type are taken from p; the parsed
+// element count must match p.dimension. When p is unknown, the element count
+// from the string is used to set p.dimension, and bytes_per_elem defaults to 4
+// (float) since the string itself does not disambiguate float from double.
+//
+// Single-pass: each parsed element is written directly into out.buffer().
+// The loop only checks against max_supportable (what the buffer can hold).
+// Mismatch with the expected dimension is checked once at the end.
+void tvector_from_string(vsql::MaybeParams<TVectorParams> &p,
+                         std::string_view from,
+                         vsql::CustomResultWith<TVectorParams> out) {
   // strtof/strtod require a null-terminated string.
   std::string input(from);
   const char *s = input.c_str();
-
-  // Skip leading whitespace
   while (*s == ' ') s++;
-  if (*s != '[') return true;
+  if (*s != '[') {
+    out.warning("tvector_from_string: missing '['");
+    return;
+  }
   s++;
+
+  auto buf = out.buffer();
+  // bpe is fixed if known; defaults to 4 (float) when inferring.
+  const size_t bpe = (p.is_known() && p.value().bytes_per_elem > 0)
+                         ? p.value().bytes_per_elem
+                         : 4;
+  // Cap the loop on what the output buffer can hold; expected-dimension
+  // mismatch is reported once at the end.
+  const size_t max_supportable = buf.size() / bpe;
 
   size_t count = 0;
   while (*s != '\0') {
-    // Skip whitespace
     while (*s == ' ') s++;
     if (*s == ']') break;
 
-    if (count >= static_cast<size_t>(p.dimension)) return true;
+    if (count >= max_supportable) {
+      out.warning("tvector_from_string: buffer too small");
+      return;
+    }
 
     char *endptr = nullptr;
-    if (p.bytes_per_elem == 8) {
+    if (bpe == 8) {
       double val = strtod(s, &endptr);
-      if (endptr == s) return true;
-      store_double(buf.data() + count * p.bytes_per_elem, val);
+      if (endptr == s) {
+        out.warning("tvector_from_string: parse error");
+        return;
+      }
+      store_double(buf.data() + count * 8, val);
     } else {
       float val = strtof(s, &endptr);
-      if (endptr == s) return true;
-      store_float(buf.data() + count * p.bytes_per_elem, val);
+      if (endptr == s) {
+        out.warning("tvector_from_string: parse error");
+        return;
+      }
+      store_float(buf.data() + count * 4, val);
     }
     count++;
     s = endptr;
 
-    // Skip whitespace and comma
     while (*s == ' ') s++;
     if (*s == ',') s++;
   }
+  if (*s != ']') {
+    out.warning("tvector_from_string: missing ']'");
+    return;
+  }
 
-  if (*s != ']') return true;
-  if (count != static_cast<size_t>(p.dimension)) return true;
+  if (p.is_known()) {
+    if (count != static_cast<size_t>(p.value().dimension)) {
+      out.warning("tvector_from_string: dimension mismatch");
+      return;
+    }
+  } else {
+    p.set(TVectorParams{.dimension = static_cast<int64_t>(count),
+                        .bytes_per_elem = 4});
+  }
 
-  *length = byte_size;
-  return false;
+  out.set_length(count * bpe);
 }
 
 // Decode: N * bpe bytes binary -> "[v1,v2,...,vN]" string.

--- a/villagesql/examples/vsql-tvector/test/r/tvector_from_string_warnings.result
+++ b/villagesql/examples/vsql-tvector/test/r/tvector_from_string_warnings.result
@@ -1,0 +1,39 @@
+INSTALL EXTENSION vsql_tvector;
+CREATE TABLE t (v TVECTOR(3));
+INSERT IGNORE INTO t VALUES ('1,2,3');
+Warnings:
+Warning	1366	Incorrect TVECTOR value: '1,2,3' for column 'v' at row 1
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1366	Incorrect TVECTOR value: '1,2,3' for column 'v' at row 1
+DELETE FROM t;
+INSERT IGNORE INTO t VALUES ('[abc,2,3]');
+Warnings:
+Warning	1366	Incorrect TVECTOR value: '[abc,2,3]' for column 'v' at row 1
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1366	Incorrect TVECTOR value: '[abc,2,3]' for column 'v' at row 1
+DELETE FROM t;
+INSERT IGNORE INTO t VALUES ('[1,2,3,4]');
+Warnings:
+Warning	1366	Incorrect TVECTOR value: '[1,2,3,4]' for column 'v' at row 1
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1366	Incorrect TVECTOR value: '[1,2,3,4]' for column 'v' at row 1
+DELETE FROM t;
+INSERT IGNORE INTO t VALUES ('[1,2,3');
+Warnings:
+Warning	1366	Incorrect TVECTOR value: '[1,2,3' for column 'v' at row 1
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1366	Incorrect TVECTOR value: '[1,2,3' for column 'v' at row 1
+DELETE FROM t;
+INSERT IGNORE INTO t VALUES ('[1,2]');
+Warnings:
+Warning	1366	Incorrect TVECTOR value: '[1,2]' for column 'v' at row 1
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1366	Incorrect TVECTOR value: '[1,2]' for column 'v' at row 1
+DELETE FROM t;
+DROP TABLE t;
+UNINSTALL EXTENSION vsql_tvector;

--- a/villagesql/examples/vsql-tvector/test/t/tvector_from_string_warnings.test
+++ b/villagesql/examples/vsql-tvector/test/t/tvector_from_string_warnings.test
@@ -1,0 +1,38 @@
+# Exercises every explicit out.warning() path in tvector_from_string.
+# Each INSERT below feeds a malformed string into a nullable TVECTOR(3)
+# column. tvector_from_string fails the encode, the row is stored as NULL,
+# and a Warning 3200 is emitted with the extension-supplied message.
+
+INSTALL EXTENSION vsql_tvector;
+
+CREATE TABLE t (v TVECTOR(3));
+
+# Test: missing '['
+INSERT IGNORE INTO t VALUES ('1,2,3');
+SHOW WARNINGS;
+DELETE FROM t;
+
+# Test: parse error (non-numeric content)
+INSERT IGNORE INTO t VALUES ('[abc,2,3]');
+SHOW WARNINGS;
+DELETE FROM t;
+
+# Test: buffer too small (more elements than dimension)
+INSERT IGNORE INTO t VALUES ('[1,2,3,4]');
+SHOW WARNINGS;
+DELETE FROM t;
+
+# Test: missing ']' (unterminated)
+INSERT IGNORE INTO t VALUES ('[1,2,3');
+SHOW WARNINGS;
+DELETE FROM t;
+
+# Test: dimension mismatch (fewer elements than dimension)
+INSERT IGNORE INTO t VALUES ('[1,2]');
+SHOW WARNINGS;
+DELETE FROM t;
+
+# All malformed inserts should have stored NULL, not a value.
+DROP TABLE t;
+
+UNINSTALL EXTENSION vsql_tvector;

--- a/villagesql/sdk/include/villagesql/extension.h
+++ b/villagesql/sdk/include/villagesql/extension.h
@@ -256,10 +256,10 @@
 //
 // If the type has SQL-level parameters (e.g., TVECTOR(1536)), define a params
 // struct and a parse function, then use the struct as the first argument of
-// the type operation functions. The SDK detects the const P& signature and
-// wires up a memoized parse cache automatically. Note the parse function is
-// called based on the canonicalized output of the `resolve_params` function,
-// all parameter error checking should be done there.
+// the type operation functions. The SDK detects the parameterized signature
+// and wires up a memoized parse cache automatically. Note the parse function
+// is called based on the canonicalized output of the `resolve_params`
+// function, all parameter error checking should be done there.
 //
 // The parse function can be a static method on the struct (shown below) or
 // any free function with the signature:
@@ -272,8 +272,15 @@
 //     }
 //   };
 //
-//   bool my_encode(const MyParams& p, std::string_view from,
-//                  Span<unsigned char> buf, size_t* length) { ... }
+//   // encode takes MaybeParams<MyParams>& — params may be unknown so the
+//   // function can infer them from the input string and call p.set(...).
+//   // Reports outcome via CustomResultWith<MyParams>: out.set_length(n),
+//   // out.set_null(), out.warning(msg), or out.error(msg).
+//   void my_encode(MaybeParams<MyParams>& p, std::string_view from,
+//                  CustomResultWith<MyParams> out) { ... }
+//
+//   // decode/compare/hash take const MyParams& — params are always known.
+//   bool my_decode(const MyParams& p, ...);
 //
 //   make_type("MYTYPE")
 //     .persisted_length(...)
@@ -283,9 +290,10 @@
 //
 //   make_type_encode<&my_encode>("my_encode", MYTYPE)
 //
-// Both registrations are required: make_type_encode detects const P& and
-// routes through the cache; .params<>() binds the parse function at startup.
-// Omitting .params<>() while using const P& signatures will crash at runtime.
+// Both registrations are required: make_type_encode detects the parameterized
+// signature and routes through the cache; .params<>() binds the parse
+// function at startup. Omitting .params<>() while using parameterized
+// signatures will crash at runtime.
 // TODO(villagesql-beta): make this a compile time error.
 //
 // Note if a Params type is registered for more than one custom type, each

--- a/villagesql/sdk/include/villagesql/extension.h
+++ b/villagesql/sdk/include/villagesql/extension.h
@@ -274,10 +274,11 @@
 //
 //   // encode takes MaybeParams<MyParams>& — params may be unknown so the
 //   // function can infer them from the input string and call p.set(...).
-//   // Reports outcome via CustomResultWith<MyParams>: out.set_length(n),
-//   // out.set_null(), out.warning(msg), or out.error(msg).
+//   // Reports outcome via CustomResult: out.set_length(n), out.set_null(),
+//   // out.warning(msg), or out.error(msg). Plain CustomResult (not
+//   // CustomResultWith<P>) since params come from the MaybeParams& arg.
 //   void my_encode(MaybeParams<MyParams>& p, std::string_view from,
-//                  CustomResultWith<MyParams> out) { ... }
+//                  CustomResult out) { ... }
 //
 //   // decode/compare/hash take const MyParams& — params are always known.
 //   bool my_decode(const MyParams& p, ...);

--- a/villagesql/sdk/include/villagesql/vsql.h
+++ b/villagesql/sdk/include/villagesql/vsql.h
@@ -32,12 +32,17 @@
 //   using namespace vsql;
 //
 //   // 1. Implement your type operations
-//   bool complex_from_string(std::string_view s,
-//                            vsql::Span<unsigned char> buf, size_t* len);
+//   void complex_from_string(std::string_view s, vsql::CustomResult out);
 //   bool complex_to_string(vsql::Span<const unsigned char> data,
 //                          vsql::Span<char> out, size_t* out_len);
 //   int  complex_compare(vsql::Span<const unsigned char> a,
 //                        vsql::Span<const unsigned char> b);
+//
+// TODO(villagesql-beta): from_string now uses the typed CustomResult /
+// CustomResultWith<P> wrappers (see PARAMETERIZED TYPES). Migrate the other
+// special VDF entry points (to_string, compare, hash, intrinsic_default) to
+// use CustomArg / CustomArgWith<P> for inputs and the appropriate typed
+// result wrappers for outputs, replacing the raw Span<...> / size_t* shape.
 //
 //   // 2. Define the type as a constexpr object
 //   static constexpr const char kComplexTypeName[] = "COMPLEX";
@@ -72,6 +77,10 @@
 
 // Object-based type builder: vsql::make_type<Name>()
 #include <villagesql/vsql/type_builder.h>
+
+// MaybeParams<P>: known/unknown parameter wrapper for parameterized
+// from_string.
+#include <villagesql/vsql/maybe_params.h>
 
 // Parameterized type cache: TypeParamsCache<P>, type_params_cache_for<P>()
 #include <villagesql/vsql/type_params_cache.h>

--- a/villagesql/sdk/include/villagesql/vsql.h
+++ b/villagesql/sdk/include/villagesql/vsql.h
@@ -38,11 +38,11 @@
 //   int  complex_compare(vsql::Span<const unsigned char> a,
 //                        vsql::Span<const unsigned char> b);
 //
-// TODO(villagesql-beta): from_string now uses the typed CustomResult /
-// CustomResultWith<P> wrappers (see PARAMETERIZED TYPES). Migrate the other
-// special VDF entry points (to_string, compare, hash, intrinsic_default) to
-// use CustomArg / CustomArgWith<P> for inputs and the appropriate typed
-// result wrappers for outputs, replacing the raw Span<...> / size_t* shape.
+// TODO(villagesql-beta): from_string now uses the typed CustomResult
+// wrapper (see PARAMETERIZED TYPES). Migrate the other special VDF entry
+// points (to_string, compare, hash, intrinsic_default) to use CustomArg /
+// CustomArgWith<P> for inputs and the appropriate typed result wrappers for
+// outputs, replacing the raw Span<...> / size_t* shape.
 //
 //   // 2. Define the type as a constexpr object
 //   static constexpr const char kComplexTypeName[] = "COMPLEX";

--- a/villagesql/sdk/include/villagesql/vsql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_builder.h
@@ -46,6 +46,7 @@
 
 #include <villagesql/abi/types.h>
 #include <villagesql/vsql/func_types.h>
+#include <villagesql/vsql/maybe_params.h>
 #include <villagesql/vsql/type_params_cache.h>
 
 namespace vsql {
@@ -197,13 +198,22 @@ struct FuncWithMetadata {
 // Extension Author Function Signatures
 // =============================================================================
 
-// Encode: string -> binary. false=success, true=error. SIZE_MAX length = NULL.
-using TypeEncodeFunc = bool (*)(std::string_view from, Span<unsigned char> buf,
-                                size_t *length);
+// Encode: string -> custom binary. The function reports its outcome by
+// calling out.set_length(n), out.set_null(), out.warning(msg), or
+// out.error(msg). If none is called, the result is undefined.
+using TypeEncodeFunc = void (*)(std::string_view from, CustomResult out);
+// Parameterized variant: MaybeParams<P> carries the params, which may be
+// known on entry (validate against the string) or unknown (infer from the
+// string and write the inferred values back via p.set()). At runtime today
+// MaybeParams<P> is always known; the unknown case is exercised by a future
+// fix_fields-time pre-execute path for constant string literals.
+//
+// Read params from the MaybeParams<P>& argument, NOT from out.params() —
+// out.params() is unsafe when params are unknown.
 template <typename P>
-using TypeEncodeWithParamsFunc = bool (*)(const P &, std::string_view from,
-                                          Span<unsigned char> buf,
-                                          size_t *length);
+using TypeEncodeWithParamsFunc = void (*)(MaybeParams<P> &,
+                                          std::string_view from,
+                                          CustomResultWith<P>);
 
 // Decode: binary -> string. false=success, true=error.
 using TypeDecodeFunc = bool (*)(Span<const unsigned char> data, Span<char> out,
@@ -384,8 +394,41 @@ struct Wrapper {
 // Type Operation VDF Wrappers
 // =============================================================================
 
+// Pre-fills result->type / result->error_msg with a default
+// "failed to encode '<input>'" warning, truncating long inputs. Both encode
+// wrappers call this before invoking the extension's from_string so that an
+// extension that early-returns without setting an outcome still surfaces a
+// useful warning.
+//
+// TODO(villagesql-beta): tighten the contract so every from_string (and
+// every other wrapped type-op once they're migrated to typed result
+// wrappers) is expected to explicitly call out.set_length / set_null /
+// warning / error on every path. This default-WARNING fallback exists today
+// because some in-tree extensions (vsql-complex, vsql-simple, vsql-test-only,
+// vsql-storage-test) early-return on failure paths without calling anything;
+// once they're updated to be explicit, drop this synthesis and treat
+// "extension didn't set a result" as an SDK bug.
+inline void set_default_encode_failure(vef_vdf_result_t *result,
+                                       const vef_invalue_t &arg) {
+  result->type = VEF_RESULT_WARNING;
+  constexpr size_t kMaxInputDisplay = 64;
+  size_t display_len = arg.str_len;
+  const char *ellipsis = "";
+  if (display_len > kMaxInputDisplay) {
+    display_len = kMaxInputDisplay;
+    ellipsis = "...";
+  }
+  snprintf(result->error_msg, VEF_MAX_ERROR_LEN, "failed to encode '%.*s%s'",
+           static_cast<int>(display_len), arg.str_value, ellipsis);
+}
+
 // TypeEncodeVdfWrapper: wraps TypeEncodeFunc into a VDF.
 // VDF signature: (STRING) -> CUSTOM(type).
+//
+// Pre-sets the result to VEF_RESULT_WARNING with a default "failed to encode
+// '<input>'" message. The extension can override by calling out.set_length(),
+// out.set_null(), out.warning(), or out.error(); any early return without
+// such a call surfaces the default warning.
 template <auto Func>
 struct TypeEncodeVdfWrapper {
   static void invoke(vef_context_t *ctx, vef_vdf_args_t *args,
@@ -395,29 +438,8 @@ struct TypeEncodeVdfWrapper {
       result->type = VEF_RESULT_NULL;
       return;
     }
-    size_t length;
-    bool failed = Func({arg.str_value, arg.str_len},
-                       {result->bin_buf, result->max_bin_len}, &length);
-    if (failed) {
-      result->type = VEF_RESULT_WARNING;
-      constexpr size_t kMaxInputDisplay = 64;
-      size_t display_len = arg.str_len;
-      const char *ellipsis = "";
-      if (display_len > kMaxInputDisplay) {
-        display_len = kMaxInputDisplay;
-        ellipsis = "...";
-      }
-      snprintf(result->error_msg, VEF_MAX_ERROR_LEN,
-               "failed to encode '%.*s%s'", static_cast<int>(display_len),
-               arg.str_value, ellipsis);
-      return;
-    }
-    if (length == SIZE_MAX) {
-      result->type = VEF_RESULT_NULL;
-      return;
-    }
-    result->type = VEF_RESULT_VALUE;
-    result->actual_len = length;
+    set_default_encode_failure(result, arg);
+    Func({arg.str_value, arg.str_len}, CustomResult(result));
   }
 };
 
@@ -484,8 +506,11 @@ struct TypeHashVdfWrapper {
 
 template <auto Func>
 struct TypeEncodeWithCacheVdfWrapper {
-  using P = std::remove_cv_t<std::remove_reference_t<
-      std::tuple_element_t<0, typename FuncParamTypes<decltype(Func)>::type>>>;
+  // Func has signature: bool(MaybeParams<P> &, string_view, Span<uchar>,
+  // size_t *). Recover P from MaybeParams<P> &.
+  using MaybeParamsRef =
+      std::tuple_element_t<0, typename FuncParamTypes<decltype(Func)>::type>;
+  using P = typename std::remove_reference_t<MaybeParamsRef>::value_type;
 
   static void invoke(vef_context_t *ctx, vef_vdf_args_t *args,
                      vef_vdf_result_t *result) {
@@ -494,30 +519,19 @@ struct TypeEncodeWithCacheVdfWrapper {
       result->type = VEF_RESULT_NULL;
       return;
     }
-    const P &p = type_params_cache_for<P>().get(result->type_params);
-    size_t length;
-    bool failed = Func(p, {arg.str_value, arg.str_len},
-                       {result->bin_buf, result->max_bin_len}, &length);
-    if (failed) {
-      result->type = VEF_RESULT_ERROR;
-      constexpr size_t kMaxInputDisplay = 64;
-      size_t display_len = arg.str_len;
-      const char *ellipsis = "";
-      if (display_len > kMaxInputDisplay) {
-        display_len = kMaxInputDisplay;
-        ellipsis = "...";
-      }
-      snprintf(result->error_msg, VEF_MAX_ERROR_LEN,
-               "failed to encode '%.*s%s'", static_cast<int>(display_len),
-               arg.str_value, ellipsis);
-      return;
+    // At runtime today the type params are always known by the time the
+    // encode VDF runs (fix_fields binds them via TD1/TD2 / Case 3). The
+    // future pre-execute path for constant literals will call this wrapper
+    // with empty type_params to request inference; the wrapper construction
+    // below will then leave MaybeParams<P> in the unknown state.
+    MaybeParams<P> maybe_params;
+    if (result->type_params.count > 0) {
+      maybe_params =
+          MaybeParams<P>(type_params_cache_for<P>().get(result->type_params));
     }
-    if (length == SIZE_MAX) {
-      result->type = VEF_RESULT_NULL;
-      return;
-    }
-    result->type = VEF_RESULT_VALUE;
-    result->actual_len = length;
+    set_default_encode_failure(result, arg);
+    Func(maybe_params, {arg.str_value, arg.str_len},
+         CustomResultWith<P>(result));
   }
 };
 

--- a/villagesql/sdk/include/villagesql/vsql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_builder.h
@@ -208,12 +208,26 @@ using TypeEncodeFunc = void (*)(std::string_view from, CustomResult out);
 // MaybeParams<P> is always known; the unknown case is exercised by a future
 // fix_fields-time pre-execute path for constant string literals.
 //
-// Read params from the MaybeParams<P>& argument, NOT from out.params() —
-// out.params() is unsafe when params are unknown.
+// The result wrapper is plain CustomResult (not CustomResultWith<P>) because
+// params come from the MaybeParams<P>& argument.
 template <typename P>
 using TypeEncodeWithParamsFunc = void (*)(MaybeParams<P> &,
-                                          std::string_view from,
-                                          CustomResultWith<P>);
+                                          std::string_view from, CustomResult);
+
+// Backward-compat (deprecated) signatures for from_string. New extensions
+// should use TypeEncodeFunc / TypeEncodeWithParamsFunc<P>; these aliases let
+// existing extensions continue to compile against the SDK during a transition
+// window. Failure on the old signature: return true and the wrapper surfaces
+// "failed to encode '<input>'". length == SIZE_MAX signals NULL output.
+//
+// TODO(villagesql-beta): drop these once all bundled extensions migrate to
+// the typed CustomResult shape.
+using TypeEncodeFuncOld = bool (*)(std::string_view from,
+                                   Span<unsigned char> buf, size_t *length);
+template <typename P>
+using TypeEncodeWithParamsFuncOld = bool (*)(const P &, std::string_view from,
+                                             Span<unsigned char> buf,
+                                             size_t *length);
 
 // Decode: binary -> string. false=success, true=error.
 using TypeDecodeFunc = bool (*)(Span<const unsigned char> data, Span<char> out,
@@ -422,13 +436,18 @@ inline void set_default_encode_failure(vef_vdf_result_t *result,
            static_cast<int>(display_len), arg.str_value, ellipsis);
 }
 
-// TypeEncodeVdfWrapper: wraps TypeEncodeFunc into a VDF.
+// TypeEncodeVdfWrapper: wraps TypeEncodeFunc / TypeEncodeFuncOld into a VDF.
 // VDF signature: (STRING) -> CUSTOM(type).
 //
-// Pre-sets the result to VEF_RESULT_WARNING with a default "failed to encode
-// '<input>'" message. The extension can override by calling out.set_length(),
-// out.set_null(), out.warning(), or out.error(); any early return without
-// such a call surfaces the default warning.
+// New signature (TypeEncodeFunc): pre-sets the result to VEF_RESULT_WARNING
+// with a default "failed to encode '<input>'" message; the extension can
+// override by calling out.set_length(), out.set_null(), out.warning(), or
+// out.error(); any early return without such a call surfaces the default
+// warning.
+//
+// Old signature (TypeEncodeFuncOld): bool return is treated as true=error
+// (synthesizes the same default warning), false=success. length == SIZE_MAX
+// signals NULL output.
 template <auto Func>
 struct TypeEncodeVdfWrapper {
   static void invoke(vef_context_t *ctx, vef_vdf_args_t *args,
@@ -438,8 +457,24 @@ struct TypeEncodeVdfWrapper {
       result->type = VEF_RESULT_NULL;
       return;
     }
-    set_default_encode_failure(result, arg);
-    Func({arg.str_value, arg.str_len}, CustomResult(result));
+    if constexpr (std::is_same_v<decltype(Func), TypeEncodeFuncOld>) {
+      size_t length;
+      bool failed = Func({arg.str_value, arg.str_len},
+                         {result->bin_buf, result->max_bin_len}, &length);
+      if (failed) {
+        set_default_encode_failure(result, arg);
+        return;
+      }
+      if (length == SIZE_MAX) {
+        result->type = VEF_RESULT_NULL;
+        return;
+      }
+      result->type = VEF_RESULT_VALUE;
+      result->actual_len = length;
+    } else {
+      set_default_encode_failure(result, arg);
+      Func({arg.str_value, arg.str_len}, CustomResult(result));
+    }
   }
 };
 
@@ -504,13 +539,27 @@ struct TypeHashVdfWrapper {
 
 // Cache-aware wrappers for parameterized types.
 
+// Recovers the params type P from the encode function's first argument.
+//   New signature first arg: MaybeParams<P>& -> P
+//   Old signature first arg: const P&        -> P
+template <typename T>
+struct ExtractEncodeParamsType {
+  using type = T;
+};
+template <typename P>
+struct ExtractEncodeParamsType<MaybeParams<P>> {
+  using type = P;
+};
+
 template <auto Func>
 struct TypeEncodeWithCacheVdfWrapper {
-  // Func has signature: bool(MaybeParams<P> &, string_view, Span<uchar>,
-  // size_t *). Recover P from MaybeParams<P> &.
-  using MaybeParamsRef =
-      std::tuple_element_t<0, typename FuncParamTypes<decltype(Func)>::type>;
-  using P = typename std::remove_reference_t<MaybeParamsRef>::value_type;
+  // Func has either:
+  //   new: void(MaybeParams<P>&, string_view, CustomResult)
+  //   old: bool(const P&, string_view, Span<uchar>, size_t*)
+  // Recover P from the first argument.
+  using FirstArgStripped = std::remove_cv_t<std::remove_reference_t<
+      std::tuple_element_t<0, typename FuncParamTypes<decltype(Func)>::type>>>;
+  using P = typename ExtractEncodeParamsType<FirstArgStripped>::type;
 
   static void invoke(vef_context_t *ctx, vef_vdf_args_t *args,
                      vef_vdf_result_t *result) {
@@ -519,19 +568,36 @@ struct TypeEncodeWithCacheVdfWrapper {
       result->type = VEF_RESULT_NULL;
       return;
     }
-    // At runtime today the type params are always known by the time the
-    // encode VDF runs (fix_fields binds them via TD1/TD2 / Case 3). The
-    // future pre-execute path for constant literals will call this wrapper
-    // with empty type_params to request inference; the wrapper construction
-    // below will then leave MaybeParams<P> in the unknown state.
-    MaybeParams<P> maybe_params;
-    if (result->type_params.count > 0) {
-      maybe_params =
-          MaybeParams<P>(type_params_cache_for<P>().get(result->type_params));
+    if constexpr (std::is_same_v<decltype(Func),
+                                 TypeEncodeWithParamsFuncOld<P>>) {
+      const P &p = type_params_cache_for<P>().get(result->type_params);
+      size_t length;
+      bool failed = Func(p, {arg.str_value, arg.str_len},
+                         {result->bin_buf, result->max_bin_len}, &length);
+      if (failed) {
+        set_default_encode_failure(result, arg);
+        return;
+      }
+      if (length == SIZE_MAX) {
+        result->type = VEF_RESULT_NULL;
+        return;
+      }
+      result->type = VEF_RESULT_VALUE;
+      result->actual_len = length;
+    } else {
+      // At runtime today the type params are always known by the time the
+      // encode VDF runs (fix_fields binds them via TD1/TD2 / Case 3). The
+      // future pre-execute path for constant literals will call this wrapper
+      // with empty type_params to request inference; the wrapper construction
+      // below will then leave MaybeParams<P> in the unknown state.
+      MaybeParams<P> maybe_params;
+      if (result->type_params.count > 0) {
+        maybe_params =
+            MaybeParams<P>(type_params_cache_for<P>().get(result->type_params));
+      }
+      set_default_encode_failure(result, arg);
+      Func(maybe_params, {arg.str_value, arg.str_len}, CustomResult(result));
     }
-    set_default_encode_failure(result, arg);
-    Func(maybe_params, {arg.str_value, arg.str_len},
-         CustomResultWith<P>(result));
   }
 };
 
@@ -1187,16 +1253,30 @@ constexpr FuncBuilder<Func, 0> make_func(const char *name) {
 }
 
 // make_type_encode<&fn>("name", TYPE) — (STRING) -> CUSTOM(type).
+//
+// Accepts four signatures:
+//   TypeEncodeFunc                 (new, non-parameterized)
+//   TypeEncodeFuncOld              (deprecated, non-parameterized)
+//   TypeEncodeWithParamsFunc<P>    (new, parameterized)
+//   TypeEncodeWithParamsFuncOld<P> (deprecated, parameterized)
 template <auto Func>
 constexpr StaticFuncDesc<1> make_type_encode(const char *name,
                                              const char *type_name) {
+  using F = decltype(Func);
   FuncWithMetadata meta{};
-  if constexpr (std::is_same_v<decltype(Func), TypeEncodeFunc>) {
+  if constexpr (std::is_same_v<F, TypeEncodeFunc> ||
+                std::is_same_v<F, TypeEncodeFuncOld>) {
     meta.f = &TypeEncodeVdfWrapper<Func>::invoke;
   } else {
+    using P = typename TypeEncodeWithCacheVdfWrapper<Func>::P;
+    static_assert(std::is_same_v<F, TypeEncodeWithParamsFunc<P>> ||
+                      std::is_same_v<F, TypeEncodeWithParamsFuncOld<P>>,
+                  "make_type_encode: function must match one of "
+                  "TypeEncodeFunc, TypeEncodeFuncOld, "
+                  "TypeEncodeWithParamsFunc<P>, or "
+                  "TypeEncodeWithParamsFuncOld<P>.");
     meta.f = &TypeEncodeWithCacheVdfWrapper<Func>::invoke;
-    meta.check_params_cache_bound =
-        &is_params_cache_bound<typename TypeEncodeWithCacheVdfWrapper<Func>::P>;
+    meta.check_params_cache_bound = &is_params_cache_bound<P>;
   }
   meta.return_type = to_vef_type(type_name);
   meta.param_types[0] = to_vef_type(STRING);

--- a/villagesql/sdk/include/villagesql/vsql/maybe_params.h
+++ b/villagesql/sdk/include/villagesql/vsql/maybe_params.h
@@ -35,7 +35,7 @@ namespace vsql {
 //
 //   void mytype_from_string(vsql::MaybeParams<MyParams> &p,
 //                           std::string_view from,
-//                           vsql::CustomResultWith<MyParams> out) {
+//                           vsql::CustomResult out) {
 //     // ... parse the string ...
 //     if (p.is_known()) {
 //       // Validate that what was parsed matches p.value().

--- a/villagesql/sdk/include/villagesql/vsql/maybe_params.h
+++ b/villagesql/sdk/include/villagesql/vsql/maybe_params.h
@@ -1,0 +1,78 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+#ifndef VILLAGESQL_VSQL_MAYBE_PARAMS_H
+#define VILLAGESQL_VSQL_MAYBE_PARAMS_H
+
+#include <cassert>
+#include <optional>
+#include <utility>
+
+namespace vsql {
+
+// MaybeParams<P> carries a parameterized type's parsed parameters in either
+// "known" or "unknown" state. It is the first argument to from_string for
+// parameterized custom types in the ::vsql API.
+//
+// At runtime today the SDK constructs MaybeParams<P> in the known state from
+// the cached parsed parameters. The unknown state exists so that a
+// fix_fields-time pre-execute path can ask the extension to infer params from
+// a constant string literal.
+//
+// Usage in an extension's from_string:
+//
+//   void mytype_from_string(vsql::MaybeParams<MyParams> &p,
+//                           std::string_view from,
+//                           vsql::CustomResultWith<MyParams> out) {
+//     // ... parse the string ...
+//     if (p.is_known()) {
+//       // Validate that what was parsed matches p.value().
+//     } else {
+//       // Infer params from the string and store them.
+//       p.set(MyParams{...});
+//     }
+//     // Encode using p.value() (now always known).
+//   }
+template <typename P>
+class MaybeParams {
+ public:
+  using value_type = P;
+
+  // Construct in unknown state.
+  MaybeParams() = default;
+
+  // Construct in known state with the given params.
+  explicit MaybeParams(P params) : params_(std::move(params)) {}
+
+  // True if params are populated (either set on construction or via set()).
+  bool is_known() const { return params_.has_value(); }
+
+  // Returns the params. is_known() must be true.
+  const P &value() const {
+    assert(params_.has_value());
+    return *params_;
+  }
+
+  // Stores the given params, transitioning from unknown to known. May also
+  // overwrite an existing known value.
+  void set(P params) { params_ = std::move(params); }
+
+ private:
+  std::optional<P> params_ = std::nullopt;
+};
+
+}  // namespace vsql
+
+#endif  // VILLAGESQL_VSQL_MAYBE_PARAMS_H

--- a/villagesql/sdk/include/villagesql/vsql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/type_builder.h
@@ -298,8 +298,8 @@ class TypeBuilder {
   template <auto Func>
   constexpr auto from_string() const {
     using namespace detail;
-    // Accepts TypeEncodeFunc or TypeEncodeWithParamsFunc<P> (const P& as first
-    // arg). Signature validation is handled by make_type_encode<Func>.
+    // Accepts TypeEncodeFunc or TypeEncodeWithParamsFunc<P> (MaybeParams<P>&
+    // as first arg). Signature validation is handled by make_type_encode<Func>.
     constexpr const char *vdf_name = kTypeOpVdfName<Name, TypeOp::kEncode>.buf;
     auto inner = func_builder::make_type_encode<Func>(
         vdf_name, state_.desc.vef_desc.name);

--- a/villagesql/test-extensions/vsql-storage-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-storage-test/src/extension.cc
@@ -116,18 +116,17 @@ static int64_t read_be64(const unsigned char *src) {
                               static_cast<uint64_t>(src[7]));
 }
 
-bool stored_int_from_string(std::string_view s, vsql::Span<unsigned char> buf,
-                            size_t *len) {
-  if (buf.size() < kFieldSize) return true;
+void stored_int_from_string(std::string_view s, vsql::CustomResult out) {
+  auto buf = out.buffer();
+  if (buf.size() < kFieldSize) return;  // wrapper default warning
   int64_t val = 0;
   auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), val);
-  if (ec != std::errc{} || ptr != s.data() + s.size()) return true;
+  if (ec != std::errc{} || ptr != s.data() + s.size()) return;
   // [0..7]: zero placeholder for Column::Ref (server fills this after insert).
   memset(buf.data(), 0, kRefSize);
   // [8..15]: big-endian encoded integer value (becomes col_data for insert).
   write_be64(buf.data() + kRefSize, val);
-  *len = kFieldSize;
-  return false;
+  out.set_length(kFieldSize);
 }
 
 bool stored_int_to_string(vsql::Span<const unsigned char> data,

--- a/villagesql/test-extensions/vsql-test-only/src/extension.cc
+++ b/villagesql/test-extensions/vsql-test-only/src/extension.cc
@@ -71,27 +71,25 @@ constexpr std::string_view kPrefixOk = "OK ";
 constexpr std::string_view kDecodeFail = "DECODE_FAIL";
 constexpr std::string_view kEncodeFail = "ENCODE_FAIL";
 
-bool fault_blob_encode(std::string_view from, vsql::Span<unsigned char> buf,
-                       size_t *length) {
+void fault_blob_encode(std::string_view from, vsql::CustomResult out) {
   if (from == kEncodeFail) {
-    return true;  // encode failure - exercises server encode-error path
+    return;  // encode failure - wrapper default warning surfaces
   }
 
+  auto buf = out.buffer();
   if (from.substr(0, kPrefixOk.size()) == kPrefixOk || from == kDecodeFail) {
-    if (from.size() > buf.size()) {
-      return true;  // error: input too long
-    }
+    if (from.size() > buf.size()) return;  // input too long
     memset(buf.data(), 0, buf.size());
     memcpy(buf.data(), from.data(), from.size());
-    *length = kFaultBlobSize;
-    return false;  // success
+    out.set_length(kFaultBlobSize);
+    return;
   }
 
   // Empty string encodes as all-zeros (used as intrinsic default).
   if (from.empty()) {
     memset(buf.data(), 0, buf.size());
-    *length = kFaultBlobSize;
-    return false;
+    out.set_length(kFaultBlobSize);
+    return;
   }
 
   // Unrecognised prefix - crash loudly so tests cannot silently pass bad input.


### PR DESCRIPTION
Also move to using CustomResult for from_string.

A future change will call this when a constant string is used.

Updates internal types, external to follow.

Updates #449 