### PR TITLE
storage: make a capability

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-storage-test/r/storage_basic.result
+++ b/mysql-test/suite/villagesql/extension/vsql-storage-test/r/storage_basic.result
@@ -1,3 +1,4 @@
+SET PERSIST vsql_allow_preview_extensions = ON;
 # Install extension
 INSTALL EXTENSION vsql_storage_test;
 # Create a table with a STORED_INT column
@@ -29,3 +30,5 @@ id	n
 DROP TABLE t1;
 # Uninstall extension
 UNINSTALL EXTENSION vsql_storage_test;
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/mysql-test/suite/villagesql/extension/vsql-storage-test/t/storage_basic.test
+++ b/mysql-test/suite/villagesql/extension/vsql-storage-test/t/storage_basic.test
@@ -6,6 +6,8 @@
 # Covers: install, CREATE TABLE, INSERT, SELECT, UPDATE, DELETE, DROP TABLE,
 # and UNINSTALL EXTENSION.
 
+SET PERSIST vsql_allow_preview_extensions = ON;
+
 --echo # Install extension
 INSTALL EXTENSION vsql_storage_test;
 
@@ -33,3 +35,6 @@ DROP TABLE t1;
 
 --echo # Uninstall extension
 UNINSTALL EXTENSION vsql_storage_test;
+
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/villagesql/sdk/include/villagesql/abi/preview/storage.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/storage.h
@@ -538,6 +538,11 @@ typedef void (*vef_storage_page_write_string_fn)(
     const unsigned char *str, uint32_t len, vef_storage_mtr_ref_t mtr_ref);
 
 typedef struct {
+  // Capability ABI version. Always the first field in every capability vtable.
+  // Extensions must check this before accessing fields added in later versions.
+  uint32_t version;
+
+  // version >= VEF_STORAGE_SE_INTF_VERSION_1
   vef_storage_mtr_start_fn mtr_start;
   vef_storage_mtr_commit_fn mtr_commit;
   vef_storage_segment_create_fn segment_create;

--- a/villagesql/sdk/include/villagesql/abi/preview/storage.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/storage.h
@@ -483,8 +483,76 @@ void vef_storage_page_write_string(vef_storage_block_ref_t block,
                                    const unsigned char *str, uint32_t len,
                                    vef_storage_mtr_ref_t mtr_ref);
 
+// Preview capability: "vsql::preview::storage"
+//
+// Provides access to InnoDB storage engine functions. Extensions that require
+// this capability can create, load, and manipulate InnoDB segments and pages.
+//
+// The server populates the vtable before vef_register() returns. Extensions
+// must not call any storage functions before registration completes.
+//
+// Capability name: VEF_PREVIEW_STORAGE_NAME
+
+#define VEF_PREVIEW_STORAGE_NAME "vsql::preview::storage"
+
+typedef vef_storage_mtr_ref_t (*vef_storage_mtr_start_fn)(
+    void *buffer, uint32_t buffer_size, uint32_t *required_size,
+    uint32_t *required_alignment, char *error_msg, uint32_t error_msg_len);
+typedef void (*vef_storage_mtr_commit_fn)(vef_storage_mtr_ref_t ref);
+typedef int (*vef_storage_segment_create_fn)(
+    vef_storage_space_ref_t space_ref, uint8_t num_segments,
+    vef_storage_trx_ref_t trx_ref, vef_storage_page_num_t *root_page_num_p,
+    char *error_msg, uint32_t error_msg_len);
+typedef int (*vef_storage_segment_drop_fn)(vef_storage_space_ref_t space_ref,
+                                           vef_storage_trx_ref_t trx_ref,
+                                           vef_storage_page_num_t root_page_num,
+                                           char *error_msg,
+                                           uint32_t error_msg_len);
+typedef int (*vef_storage_page_load_fn)(
+    vef_storage_block_ref_t *block_p, uint64_t *position_p,
+    unsigned char **data_p, uint32_t *data_size_p,
+    vef_storage_space_ref_t space_ref, vef_storage_page_num_t page_num,
+    vef_storage_latch_t latch_mode, vef_storage_mtr_ref_t mtr_ref,
+    char *error_msg, uint32_t error_msg_len);
+typedef int (*vef_storage_page_allocate_and_load_fn)(
+    vef_storage_block_ref_t *block_p, vef_storage_page_num_t *page_num_p,
+    unsigned char **data_p, uint32_t *data_size_p,
+    unsigned char *segment_header, vef_storage_mtr_ref_t mtr_ref,
+    char *error_msg, uint32_t error_msg_len);
+typedef int (*vef_storage_page_latch_fn)(
+    vef_storage_block_ref_t block, uint64_t position, vef_storage_latch_t latch,
+    vef_storage_mtr_ref_t mtr_ref, char *error_msg, uint32_t error_msg_len);
+typedef int (*vef_storage_page_release_fn)(vef_storage_block_ref_t block,
+                                           uint64_t position,
+                                           vef_storage_mtr_ref_t mtr_ref,
+                                           char *error_msg,
+                                           uint32_t error_msg_len);
+typedef uint32_t (*vef_storage_page_get_size_fn)(
+    vef_storage_space_ref_t space_ref);
+typedef void (*vef_storage_page_write_integer_fn)(
+    vef_storage_block_ref_t block, vef_storage_page_offset_t offset,
+    uint64_t value, vef_storage_integer_bytes_t bytes,
+    vef_storage_mtr_ref_t mtr_ref);
+typedef void (*vef_storage_page_write_string_fn)(
+    vef_storage_block_ref_t block, vef_storage_page_offset_t offset,
+    const unsigned char *str, uint32_t len, vef_storage_mtr_ref_t mtr_ref);
+
+typedef struct {
+  vef_storage_mtr_start_fn mtr_start;
+  vef_storage_mtr_commit_fn mtr_commit;
+  vef_storage_segment_create_fn segment_create;
+  vef_storage_segment_drop_fn segment_drop;
+  vef_storage_page_load_fn page_load;
+  vef_storage_page_allocate_and_load_fn page_allocate_and_load;
+  vef_storage_page_latch_fn page_latch;
+  vef_storage_page_release_fn page_release;
+  vef_storage_page_get_size_fn page_get_size;
+  vef_storage_page_write_integer_fn page_write_integer;
+  vef_storage_page_write_string_fn page_write_string;
+} vef_preview_storage_t;
+
 #ifdef __cplusplus
-}  // extern "C"
+}
 #endif
 
 #endif  // VILLAGESQL_ABI_PREVIEW_STORAGE_H_

--- a/villagesql/sdk/include/villagesql/preview/storage_api.h
+++ b/villagesql/sdk/include/villagesql/preview/storage_api.h
@@ -54,13 +54,13 @@ namespace vsql::preview_storage {
 class StorageCapability {
  public:
   static constexpr const char *kName = VEF_PREVIEW_STORAGE_NAME;
+  // vef_preview_storage_t has no version field; 0 means no minimum enforced.
+  static constexpr uint32_t kAbiVersion = 0;
 
   // Populated by the server via the required_capability receive callback.
   // Public so that detail::storage_cap_receive<> can access it.
   vef_preview_storage_t abi_{};
 };
-
-inline StorageCapability make_capability() { return StorageCapability{}; }
 
 // Error codes returned by storage ABI functions.
 enum class Error {
@@ -87,9 +87,10 @@ inline thread_local char tl_error_msg[ERROR_MSG_SIZE] = {};
 inline const vef_preview_storage_t *g_abi = nullptr;
 
 template <StorageCapability *cap_ptr>
-void storage_cap_receive(void *vtable) {
-  cap_ptr->abi_ = *static_cast<vef_preview_storage_t *>(vtable);
+bool storage_cap_receive(vef_capability_receive_arg_t *arg) {
+  cap_ptr->abi_ = *static_cast<vef_preview_storage_t *>(arg->vtable);
   g_abi = &cap_ptr->abi_;
+  return true;
 }
 }  // namespace detail
 
@@ -908,15 +909,16 @@ struct Column {
 namespace vsql::preview {
 
 // Traits type for registering the storage capability via
-// .with<preview_storage<cap>>. Only available when this header is included.
-template <auto &cap>
+// .with<preview_storage<Stg>>. Only available when this header is included.
+template <auto &Stg>
 struct preview_storage {
   template <typename EB>
   static constexpr auto bind(EB builder) {
     using Cap = vsql::preview_storage::StorageCapability;
-    return builder.required_capability(
-        {Cap::kName, &vsql::preview_storage::detail::storage_cap_receive<&cap>,
-         villagesql::detail::abi_type_hash<vef_preview_storage_t>()});
+    return builder.required_capability(vef_required_capability_t{
+        Cap::kName, &vsql::preview_storage::detail::storage_cap_receive<&Stg>,
+        villagesql::detail::abi_type_hash<vef_preview_storage_t>(),
+        Cap::kAbiVersion});
   }
 };
 

--- a/villagesql/sdk/include/villagesql/preview/storage_api.h
+++ b/villagesql/sdk/include/villagesql/preview/storage_api.h
@@ -58,11 +58,12 @@ inline thread_local char tl_error_msg[ERROR_MSG_SIZE] = {};
 
 // TODO(villagesql-indexing): remove this global pointer, instead passing the
 // capability in the API.
-// Module-level vtable pointer, written by CapReceiveSlot<StorageCapability>
-// during registration (via CapabilityTraits::vtable_destination).
-// The inline implementations below call through this pointer so that
-// extensions that don't use storage never emit references to vef_storage_*
-// symbols at link time.
+// Module-level vtable pointer. The server writes it via vtable_dest during
+// extension registration
+// (CapabilityTraits<StorageCapability>::vtable_destination returns &g_abi). The
+// inline implementations below call through this pointer so that extensions
+// that don't use storage never emit references to vef_storage_* symbols at link
+// time.
 inline const vef_preview_storage_t *g_abi = nullptr;
 }  // namespace detail
 

--- a/villagesql/sdk/include/villagesql/preview/storage_api.h
+++ b/villagesql/sdk/include/villagesql/preview/storage_api.h
@@ -35,11 +35,32 @@
 #include <vector>
 
 #include <villagesql/abi/preview/storage.h>
+#include <villagesql/detail/capability_hash.h>
+#include <villagesql/vsql/extension_builder.h>
 
 static_assert(VEF_STORAGE_SE_INTF_VERSION == 1,
               "This C++ wrapper supports ABI v1 only");
 
 namespace vsql::preview_storage {
+
+// C++ wrapper around vef_preview_storage_t.
+//
+// Usage:
+//   static auto g_storage = vsql::preview_storage::make_capability();
+//
+// Register with:
+//   make_extension().with<vsql::preview::preview_storage<g_storage>>()
+//
+class StorageCapability {
+ public:
+  static constexpr const char *kName = VEF_PREVIEW_STORAGE_NAME;
+
+  // Populated by the server via the required_capability receive callback.
+  // Public so that detail::storage_cap_receive<> can access it.
+  vef_preview_storage_t abi_{};
+};
+
+inline StorageCapability make_capability() { return StorageCapability{}; }
 
 // Error codes returned by storage ABI functions.
 enum class Error {
@@ -55,6 +76,21 @@ enum class Error {
 namespace detail {
 inline constexpr size_t ERROR_MSG_SIZE = 512;
 inline thread_local char tl_error_msg[ERROR_MSG_SIZE] = {};
+
+// TODO(villagesql-indexing): remove this global pointer, instead passing the
+// capability in the API.
+// Module-level vtable pointer, set by storage_cap_receive when the server
+// calls the required_capability receive callback during registration.
+// The inline implementations below call through this pointer so that
+// extensions that don't use storage never emit references to vef_storage_*
+// symbols at link time.
+inline const vef_preview_storage_t *g_abi = nullptr;
+
+template <StorageCapability *cap_ptr>
+void storage_cap_receive(void *vtable) {
+  cap_ptr->abi_ = *static_cast<vef_preview_storage_t *>(vtable);
+  g_abi = &cap_ptr->abi_;
+}
 }  // namespace detail
 
 // Returns a string_view over the error message from the last failed call on
@@ -402,9 +438,9 @@ inline MtrCtx::Ref MtrCtx::start() {
   uint32_t required_size = 0;
   uint32_t required_alignment = 0;
 
-  m_ref = vef_storage_mtr_start(m_buf, MAX_STACK_SIZE, &required_size,
-                                &required_alignment, detail::tl_error_msg,
-                                detail::ERROR_MSG_SIZE);
+  m_ref = detail::g_abi->mtr_start(m_buf, MAX_STACK_SIZE, &required_size,
+                                   &required_alignment, detail::tl_error_msg,
+                                   detail::ERROR_MSG_SIZE);
   if (m_ref != nullptr) {
     return m_ref;
   }
@@ -430,15 +466,15 @@ inline MtrCtx::Ref MtrCtx::start() {
       return nullptr;
     }
   }
-  m_ref = vef_storage_mtr_start(m_heap_buf, m_heap_size, &required_size,
-                                &required_alignment, detail::tl_error_msg,
-                                detail::ERROR_MSG_SIZE);
+  m_ref = detail::g_abi->mtr_start(m_heap_buf, m_heap_size, &required_size,
+                                   &required_alignment, detail::tl_error_msg,
+                                   detail::ERROR_MSG_SIZE);
   return m_ref;
 }
 
 inline void MtrCtx::commit() {
   if (m_ref != nullptr) {
-    vef_storage_mtr_commit(m_ref);
+    detail::g_abi->mtr_commit(m_ref);
     m_ref = nullptr;
   }
 }
@@ -453,9 +489,9 @@ inline MtrCtx::~MtrCtx() {
 // Segment inline implementations
 inline Error Segment::create(Space::Ref space, uint8_t num_segments,
                              TrxRef trx_ref, PageRef &root_page_ref) {
-  return static_cast<Error>(
-      vef_storage_segment_create(space, num_segments, trx_ref, &root_page_ref,
-                                 detail::tl_error_msg, detail::ERROR_MSG_SIZE));
+  return static_cast<Error>(detail::g_abi->segment_create(
+      space, num_segments, trx_ref, &root_page_ref, detail::tl_error_msg,
+      detail::ERROR_MSG_SIZE));
 }
 
 inline Segment::Ref Segment::get_header(Page &root_page, size_t seg_no) {
@@ -478,9 +514,9 @@ inline Segment::Ref Segment::get_header(Page &root_page, size_t seg_no) {
 
 inline Error Segment::drop(Space::Ref space, TrxRef trx_ref,
                            PageRef root_page_ref) {
-  return static_cast<Error>(
-      vef_storage_segment_drop(space, trx_ref, root_page_ref,
-                               detail::tl_error_msg, detail::ERROR_MSG_SIZE));
+  return static_cast<Error>(detail::g_abi->segment_drop(
+      space, trx_ref, root_page_ref, detail::tl_error_msg,
+      detail::ERROR_MSG_SIZE));
 }
 
 // Page inline implementations
@@ -498,7 +534,7 @@ inline bool Page::is_loaded(Latch latch) const {
 }
 
 inline uint32_t Page::get_size(Space::Ref space) {
-  return vef_storage_page_get_size(space);
+  return detail::g_abi->page_get_size(space);
 }
 
 inline uint32_t Page::data_size() const {
@@ -529,15 +565,17 @@ inline void Page::read_links(Ref &prev_page, Ref &next_page) const {
 inline void Page::write_prev_link(Ref prev_page, MtrCtx::Ref mtr) {
   assert(is_loaded());
   if (!is_loaded()) return;
-  vef_storage_page_write_integer(m_block, VEF_STORAGE_FIL_PAGE_PREV, prev_page,
-                                 VEF_STORAGE_PAGE_INT_4BYTES, mtr);
+  detail::g_abi->page_write_integer(m_block, VEF_STORAGE_FIL_PAGE_PREV,
+                                    prev_page, VEF_STORAGE_PAGE_INT_4BYTES,
+                                    mtr);
 }
 
 inline void Page::write_next_link(Ref next_page, MtrCtx::Ref mtr) {
   assert(is_loaded());
   if (!is_loaded()) return;
-  vef_storage_page_write_integer(m_block, VEF_STORAGE_FIL_PAGE_NEXT, next_page,
-                                 VEF_STORAGE_PAGE_INT_4BYTES, mtr);
+  detail::g_abi->page_write_integer(m_block, VEF_STORAGE_FIL_PAGE_NEXT,
+                                    next_page, VEF_STORAGE_PAGE_INT_4BYTES,
+                                    mtr);
 }
 
 inline void Page::write_links(Ref prev_page, Ref next_page, MtrCtx::Ref mtr) {
@@ -566,10 +604,10 @@ inline bool Page::data_bounds_check(Offset offset, size_t size) const {
 inline Error Page::load(Space::Ref space, Ref page, Latch latch,
                         MtrCtx::Ref mtr) {
   reset();
-  auto err = static_cast<Error>(
-      vef_storage_page_load(&m_block, &m_position, &m_data, &m_data_size, space,
-                            page, static_cast<vef_storage_latch_t>(latch), mtr,
-                            detail::tl_error_msg, detail::ERROR_MSG_SIZE));
+  auto err = static_cast<Error>(detail::g_abi->page_load(
+      &m_block, &m_position, &m_data, &m_data_size, space, page,
+      static_cast<vef_storage_latch_t>(latch), mtr, detail::tl_error_msg,
+      detail::ERROR_MSG_SIZE));
   if (err != Error::SUCCESS) {
     reset();
     return err;
@@ -581,7 +619,7 @@ inline Error Page::load(Space::Ref space, Ref page, Latch latch,
 
 inline Error Page::load_new(Segment::Ref segment_header, MtrCtx::Ref mtr) {
   reset();
-  auto err = static_cast<Error>(vef_storage_page_allocate_and_load(
+  auto err = static_cast<Error>(detail::g_abi->page_allocate_and_load(
       &m_block, &m_ref, &m_data, &m_data_size,
       static_cast<unsigned char *>(segment_header), mtr, detail::tl_error_msg,
       detail::ERROR_MSG_SIZE));
@@ -624,8 +662,8 @@ inline Error Page::latch(Latch &latch, MtrCtx::Ref mtr) {
 
   auto abi_latch = static_cast<vef_storage_latch_t>(latch);
   auto err = static_cast<Error>(
-      vef_storage_page_latch(m_block, m_position, abi_latch, mtr,
-                             detail::tl_error_msg, detail::ERROR_MSG_SIZE));
+      detail::g_abi->page_latch(m_block, m_position, abi_latch, mtr,
+                                detail::tl_error_msg, detail::ERROR_MSG_SIZE));
   if (err == Error::SUCCESS) {
     m_latch = latch;
   }
@@ -648,7 +686,7 @@ inline Error Page::release(MtrCtx::Ref mtr) {
     return Error::INVALID_ARGUMENT;
   }
 
-  auto err = static_cast<Error>(vef_storage_page_release(
+  auto err = static_cast<Error>(detail::g_abi->page_release(
       m_block, m_position, mtr, detail::tl_error_msg, detail::ERROR_MSG_SIZE));
   if (err != Error::SUCCESS) return err;
 
@@ -660,35 +698,35 @@ inline Error Page::release(MtrCtx::Ref mtr) {
 inline void Page::write_integer_1(Offset offset, uint8_t value,
                                   MtrCtx::Ref mtr) {
   if (!data_bounds_check(offset, 1)) return;
-  vef_storage_page_write_integer(m_block, offset, value,
-                                 VEF_STORAGE_PAGE_INT_1BYTE, mtr);
+  detail::g_abi->page_write_integer(m_block, offset, value,
+                                    VEF_STORAGE_PAGE_INT_1BYTE, mtr);
 }
 
 inline void Page::write_integer_2(Offset offset, uint16_t value,
                                   MtrCtx::Ref mtr) {
   if (!data_bounds_check(offset, 2)) return;
-  vef_storage_page_write_integer(m_block, offset, value,
-                                 VEF_STORAGE_PAGE_INT_2BYTES, mtr);
+  detail::g_abi->page_write_integer(m_block, offset, value,
+                                    VEF_STORAGE_PAGE_INT_2BYTES, mtr);
 }
 
 inline void Page::write_integer_4(Offset offset, uint32_t value,
                                   MtrCtx::Ref mtr) {
   if (!data_bounds_check(offset, 4)) return;
-  vef_storage_page_write_integer(m_block, offset, value,
-                                 VEF_STORAGE_PAGE_INT_4BYTES, mtr);
+  detail::g_abi->page_write_integer(m_block, offset, value,
+                                    VEF_STORAGE_PAGE_INT_4BYTES, mtr);
 }
 
 inline void Page::write_integer_8(Offset offset, uint64_t value,
                                   MtrCtx::Ref mtr) {
   if (!data_bounds_check(offset, 8)) return;
-  vef_storage_page_write_integer(m_block, offset, value,
-                                 VEF_STORAGE_PAGE_INT_8BYTES, mtr);
+  detail::g_abi->page_write_integer(m_block, offset, value,
+                                    VEF_STORAGE_PAGE_INT_8BYTES, mtr);
 }
 
 inline void Page::write_string(Offset offset, const unsigned char *str,
                                size_t len, MtrCtx::Ref mtr) {
   if (!data_bounds_check(offset, len)) return;
-  vef_storage_page_write_string(m_block, offset, str, len, mtr);
+  detail::g_abi->page_write_string(m_block, offset, str, len, mtr);
 }
 
 template <typename T>
@@ -866,4 +904,22 @@ struct Column {
 };
 
 }  // namespace vsql::preview_storage
+
+namespace vsql::preview {
+
+// Traits type for registering the storage capability via
+// .with<preview_storage<cap>>. Only available when this header is included.
+template <auto &cap>
+struct preview_storage {
+  template <typename EB>
+  static constexpr auto bind(EB builder) {
+    using Cap = vsql::preview_storage::StorageCapability;
+    return builder.required_capability(
+        {Cap::kName, &vsql::preview_storage::detail::storage_cap_receive<&cap>,
+         villagesql::detail::abi_type_hash<vef_preview_storage_t>()});
+  }
+};
+
+}  // namespace vsql::preview
+
 #endif  // VILLAGESQL_PREVIEW_STORAGE_API_H_

--- a/villagesql/sdk/include/villagesql/preview/storage_api.h
+++ b/villagesql/sdk/include/villagesql/preview/storage_api.h
@@ -41,20 +41,6 @@ static_assert(VEF_STORAGE_SE_INTF_VERSION == 1,
 
 namespace vsql::preview_storage {
 
-// C++ wrapper around vef_preview_storage_t.
-//
-// Usage:
-//   static auto STORAGE = vsql::preview_storage::StorageCapability();
-//
-// Register with:
-//   make_extension().with(STORAGE)
-//
-class StorageCapability {
- public:
-  static constexpr const char *kName = VEF_PREVIEW_STORAGE_NAME;
-  static constexpr uint32_t kAbiVersion = VEF_STORAGE_SE_INTF_VERSION_1;
-};
-
 // Error codes returned by storage ABI functions.
 enum class Error {
   SUCCESS = VEF_STORAGE_SUCCESS,

--- a/villagesql/sdk/include/villagesql/preview/storage_api.h
+++ b/villagesql/sdk/include/villagesql/preview/storage_api.h
@@ -35,8 +35,6 @@
 #include <vector>
 
 #include <villagesql/abi/preview/storage.h>
-#include <villagesql/detail/capability_hash.h>
-#include <villagesql/vsql/extension_builder.h>
 
 static_assert(VEF_STORAGE_SE_INTF_VERSION == 1,
               "This C++ wrapper supports ABI v1 only");
@@ -46,20 +44,15 @@ namespace vsql::preview_storage {
 // C++ wrapper around vef_preview_storage_t.
 //
 // Usage:
-//   static auto g_storage = vsql::preview_storage::make_capability();
+//   static auto STORAGE = vsql::preview_storage::StorageCapability();
 //
 // Register with:
-//   make_extension().with<vsql::preview::preview_storage<g_storage>>()
+//   make_extension().with(STORAGE)
 //
 class StorageCapability {
  public:
   static constexpr const char *kName = VEF_PREVIEW_STORAGE_NAME;
-  // vef_preview_storage_t has no version field; 0 means no minimum enforced.
-  static constexpr uint32_t kAbiVersion = 0;
-
-  // Populated by the server via the required_capability receive callback.
-  // Public so that detail::storage_cap_receive<> can access it.
-  vef_preview_storage_t abi_{};
+  static constexpr uint32_t kAbiVersion = VEF_STORAGE_SE_INTF_VERSION_1;
 };
 
 // Error codes returned by storage ABI functions.
@@ -79,19 +72,12 @@ inline thread_local char tl_error_msg[ERROR_MSG_SIZE] = {};
 
 // TODO(villagesql-indexing): remove this global pointer, instead passing the
 // capability in the API.
-// Module-level vtable pointer, set by storage_cap_receive when the server
-// calls the required_capability receive callback during registration.
+// Module-level vtable pointer, written by CapReceiveSlot<StorageCapability>
+// during registration (via CapabilityTraits::vtable_destination).
 // The inline implementations below call through this pointer so that
 // extensions that don't use storage never emit references to vef_storage_*
 // symbols at link time.
 inline const vef_preview_storage_t *g_abi = nullptr;
-
-template <StorageCapability *cap_ptr>
-bool storage_cap_receive(vef_capability_receive_arg_t *arg) {
-  cap_ptr->abi_ = *static_cast<vef_preview_storage_t *>(arg->vtable);
-  g_abi = &cap_ptr->abi_;
-  return true;
-}
 }  // namespace detail
 
 // Returns a string_view over the error message from the last failed call on
@@ -905,23 +891,5 @@ struct Column {
 };
 
 }  // namespace vsql::preview_storage
-
-namespace vsql::preview {
-
-// Traits type for registering the storage capability via
-// .with<preview_storage<Stg>>. Only available when this header is included.
-template <auto &Stg>
-struct preview_storage {
-  template <typename EB>
-  static constexpr auto bind(EB builder) {
-    using Cap = vsql::preview_storage::StorageCapability;
-    return builder.required_capability(vef_required_capability_t{
-        Cap::kName, &vsql::preview_storage::detail::storage_cap_receive<&Stg>,
-        villagesql::detail::abi_type_hash<vef_preview_storage_t>(),
-        Cap::kAbiVersion});
-  }
-};
-
-}  // namespace vsql::preview
 
 #endif  // VILLAGESQL_PREVIEW_STORAGE_API_H_

--- a/villagesql/sdk/include/villagesql/preview/storage_builder.h
+++ b/villagesql/sdk/include/villagesql/preview/storage_builder.h
@@ -30,6 +30,28 @@
 
 namespace vsql::preview_storage_builder {
 
+// Token that activates the storage API for this extension.
+//
+// Declare one static instance and pass it to make_extension().with() to
+// enable MtrCtx, Page, Segment, and Arena from storage_api.h. Without
+// this registration, calling any storage API function is undefined behavior.
+//
+// Usage:
+//   static auto STORAGE = vsql::preview_storage_builder::StorageCapability();
+//
+//   VSQL_EXTENSION_INIT {
+//     return make_extension()
+//         .with(STORAGE)
+//         ...
+//         .build();
+//   }
+//
+class StorageCapability {
+ public:
+  static constexpr const char *kName = VEF_PREVIEW_STORAGE_NAME;
+  static constexpr uint32_t kAbiVersion = VEF_STORAGE_SE_INTF_VERSION_1;
+};
+
 // =============================================================================
 // StorageBuilder<UserCtx>
 // =============================================================================
@@ -320,7 +342,7 @@ constexpr StorageBuilder<UserCtx> make_storage() {
 namespace vsql::detail {
 
 template <>
-struct CapabilityTraits<::vsql::preview_storage::StorageCapability> {
+struct CapabilityTraits<::vsql::preview_storage_builder::StorageCapability> {
   static constexpr const char *kName = VEF_PREVIEW_STORAGE_NAME;
   static constexpr uint32_t kAbiVersion = VEF_STORAGE_SE_INTF_VERSION_1;
   using AbiType = vef_preview_storage_t;
@@ -329,7 +351,7 @@ struct CapabilityTraits<::vsql::preview_storage::StorageCapability> {
   // inline implementations (MtrCtx, Page, Segment) can call through it
   // without holding a reference to the StorageCapability instance.
   static void *vtable_destination(
-      ::vsql::preview_storage::StorageCapability * /*p*/) noexcept {
+      ::vsql::preview_storage_builder::StorageCapability * /*p*/) noexcept {
     return static_cast<void *>(&::vsql::preview_storage::detail::g_abi);
   }
 };

--- a/villagesql/sdk/include/villagesql/preview/storage_builder.h
+++ b/villagesql/sdk/include/villagesql/preview/storage_builder.h
@@ -26,6 +26,7 @@
 
 #include <villagesql/abi/preview/storage.h>
 #include <villagesql/preview/storage_api.h>
+#include <villagesql/vsql/capability_traits.h>
 
 namespace vsql::preview_storage_builder {
 
@@ -315,5 +316,24 @@ constexpr StorageBuilder<UserCtx> make_storage() {
 }
 
 }  // namespace vsql::preview_storage_builder
+
+namespace vsql::detail {
+
+template <>
+struct CapabilityTraits<::vsql::preview_storage::StorageCapability> {
+  static constexpr const char *kName = VEF_PREVIEW_STORAGE_NAME;
+  static constexpr uint32_t kAbiVersion = VEF_STORAGE_SE_INTF_VERSION_1;
+  using AbiType = vef_preview_storage_t;
+
+  // Write the vtable pointer into the module-level g_abi so that the
+  // inline implementations (MtrCtx, Page, Segment) can call through it
+  // without holding a reference to the StorageCapability instance.
+  static void *vtable_destination(
+      ::vsql::preview_storage::StorageCapability * /*p*/) noexcept {
+    return static_cast<void *>(&::vsql::preview_storage::detail::g_abi);
+  }
+};
+
+}  // namespace vsql::detail
 
 #endif  // VILLAGESQL_PREVIEW_STORAGE_BUILDER_H

--- a/villagesql/services/CMakeLists.txt
+++ b/villagesql/services/CMakeLists.txt
@@ -17,6 +17,7 @@ SET(VILLAGESQL_SERVICES_SOURCES
   capability_registry.cc
   preview/keyring.cc
   preview/ping.cc
+  preview/storage.cc
   status_vars.cc
   sys_vars.cc
 )

--- a/villagesql/services/capability_registry.cc
+++ b/villagesql/services/capability_registry.cc
@@ -20,6 +20,7 @@
 #include "villagesql/sdk/include/villagesql/detail/capability_hash.h"
 #include "villagesql/services/preview/keyring.h"
 #include "villagesql/services/preview/ping.h"
+#include "villagesql/services/preview/storage.h"
 
 bool vsql_allow_preview_extensions = false;
 
@@ -92,6 +93,9 @@ void register_builtin_capabilities() {
   register_capability(
       VEF_PREVIEW_KEYRING_NAME, preview_keyring_vtable(),
       villagesql::detail::abi_type_hash<vef_preview_keyring_t>());
+  register_capability(
+      VEF_PREVIEW_STORAGE_NAME, preview_storage_vtable(),
+      villagesql::detail::abi_type_hash<vef_preview_storage_t>());
   // TODO(villagesql-beta): register "vsql::thread_worker" and "vsql::sql" here
 }
 

--- a/villagesql/services/preview/storage.cc
+++ b/villagesql/services/preview/storage.cc
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+#include "villagesql/services/preview/storage.h"
+#include "villagesql/sdk/include/villagesql/abi/preview/storage.h"
+
+namespace villagesql::services {
+
+namespace {
+
+vef_preview_storage_t g_storage_vtable{
+    vef_storage_mtr_start,         vef_storage_mtr_commit,
+    vef_storage_segment_create,    vef_storage_segment_drop,
+    vef_storage_page_load,         vef_storage_page_allocate_and_load,
+    vef_storage_page_latch,        vef_storage_page_release,
+    vef_storage_page_get_size,     vef_storage_page_write_integer,
+    vef_storage_page_write_string,
+};
+
+}  // namespace
+
+vef_preview_storage_t *preview_storage_vtable() { return &g_storage_vtable; }
+
+}  // namespace villagesql::services

--- a/villagesql/services/preview/storage.cc
+++ b/villagesql/services/preview/storage.cc
@@ -21,11 +21,17 @@ namespace villagesql::services {
 namespace {
 
 vef_preview_storage_t g_storage_vtable{
-    vef_storage_mtr_start,         vef_storage_mtr_commit,
-    vef_storage_segment_create,    vef_storage_segment_drop,
-    vef_storage_page_load,         vef_storage_page_allocate_and_load,
-    vef_storage_page_latch,        vef_storage_page_release,
-    vef_storage_page_get_size,     vef_storage_page_write_integer,
+    VEF_STORAGE_SE_INTF_VERSION,
+    vef_storage_mtr_start,
+    vef_storage_mtr_commit,
+    vef_storage_segment_create,
+    vef_storage_segment_drop,
+    vef_storage_page_load,
+    vef_storage_page_allocate_and_load,
+    vef_storage_page_latch,
+    vef_storage_page_release,
+    vef_storage_page_get_size,
+    vef_storage_page_write_integer,
     vef_storage_page_write_string,
 };
 

--- a/villagesql/services/preview/storage.h
+++ b/villagesql/services/preview/storage.h
@@ -1,0 +1,29 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+#ifndef VILLAGESQL_SERVICES_PREVIEW_STORAGE_H
+#define VILLAGESQL_SERVICES_PREVIEW_STORAGE_H
+
+#include "villagesql/sdk/include/villagesql/abi/preview/storage.h"
+
+namespace villagesql::services {
+
+// Returns the server-side vtable for the "vsql::preview::storage" preview
+// capability.
+vef_preview_storage_t *preview_storage_vtable();
+
+}  // namespace villagesql::services
+
+#endif  // VILLAGESQL_SERVICES_PREVIEW_STORAGE_H

--- a/villagesql/test-extensions/vsql-storage-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-storage-test/src/extension.cc
@@ -330,6 +330,4 @@ constexpr auto STORED_INT =
 
 using namespace vsql;
 
-VEF_GENERATE_ENTRY_POINTS(make_extension()
-                              .with<vsql::preview::preview_storage<STORAGE>>()
-                              .type(STORED_INT))
+VEF_GENERATE_ENTRY_POINTS(make_extension().with(STORAGE).type(STORED_INT))

--- a/villagesql/test-extensions/vsql-storage-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-storage-test/src/extension.cc
@@ -50,6 +50,7 @@
 
 namespace storage = vsql::preview_storage;
 using vsql::preview_storage_builder::make_storage;
+using vsql::preview_storage_builder::StorageCapability;
 
 // Per-column user context. Populated during create/load and used by every
 // subsequent storage call for that column.
@@ -301,7 +302,7 @@ bool stored_int_purge(Ctx * /*ctx*/, storage::MtrCtx::Ref /*mctx*/,
 // Type and extension registration
 // ============================================================================
 
-static auto STORAGE = storage::StorageCapability();
+static auto STORAGE = StorageCapability();
 
 static constexpr vef_type_storage_intf_t kStoredIntStorageIntf =
     make_storage<StoredIntCtx>()

--- a/villagesql/test-extensions/vsql-storage-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-storage-test/src/extension.cc
@@ -301,6 +301,8 @@ bool stored_int_purge(Ctx * /*ctx*/, storage::MtrCtx::Ref /*mctx*/,
 // Type and extension registration
 // ============================================================================
 
+static auto STORAGE = storage::make_capability();
+
 static constexpr vef_type_storage_intf_t kStoredIntStorageIntf =
     make_storage<StoredIntCtx>()
         .create<&stored_int_create>()
@@ -328,4 +330,6 @@ constexpr auto STORED_INT =
 
 using namespace vsql;
 
-VEF_GENERATE_ENTRY_POINTS(make_extension().type(STORED_INT))
+VEF_GENERATE_ENTRY_POINTS(make_extension()
+                              .with<vsql::preview::preview_storage<STORAGE>>()
+                              .type(STORED_INT))

--- a/villagesql/test-extensions/vsql-storage-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-storage-test/src/extension.cc
@@ -301,7 +301,7 @@ bool stored_int_purge(Ctx * /*ctx*/, storage::MtrCtx::Ref /*mctx*/,
 // Type and extension registration
 // ============================================================================
 
-static auto STORAGE = storage::make_capability();
+static auto STORAGE = storage::StorageCapability();
 
 static constexpr vef_type_storage_intf_t kStoredIntStorageIntf =
     make_storage<StoredIntCtx>()


### PR DESCRIPTION
Make a capability for storage.  The API is still going through a global vtable pointer.  A future PR will reorg the code to get rid of this.