### PR TITLE
ci: always report status on doc-only PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,8 @@ on:
       - 'Docs/**'
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - '**.md'
-      - 'Docs/**'
+    # No paths-ignore here — the job must always run on PRs so the required
+    # status check is always reported. Docs-only detection happens inside the job.
 
 # Cancel superseded runs on the same PR branch. main pushes are not cancelled
 # so each merged commit gets its own pass.
@@ -38,24 +37,45 @@ jobs:
         fetch-depth: 50
         path: source
 
+    - name: Check if build is needed
+      id: check-paths
+      working-directory: ./source
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          if echo "$CHANGED" | grep -qvE '\.(md)$|^Docs/'; then
+            echo "needed=true" >> $GITHUB_OUTPUT
+          else
+            echo "All changed files are documentation — skipping build"
+            echo "needed=false" >> $GITHUB_OUTPUT
+          fi
+        else
+          echo "needed=true" >> $GITHUB_OUTPUT
+        fi
+
     - name: Setup VillageSQL build environment
+      if: steps.check-paths.outputs.needed == 'true'
       uses: ./source/.github/actions/setup-villagesql-build
       with:
         cache-key-prefix: build
 
     - name: Build VillageSQL
+      if: steps.check-paths.outputs.needed == 'true'
       working-directory: ./source
       run: ./scripts/build-ci.sh
       env:
         PARALLEL_JOBS: 16
 
     - name: Evict stale ccache entries
+      if: steps.check-paths.outputs.needed == 'true'
       run: ccache --evict-older-than 3600s
 
     - name: Show ccache statistics
+      if: steps.check-paths.outputs.needed == 'true'
       run: ccache -s
 
     - name: Run tests
+      if: steps.check-paths.outputs.needed == 'true'
       uses: ./source/.github/actions/run-tests
       with:
         artifact-name: test-logs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,8 @@ jobs:
       working-directory: ./source
       run: |
         if [ "${{ github.event_name }}" = "pull_request" ]; then
-          CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          git fetch origin ${{ github.base_ref }} --depth=50
+          CHANGED=$(git diff --name-only FETCH_HEAD...HEAD)
           if echo "$CHANGED" | grep -qvE '\.(md)$|^Docs/'; then
             echo "needed=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Description
paths-ignore at the trigger level prevents the workflow from firing on docs-only PRs, leaving the required check - "Build and Test VillageSQL" - stuck at "Expected — Waiting for status to be reported" instead of "Check passed."

Removes paths-ignore from pull_requests. Adds a "Check if build is needed" step to detect doc-only changes and gate all expensive steps on the result. The push trigger keeps its paths-ignore. This (overly complicated looking) approach is listed by Claude and Gemini as a "common workaround for GHA limitations."
AI=CLAUDE

## Related Issue
#440 introduced it
#465 exposed the issue

## How was this tested?
Will test itself when this PR merges and then I will send an empty commit to #465 to retrigger stuck ci.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
