### PR TITLE
Custom Index: Add system tables

### DIFF
--- a/mysql-test/r/partition_innodb_tablespace.result
+++ b/mysql-test/r/partition_innodb_tablespace.result
@@ -42,6 +42,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1#p#p0	test/t1#p#p0	97	5	Dynamic	0	Single
 test/t1#p#p1	test/t1#p#p1	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -54,6 +56,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 test/t1#p#p0	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alternate_dir/data/test/t1#p#p0.ibd
 test/t1#p#p1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alternate_dir/data2/test/t1#p#p1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -66,6 +70,8 @@ mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATA
 test/t1#p#p0	TABLESPACE	InnoDB	NORMAL	test/t1#p#p0	MYSQL_TMP_DIR/alternate_dir/data/test/t1#p#p0.ibd
 test/t1#p#p1	TABLESPACE	InnoDB	NORMAL	test/t1#p#p1	MYSQL_TMP_DIR/alternate_dir/data2/test/t1#p#p1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -102,6 +108,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1#p#p0	test/t1#p#p0	97	5	Dynamic	0	Single
 test/t1#p#p1	test/t1#p#p1	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -114,6 +122,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 test/t1#p#p0	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alternate_dir/data/test/t1#p#p0.ibd
 test/t1#p#p1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alternate_dir/data2/test/t1#p#p1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -126,6 +136,8 @@ mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATA
 test/t1#p#p0	TABLESPACE	InnoDB	NORMAL	test/t1#p#p0	MYSQL_TMP_DIR/alternate_dir/data/test/t1#p#p0.ibd
 test/t1#p#p1	TABLESPACE	InnoDB	NORMAL	test/t1#p#p1	MYSQL_TMP_DIR/alternate_dir/data2/test/t1#p#p1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -151,6 +163,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t11#p#p0	test/t11#p#p0	97	5	Dynamic	0	Single
 test/t11#p#p1	test/t11#p#p1	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -163,6 +177,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 test/t11#p#p0	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alternate_dir/data/test/t11#p#p0.ibd
 test/t11#p#p1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alternate_dir/data2/test/t11#p#p1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -175,6 +191,8 @@ mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATA
 test/t11#p#p0	TABLESPACE	InnoDB	NORMAL	test/t11#p#p0	MYSQL_TMP_DIR/alternate_dir/data/test/t11#p#p0.ibd
 test/t11#p#p1	TABLESPACE	InnoDB	NORMAL	test/t11#p#p1	MYSQL_TMP_DIR/alternate_dir/data2/test/t11#p#p1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -209,6 +227,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1#p#p0	test/t1#p#p0	97	5	Dynamic	0	Single
 test/t1#p#p1	test/t1#p#p1	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -221,6 +241,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 test/t1#p#p0	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alternate_dir/data/test/t1#p#p0.ibd
 test/t1#p#p1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alternate_dir/data2/test/t1#p#p1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -233,6 +255,8 @@ mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATA
 test/t1#p#p0	TABLESPACE	InnoDB	NORMAL	test/t1#p#p0	MYSQL_TMP_DIR/alternate_dir/data/test/t1#p#p0.ibd
 test/t1#p#p1	TABLESPACE	InnoDB	NORMAL	test/t1#p#p1	MYSQL_TMP_DIR/alternate_dir/data2/test/t1#p#p1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -301,6 +325,8 @@ test/t1#p#p1#sp#s3	test/t1#p#p1#sp#s3	97	5	Dynamic	0	Single
 test/t1#p#p2#sp#s4	test/t1#p#p2#sp#s4	97	5	Dynamic	0	Single
 test/t1#p#p2#sp#s5	test/t1#p#p2#sp#s5	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -317,6 +343,8 @@ test/t1#p#p1#sp#s3	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alternate_dir/data
 test/t1#p#p2#sp#s4	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alternate_dir/data/test/t1#p#p2#sp#s4.ibd
 test/t1#p#p2#sp#s5	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alternate_dir/data2/test/t1#p#p2#sp#s5.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -333,6 +361,8 @@ test/t1#p#p1#sp#s3	TABLESPACE	InnoDB	NORMAL	test/t1#p#p1#sp#s3	MYSQL_TMP_DIR/alt
 test/t1#p#p2#sp#s4	TABLESPACE	InnoDB	NORMAL	test/t1#p#p2#sp#s4	MYSQL_TMP_DIR/alternate_dir/data/test/t1#p#p2#sp#s4.ibd
 test/t1#p#p2#sp#s5	TABLESPACE	InnoDB	NORMAL	test/t1#p#p2#sp#s5	MYSQL_TMP_DIR/alternate_dir/data2/test/t1#p#p2#sp#s5.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -403,6 +433,8 @@ test/t1#p#p1#sp#s3	test/t1#p#p1#sp#s3	97	5	Dynamic	0	Single
 test/t1#p#p2#sp#s4	test/t1#p#p2#sp#s4	97	5	Dynamic	0	Single
 test/t1#p#p2#sp#s5	test/t1#p#p2#sp#s5	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -419,6 +451,8 @@ test/t1#p#p1#sp#s3	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alternate_dir/data
 test/t1#p#p2#sp#s4	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alternate_dir/data/test/t1#p#p2#sp#s4.ibd
 test/t1#p#p2#sp#s5	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alternate_dir/data2/test/t1#p#p2#sp#s5.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -435,6 +469,8 @@ test/t1#p#p1#sp#s3	TABLESPACE	InnoDB	NORMAL	test/t1#p#p1#sp#s3	MYSQL_TMP_DIR/alt
 test/t1#p#p2#sp#s4	TABLESPACE	InnoDB	NORMAL	test/t1#p#p2#sp#s4	MYSQL_TMP_DIR/alternate_dir/data/test/t1#p#p2#sp#s4.ibd
 test/t1#p#p2#sp#s5	TABLESPACE	InnoDB	NORMAL	test/t1#p#p2#sp#s5	MYSQL_TMP_DIR/alternate_dir/data2/test/t1#p#p2#sp#s5.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -570,6 +606,8 @@ test/t1#p#p0	test/t1#p#p0	97	4	Dynamic	0	Single
 test/t_file_per_table_off	innodb_system	161	5	Dynamic	0	System
 test/t_file_per_table_on	test/t_file_per_table_on	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -582,6 +620,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 test/t1#p#p0	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alternate_dir/data_part/test/t1#p#p0.ibd
 test/t_file_per_table_on	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t_file_per_table_on.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -594,6 +634,8 @@ mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATA
 test/t1#p#p0	TABLESPACE	InnoDB	NORMAL	test/t1#p#p0	MYSQL_TMP_DIR/alternate_dir/data_part/test/t1#p#p0.ibd
 test/t_file_per_table_on	TABLESPACE	InnoDB	NORMAL	test/t_file_per_table_on	MYSQLD_DATADIR/test/t_file_per_table_on.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd

--- a/mysql-test/suite/innodb/r/case_insensitive_fs.result
+++ b/mysql-test/suite/innodb/r/case_insensitive_fs.result
@@ -35,6 +35,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 test/t1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/Known_Dir/test/t1.ibd
 ts1	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/Known_Dir/ts1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -47,6 +49,8 @@ mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATA
 test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQL_TMP_DIR/Known_Dir/test/t1.ibd
 ts1	TABLESPACE	InnoDB	NORMAL	ts1	MYSQL_TMP_DIR/Known_Dir/ts1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -82,6 +86,8 @@ ts1	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/Known_Dir/ts1.ibd
 ts2	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/KNOWN_DIR/ts2.ibd
 ts3	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/known_dir/ts3.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -98,6 +104,8 @@ ts1	TABLESPACE	InnoDB	NORMAL	ts1	MYSQL_TMP_DIR/Known_Dir/ts1.ibd
 ts2	TABLESPACE	InnoDB	NORMAL	ts2	MYSQL_TMP_DIR/KNOWN_DIR/ts2.ibd
 ts3	TABLESPACE	InnoDB	NORMAL	ts3	MYSQL_TMP_DIR/known_dir/ts3.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd

--- a/mysql-test/suite/innodb/r/choose_tbsp_location-discard.result
+++ b/mysql-test/suite/innodb/r/choose_tbsp_location-discard.result
@@ -209,6 +209,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t5980	test/t5980	97	6	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -220,6 +222,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t5980	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t5980.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -231,6 +235,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t5980	TABLESPACE	InnoDB	NORMAL	test/t5980	MYSQL_TMP_DIR/alt_dir/test/t5980.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -245,6 +251,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -255,6 +263,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -265,6 +275,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -466,6 +478,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t5980	test/t5980	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -477,6 +491,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t5980	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t5980.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -488,6 +504,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t5980	TABLESPACE	InnoDB	NORMAL	test/t5980	MYSQL_TMP_DIR/alt_dir/test/t5980.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -553,6 +571,8 @@ test/t5980b	test/t5980b	97	5	Dynamic	0	Single
 test/t5980c	test/t5980c	33	5	Dynamic	0	Single
 test/t5980d	test/t5980d	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -567,6 +587,8 @@ test/t5980b	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t5980b.ibd
 test/t5980c	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t5980c.ibd
 test/t5980d	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t5980d.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -581,6 +603,8 @@ test/t5980b	TABLESPACE	InnoDB	NORMAL	test/t5980b	MYSQL_TMP_DIR/alt_dir/test/t598
 test/t5980c	TABLESPACE	InnoDB	NORMAL	test/t5980c	MYSQLD_DATADIR/test/t5980c.ibd
 test/t5980d	TABLESPACE	InnoDB	NORMAL	test/t5980d	MYSQL_TMP_DIR/alt_dir/test/t5980d.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -635,6 +659,8 @@ test/t5980b	test/t5980b	97	5	Dynamic	0	Single
 test/t5980c	test/t5980c	33	5	Dynamic	0	Single
 test/t5980d	test/t5980d	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -649,6 +675,8 @@ test/t5980b	Single	DEFAULT	0	0	0	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t5980b.ibd
 test/t5980c	Single	DEFAULT	0	0	0	Dynamic	MYSQLD_DATADIR/test/t5980c.ibd
 test/t5980d	Single	DEFAULT	0	0	0	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t5980d.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -659,6 +687,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -727,6 +757,8 @@ test/t5980bb	test/t5980bb	97	5	Dynamic	0	Single
 test/t5980c	test/t5980c	33	5	Dynamic	0	Single
 test/t5980d	test/t5980d	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -741,6 +773,8 @@ test/t5980bb	Single	DEFAULT	0	0	0	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t5980bb.ibd
 test/t5980c	Single	DEFAULT	0	0	0	Dynamic	MYSQLD_DATADIR/test/t5980c.ibd
 test/t5980d	Single	DEFAULT	0	0	0	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t5980d.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -751,6 +785,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -817,6 +853,8 @@ test/t5980bb	test/t5980bb	97	5	Dynamic	0	Single
 test/t5980c	test/t5980c	33	5	Dynamic	0	Single
 test/t5980d	test/t5980d	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -831,6 +869,8 @@ test/t5980bb	Single	DEFAULT	0	0	0	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t5980bb.ibd
 test/t5980c	Single	DEFAULT	0	0	0	Dynamic	MYSQLD_DATADIR/test/t5980c.ibd
 test/t5980d	Single	DEFAULT	0	0	0	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t5980d.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -841,6 +881,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -890,6 +932,8 @@ test/t5980b	test/t5980b	97	5	Dynamic	0	Single
 test/t5980c	test/t5980c	33	5	Dynamic	0	Single
 test/t5980d	test/t5980d	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -904,6 +948,8 @@ test/t5980b	Single	DEFAULT	0	0	0	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t5980b.ibd
 test/t5980c	Single	DEFAULT	0	0	0	Dynamic	MYSQLD_DATADIR/test/t5980c.ibd
 test/t5980d	Single	DEFAULT	0	0	0	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t5980d.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -914,6 +960,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1016,6 +1064,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1026,6 +1076,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1036,6 +1088,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd

--- a/mysql-test/suite/innodb/r/create_tablespace.result
+++ b/mysql-test/suite/innodb/r/create_tablespace.result
@@ -160,6 +160,8 @@ s_Cöŀumň	General	DEFAULT	0	1	1	Any	s_utf8_a.ibd
 s_cöĿǖmň	General	DEFAULT	0	1	1	Any	s_utf8_b.ibd
 s_வணக்கம்	General	DEFAULT	0	1	1	Any	ஆவணம்.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -175,6 +177,8 @@ s_Cöŀumň	TABLESPACE	InnoDB	NORMAL	s_Cöŀumň	MYSQLD_DATADIR/s_utf8_a.ibd
 s_cöĿǖmň	TABLESPACE	InnoDB	NORMAL	s_cöĿǖmň	MYSQLD_DATADIR/s_utf8_b.ibd
 s_வணக்கம்	TABLESPACE	InnoDB	NORMAL	s_வணக்கம்	MYSQLD_DATADIR/ஆவணம்.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -190,6 +194,8 @@ test/t_utf8_1	s_Cöŀumň	161	5	Dynamic	0	General
 test/t_utf8_2	s_cöĿǖmň	161	5	Dynamic	0	General
 test/t_utf8_3	s_வணக்கம்	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -346,6 +352,8 @@ s2_remote	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/s2_#_dir/s2.ibd
 s4_def	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/tablespace.ibd/s4.ibd
 s_def	General	DEFAULT	0	1	1	Any	s_def.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -361,6 +369,8 @@ s2_remote	TABLESPACE	InnoDB	NORMAL	s2_remote	MYSQL_TMP_DIR/s2_#_dir/s2.ibd
 s4_def	TABLESPACE	InnoDB	NORMAL	s4_def	MYSQL_TMP_DIR/tablespace.ibd/s4.ibd
 s_def	TABLESPACE	InnoDB	NORMAL	s_def	MYSQLD_DATADIR/s_def.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -403,6 +413,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_single	test/t_single	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -415,6 +427,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 s_def	General	DEFAULT	0	1	1	Any	s_def.ibd
 test/t_single	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t_single.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -427,6 +441,8 @@ mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATA
 s_def	TABLESPACE	InnoDB	NORMAL	s_def	MYSQLD_DATADIR/s_def.ibd
 test/t_single	TABLESPACE	InnoDB	NORMAL	test/t_single	MYSQLD_DATADIR/test/t_single.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -475,6 +491,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_def	General	DEFAULT	0	1	1	Any	s_def.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -486,6 +504,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_def	TABLESPACE	InnoDB	NORMAL	s_def	MYSQLD_DATADIR/s_def.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -518,6 +538,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_def	General	DEFAULT	0	1	1	Any	s_def.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -529,6 +551,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_def	TABLESPACE	InnoDB	NORMAL	s_def	MYSQLD_DATADIR/s_def.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -542,6 +566,8 @@ test/t_def_in_def	s_def	161	5	Dynamic	0	General
 test/t_dyn_in_def	s_def	161	5	Dynamic	0	General
 test/t_red_in_def	s_def	128	5	Redundant	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -575,6 +601,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/test@002ft_def_in_def	s_def	161	5	Dynamic	0	General
 test/t_def_in_def	s_def	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -586,6 +614,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_def	General	DEFAULT	0	1	1	Any	s_def.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -597,6 +627,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_def	TABLESPACE	InnoDB	NORMAL	s_def	MYSQLD_DATADIR/s_def.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -656,6 +688,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 s_def	General	DEFAULT	0	1	1	Any	s_def.ibd
 test/s_single	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/s_single.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -668,6 +702,8 @@ mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATA
 s_def	TABLESPACE	InnoDB	NORMAL	s_def	MYSQLD_DATADIR/s_def.ibd
 test/s_single	TABLESPACE	InnoDB	NORMAL	test/s_single	MYSQLD_DATADIR/test/s_single.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -743,6 +779,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_def	General	DEFAULT	0	1	1	Any	s_def.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -754,6 +792,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_def	TABLESPACE	InnoDB	NORMAL	s_def	MYSQLD_DATADIR/s_def.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -766,6 +806,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/test@002ft_def_in_def	s_def	161	5	Dynamic	0	General
 test/t_def_in_def	s_def	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -791,6 +833,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_def	General	DEFAULT	0	1	1	Any	s_def.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -802,6 +846,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_def	TABLESPACE	InnoDB	NORMAL	s_def	MYSQLD_DATADIR/s_def.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -815,6 +861,8 @@ test/t_com_in_system	innodb_system	129	5	Compact	0	System
 test/t_dyn_in_system	innodb_system	161	5	Dynamic	0	System
 test/t_red_in_system	innodb_system	128	5	Redundant	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -849,6 +897,8 @@ test/t_def_as_remote	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/test/t_def_as_re
 test/t_dyn_as_file_per_table	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t_dyn_as_file_per_table.ibd
 test/t_red_as_file_per_table	Single	DEFAULT	0	1	1	Compact or Redundant	MYSQLD_DATADIR/test/t_red_as_file_per_table.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -864,6 +914,8 @@ test/t_def_as_remote	TABLESPACE	InnoDB	NORMAL	test/t_def_as_remote	MYSQL_TMP_DIR
 test/t_dyn_as_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_dyn_as_file_per_table	MYSQLD_DATADIR/test/t_dyn_as_file_per_table.ibd
 test/t_red_as_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_red_as_file_per_table	MYSQLD_DATADIR/test/t_red_as_file_per_table.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -878,6 +930,8 @@ test/t_def_as_remote	test/t_def_as_remote	97	5	Dynamic	0	Single
 test/t_dyn_as_file_per_table	test/t_dyn_as_file_per_table	33	5	Dynamic	0	Single
 test/t_red_as_file_per_table	test/t_red_as_file_per_table	0	5	Redundant	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -929,6 +983,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 s_def	General	DEFAULT	0	1	1	Any	s_def.ibd
 s_multiple	General	DEFAULT	0	1	1	Any	multiple.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -941,6 +997,8 @@ mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATA
 s_def	TABLESPACE	InnoDB	NORMAL	s_def	MYSQLD_DATADIR/s_def.ibd
 s_multiple	TABLESPACE	InnoDB	NORMAL	s_multiple	MYSQLD_DATADIR/multiple.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -955,6 +1013,8 @@ test/t_def_was_remote	s_multiple	161	5	Dynamic	0	General
 test/t_dyn_was_file_per_table	s_multiple	161	5	Dynamic	0	General
 test/t_red_was_file_per_table	s_multiple	128	5	Redundant	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -986,6 +1046,8 @@ test/t_def_to_file_per_table	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t_
 test/t_dyn_to_file_per_table	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t_dyn_to_file_per_table.ibd
 test/t_red_to_file_per_table	Single	DEFAULT	0	1	1	Compact or Redundant	MYSQLD_DATADIR/test/t_red_to_file_per_table.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1002,6 +1064,8 @@ test/t_def_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_def_to_file_per_tab
 test/t_dyn_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_dyn_to_file_per_table	MYSQLD_DATADIR/test/t_dyn_to_file_per_table.ibd
 test/t_red_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_red_to_file_per_table	MYSQLD_DATADIR/test/t_red_to_file_per_table.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1016,6 +1080,8 @@ test/t_def_to_file_per_table	test/t_def_to_file_per_table	33	5	Dynamic	0	Single
 test/t_dyn_to_file_per_table	test/t_dyn_to_file_per_table	33	5	Dynamic	0	Single
 test/t_red_to_file_per_table	test/t_red_to_file_per_table	0	5	Redundant	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1133,6 +1199,8 @@ s_ignore1	General	DEFAULT	0	1	1	Any	s_ignore1.ibd
 s_ignore2	General	DEFAULT	0	1	1	Any	s_ignore2.ibd
 s_ignore3	General	DEFAULT	0	1	1	Any	s_ignore3.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1147,6 +1215,8 @@ s_ignore1	TABLESPACE	InnoDB	NORMAL	s_ignore1	MYSQLD_DATADIR/s_ignore1.ibd
 s_ignore2	TABLESPACE	InnoDB	NORMAL	s_ignore2	MYSQLD_DATADIR/s_ignore2.ibd
 s_ignore3	TABLESPACE	InnoDB	NORMAL	s_ignore3	MYSQLD_DATADIR/s_ignore3.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1182,6 +1252,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_in_def	s_def	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1343,6 +1415,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t	s_def	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1370,6 +1444,8 @@ s_alt1	General	DEFAULT	0	1	1	Any	s_alt1.ibd
 s_alt2	General	DEFAULT	0	1	1	Any	s_alt2.ibd
 s_def	General	DEFAULT	0	1	1	Any	s_def.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1383,6 +1459,8 @@ s_alt1	TABLESPACE	InnoDB	NORMAL	s_alt1	MYSQLD_DATADIR/s_alt1.ibd
 s_alt2	TABLESPACE	InnoDB	NORMAL	s_alt2	MYSQLD_DATADIR/s_alt2.ibd
 s_def	TABLESPACE	InnoDB	NORMAL	s_def	MYSQLD_DATADIR/s_def.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1405,6 +1483,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_nomad	s_alt1	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1427,6 +1507,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_nomad	s_alt2	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1447,6 +1529,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_nomad	s_def	161	4	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1460,6 +1544,8 @@ s_alt1	General	DEFAULT	0	1	1	Any	s_alt1.ibd
 s_alt2	General	DEFAULT	0	1	1	Any	s_alt2.ibd
 s_def	General	DEFAULT	0	1	1	Any	s_def.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1473,6 +1559,8 @@ s_alt1	TABLESPACE	InnoDB	NORMAL	s_alt1	MYSQLD_DATADIR/s_alt1.ibd
 s_alt2	TABLESPACE	InnoDB	NORMAL	s_alt2	MYSQLD_DATADIR/s_alt2.ibd
 s_def	TABLESPACE	InnoDB	NORMAL	s_def	MYSQLD_DATADIR/s_def.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1503,6 +1591,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_system	innodb_system	33	5	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1523,6 +1613,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_system	s_def	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1543,6 +1635,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_system	innodb_system	161	5	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1629,6 +1723,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_still_system	innodb_system	161	5	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1714,6 +1810,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_single	test/t_single	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1734,6 +1832,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_single	s_def	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1769,6 +1869,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_innodb	s_def	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1805,6 +1907,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_innodb	s_def	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1832,6 +1936,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_dyn_in_s_def	s_def	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1852,6 +1958,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1873,6 +1981,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_dyn_in_s_def	s_def	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1893,6 +2003,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1921,6 +2033,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_dyn_in_s_def	s_def	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1951,6 +2065,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_nomad	s_short_life	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1971,6 +2087,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1995,6 +2113,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_nomad	s_shorter_life	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -2041,6 +2161,8 @@ test1/t_general	s_def	161	5	Dynamic	0	General
 test1/t_single	test1/t_single	33	5	Dynamic	0	Single
 test1/t_system	innodb_system	33	5	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -2055,6 +2177,8 @@ s_empty1	General	DEFAULT	0	1	1	Any	s_empty1.ibd
 test/t_single	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t_single.ibd
 test1/t_single	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test1/t_single.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -2069,6 +2193,8 @@ s_empty1	TABLESPACE	InnoDB	NORMAL	s_empty1	MYSQLD_DATADIR/s_empty1.ibd
 test/t_single	TABLESPACE	InnoDB	NORMAL	test/t_single	MYSQLD_DATADIR/test/t_single.ibd
 test1/t_single	TABLESPACE	InnoDB	NORMAL	test1/t_single	MYSQLD_DATADIR/test1/t_single.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -2083,6 +2209,8 @@ test/t_general	s_def	161	5	Dynamic	0	General
 test/t_single	test/t_single	33	5	Dynamic	0	Single
 test/t_system	innodb_system	33	5	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -2096,6 +2224,8 @@ s_def	General	DEFAULT	0	1	1	Any	s_def.ibd
 s_empty1	General	DEFAULT	0	1	1	Any	s_empty1.ibd
 test/t_single	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t_single.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -2109,6 +2239,8 @@ s_def	TABLESPACE	InnoDB	NORMAL	s_def	MYSQLD_DATADIR/s_def.ibd
 s_empty1	TABLESPACE	InnoDB	NORMAL	s_empty1	MYSQLD_DATADIR/s_empty1.ibd
 test/t_single	TABLESPACE	InnoDB	NORMAL	test/t_single	MYSQLD_DATADIR/test/t_single.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -2134,6 +2266,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	s1	161	4	Dynamic	0	General
 test/t2	innodb_system	33	4	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -2168,6 +2302,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	innodb_system	33	4	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -2180,6 +2316,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	s1	161	4	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single

--- a/mysql-test/suite/innodb/r/create_tablespace_16k.result
+++ b/mysql-test/suite/innodb/r/create_tablespace_16k.result
@@ -45,6 +45,8 @@ s_2k	General	DEFAULT	2048	1	1	Compressed	s_2k.ibd
 s_4k	General	DEFAULT	4096	1	1	Compressed	s_4k.ibd
 s_8k	General	DEFAULT	8192	1	1	Compressed	s_8k.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -60,6 +62,8 @@ s_2k	TABLESPACE	InnoDB	NORMAL	s_2k	MYSQLD_DATADIR/s_2k.ibd
 s_4k	TABLESPACE	InnoDB	NORMAL	s_4k	MYSQLD_DATADIR/s_4k.ibd
 s_8k	TABLESPACE	InnoDB	NORMAL	s_8k	MYSQLD_DATADIR/s_8k.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -404,6 +408,8 @@ s_4k	General	DEFAULT	4096	1	1	Compressed	s_4k.ibd
 s_8k	General	DEFAULT	8192	1	1	Compressed	s_8k.ibd
 s_missing	General	DEFAULT	0	1	1	Any	delete_me.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -420,6 +426,8 @@ s_4k	TABLESPACE	InnoDB	NORMAL	s_4k	MYSQLD_DATADIR/s_4k.ibd
 s_8k	TABLESPACE	InnoDB	NORMAL	s_8k	MYSQLD_DATADIR/s_8k.ibd
 s_missing	TABLESPACE	InnoDB	NORMAL	s_missing	MYSQLD_DATADIR/delete_me.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -458,6 +466,8 @@ test/t_zip8k_in_8k_as	s_8k	169	5	Compressed	8192	General
 test/t_zip8k_in_8k_from_1k	s_8k	169	5	Compressed	8192	General
 test/t_zip8k_in_8k_like	s_8k	169	5	Compressed	8192	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -490,6 +500,8 @@ s_4k	General	DEFAULT	4096	1	1	Compressed	s_4k.ibd
 s_8k	General	DEFAULT	8192	1	1	Compressed	s_8k.ibd
 s_missing	General	DEFAULT	0	0	0	Any	delete_me.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -505,6 +517,8 @@ s_2k	TABLESPACE	InnoDB	NORMAL	s_2k	MYSQLD_DATADIR/s_2k.ibd
 s_4k	TABLESPACE	InnoDB	NORMAL	s_4k	MYSQLD_DATADIR/s_4k.ibd
 s_8k	TABLESPACE	InnoDB	NORMAL	s_8k	MYSQLD_DATADIR/s_8k.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -543,6 +557,8 @@ test/t_zip8k_in_8k_as	s_8k	169	5	Compressed	8192	General
 test/t_zip8k_in_8k_from_1k	s_8k	169	5	Compressed	8192	General
 test/t_zip8k_in_8k_like	s_8k	169	5	Compressed	8192	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -647,6 +663,8 @@ test/t_zip4k_as_remote	Single	DEFAULT	4096	1	1	Compressed	MYSQL_TMP_DIR/test/t_z
 test/t_zip8k_as_file_per_table	Single	DEFAULT	8192	1	1	Compressed	MYSQLD_DATADIR/test/t_zip8k_as_file_per_table.ibd
 test/t_zip8k_as_remote	Single	DEFAULT	8192	1	1	Compressed	MYSQL_TMP_DIR/test/t_zip8k_as_remote.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -672,6 +690,8 @@ test/t_zip4k_as_remote	TABLESPACE	InnoDB	NORMAL	test/t_zip4k_as_remote	MYSQL_TMP
 test/t_zip8k_as_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip8k_as_file_per_table	MYSQLD_DATADIR/test/t_zip8k_as_file_per_table.ibd
 test/t_zip8k_as_remote	TABLESPACE	InnoDB	NORMAL	test/t_zip8k_as_remote	MYSQL_TMP_DIR/test/t_zip8k_as_remote.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -692,6 +712,8 @@ test/t_zip4k_as_remote	test/t_zip4k_as_remote	103	5	Compressed	4096	Single
 test/t_zip8k_as_file_per_table	test/t_zip8k_as_file_per_table	41	5	Compressed	8192	Single
 test/t_zip8k_as_remote	test/t_zip8k_as_remote	105	5	Compressed	8192	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -991,6 +1013,8 @@ s_4k	General	DEFAULT	4096	1	1	Compressed	s_4k.ibd
 s_8k	General	DEFAULT	8192	1	1	Compressed	s_8k.ibd
 test/t_zip16k_as_file_per_table	Single	DEFAULT	DEFAULT	1	1	Compressed	MYSQLD_DATADIR/test/t_zip16k_as_file_per_table.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1007,6 +1031,8 @@ s_4k	TABLESPACE	InnoDB	NORMAL	s_4k	MYSQLD_DATADIR/s_4k.ibd
 s_8k	TABLESPACE	InnoDB	NORMAL	s_8k	MYSQLD_DATADIR/s_8k.ibd
 test/t_zip16k_as_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip16k_as_file_per_table	MYSQLD_DATADIR/test/t_zip16k_as_file_per_table.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1026,6 +1052,8 @@ test/t_zip4k_remote_in_s_4k	s_4k	167	5	Compressed	4096	General
 test/t_zip8k_in_s_8k	s_8k	169	5	Compressed	8192	General
 test/t_zip8k_remote_in_s_8k	s_8k	169	5	Compressed	8192	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1187,6 +1215,8 @@ test/t_zip2k_to_file_per_table	Single	DEFAULT	2048	1	1	Compressed	MYSQLD_DATADIR
 test/t_zip4k_to_file_per_table	Single	DEFAULT	4096	1	1	Compressed	MYSQLD_DATADIR/test/t_zip4k_to_file_per_table.ibd
 test/t_zip8k_to_file_per_table	Single	DEFAULT	8192	1	1	Compressed	MYSQLD_DATADIR/test/t_zip8k_to_file_per_table.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1207,6 +1237,8 @@ test/t_zip2k_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip2k_to_file_per
 test/t_zip4k_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip4k_to_file_per_table	MYSQLD_DATADIR/test/t_zip4k_to_file_per_table.ibd
 test/t_zip8k_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip8k_to_file_per_table	MYSQLD_DATADIR/test/t_zip8k_to_file_per_table.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1226,6 +1258,8 @@ test/t_zip4k_to_file_per_table	test/t_zip4k_to_file_per_table	39	5	Compressed	40
 test/t_zip8k_remote_in_s_8k	s_8k	169	5	Compressed	8192	General
 test/t_zip8k_to_file_per_table	test/t_zip8k_to_file_per_table	41	5	Compressed	8192	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1281,6 +1315,8 @@ test/t_zip2k_to_file_per_table	Single	DEFAULT	2048	1	1	Compressed	MYSQLD_DATADIR
 test/t_zip4k_to_file_per_table	Single	DEFAULT	4096	1	1	Compressed	MYSQLD_DATADIR/test/t_zip4k_to_file_per_table.ibd
 test/t_zip8k_to_file_per_table	Single	DEFAULT	8192	1	1	Compressed	MYSQLD_DATADIR/test/t_zip8k_to_file_per_table.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1300,6 +1336,8 @@ test/t_zip2k_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip2k_to_file_per
 test/t_zip4k_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip4k_to_file_per_table	MYSQLD_DATADIR/test/t_zip4k_to_file_per_table.ibd
 test/t_zip8k_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip8k_to_file_per_table	MYSQLD_DATADIR/test/t_zip8k_to_file_per_table.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1314,6 +1352,8 @@ test/t_zip2k_to_file_per_table	test/t_zip2k_to_file_per_table	37	5	Compressed	20
 test/t_zip4k_to_file_per_table	test/t_zip4k_to_file_per_table	39	5	Compressed	4096	Single
 test/t_zip8k_to_file_per_table	test/t_zip8k_to_file_per_table	41	5	Compressed	8192	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single

--- a/mysql-test/suite/innodb/r/create_tablespace_32k.result
+++ b/mysql-test/suite/innodb/r/create_tablespace_32k.result
@@ -65,6 +65,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_32k	General	DEFAULT	0	1	1	Any	s_32k.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -76,6 +78,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_32k	TABLESPACE	InnoDB	NORMAL	s_32k	MYSQLD_DATADIR/s_32k.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -150,6 +154,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_32k	General	DEFAULT	0	1	1	Any	s_32k.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -161,6 +167,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_32k	TABLESPACE	InnoDB	NORMAL	s_32k	MYSQLD_DATADIR/s_32k.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -174,6 +182,8 @@ test/t_com_in_32k	s_32k	129	5	Compact	0	General
 test/t_dyn_in_32k	s_32k	161	5	Dynamic	0	General
 test/t_red_in_32k	s_32k	128	5	Redundant	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single

--- a/mysql-test/suite/innodb/r/create_tablespace_4k.result
+++ b/mysql-test/suite/innodb/r/create_tablespace_4k.result
@@ -55,6 +55,8 @@ s_1k	General	DEFAULT	1024	1	1	Compressed	s_1k.ibd
 s_2k	General	DEFAULT	2048	1	1	Compressed	s_2k.ibd
 s_4k	General	DEFAULT	0	1	1	Any	s_4k.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -68,6 +70,8 @@ s_1k	TABLESPACE	InnoDB	NORMAL	s_1k	MYSQLD_DATADIR/s_1k.ibd
 s_2k	TABLESPACE	InnoDB	NORMAL	s_2k	MYSQLD_DATADIR/s_2k.ibd
 s_4k	TABLESPACE	InnoDB	NORMAL	s_4k	MYSQLD_DATADIR/s_4k.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -281,6 +285,8 @@ s_1k	General	DEFAULT	1024	1	1	Compressed	s_1k.ibd
 s_2k	General	DEFAULT	2048	1	1	Compressed	s_2k.ibd
 s_4k	General	DEFAULT	0	1	1	Any	s_4k.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -294,6 +300,8 @@ s_1k	TABLESPACE	InnoDB	NORMAL	s_1k	MYSQLD_DATADIR/s_1k.ibd
 s_2k	TABLESPACE	InnoDB	NORMAL	s_2k	MYSQLD_DATADIR/s_2k.ibd
 s_4k	TABLESPACE	InnoDB	NORMAL	s_4k	MYSQLD_DATADIR/s_4k.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -323,6 +331,8 @@ test/t_zip2k_in_2k_as	s_2k	165	5	Compressed	2048	General
 test/t_zip2k_in_2k_from_1k	s_2k	165	5	Compressed	2048	General
 test/t_zip2k_in_2k_like	s_2k	165	5	Compressed	2048	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -346,6 +356,8 @@ s_1k	General	DEFAULT	1024	1	1	Compressed	s_1k.ibd
 s_2k	General	DEFAULT	2048	1	1	Compressed	s_2k.ibd
 s_4k	General	DEFAULT	0	1	1	Any	s_4k.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -359,6 +371,8 @@ s_1k	TABLESPACE	InnoDB	NORMAL	s_1k	MYSQLD_DATADIR/s_1k.ibd
 s_2k	TABLESPACE	InnoDB	NORMAL	s_2k	MYSQLD_DATADIR/s_2k.ibd
 s_4k	TABLESPACE	InnoDB	NORMAL	s_4k	MYSQLD_DATADIR/s_4k.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -388,6 +402,8 @@ test/t_zip2k_in_2k_as	s_2k	165	5	Compressed	2048	General
 test/t_zip2k_in_2k_from_1k	s_2k	165	5	Compressed	2048	General
 test/t_zip2k_in_2k_like	s_2k	165	5	Compressed	2048	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -462,6 +478,8 @@ test/t_zip2k_as_remote	Single	DEFAULT	2048	1	1	Compressed	MYSQL_TMP_DIR/test/t_z
 test/t_zip4k_as_file_per_table	Single	DEFAULT	DEFAULT	1	1	Compressed	MYSQLD_DATADIR/test/t_zip4k_as_file_per_table.ibd
 test/t_zip4k_as_remote	Single	DEFAULT	DEFAULT	1	1	Compressed	MYSQL_TMP_DIR/test/t_zip4k_as_remote.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -481,6 +499,8 @@ test/t_zip2k_as_remote	TABLESPACE	InnoDB	NORMAL	test/t_zip2k_as_remote	MYSQL_TMP
 test/t_zip4k_as_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip4k_as_file_per_table	MYSQLD_DATADIR/test/t_zip4k_as_file_per_table.ibd
 test/t_zip4k_as_remote	TABLESPACE	InnoDB	NORMAL	test/t_zip4k_as_remote	MYSQL_TMP_DIR/test/t_zip4k_as_remote.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -497,6 +517,8 @@ test/t_zip2k_as_remote	test/t_zip2k_as_remote	101	5	Compressed	2048	Single
 test/t_zip4k_as_file_per_table	test/t_zip4k_as_file_per_table	39	5	Compressed	4096	Single
 test/t_zip4k_as_remote	test/t_zip4k_as_remote	103	5	Compressed	4096	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -606,6 +628,8 @@ s_2k	General	DEFAULT	2048	1	1	Compressed	s_2k.ibd
 s_4k	General	DEFAULT	0	1	1	Any	s_4k.ibd
 test/t_zip4k_as_file_per_table	Single	DEFAULT	DEFAULT	1	1	Compressed	MYSQLD_DATADIR/test/t_zip4k_as_file_per_table.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -620,6 +644,8 @@ s_2k	TABLESPACE	InnoDB	NORMAL	s_2k	MYSQLD_DATADIR/s_2k.ibd
 s_4k	TABLESPACE	InnoDB	NORMAL	s_4k	MYSQLD_DATADIR/s_4k.ibd
 test/t_zip4k_as_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip4k_as_file_per_table	MYSQLD_DATADIR/test/t_zip4k_as_file_per_table.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -635,6 +661,8 @@ test/t_zip2k_in_s_2k	s_2k	165	5	Compressed	2048	General
 test/t_zip2k_remote_in_s_2k	s_2k	165	5	Compressed	2048	General
 test/t_zip4k_as_file_per_table	test/t_zip4k_as_file_per_table	39	5	Compressed	4096	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -704,6 +732,8 @@ test/t_zip1k_to_file_per_table	Single	DEFAULT	1024	1	1	Compressed	MYSQLD_DATADIR
 test/t_zip2k_to_file_per_table	Single	DEFAULT	2048	1	1	Compressed	MYSQLD_DATADIR/test/t_zip2k_to_file_per_table.ibd
 test/t_zip4k_as_file_per_table	Single	DEFAULT	DEFAULT	1	1	Compressed	MYSQLD_DATADIR/test/t_zip4k_as_file_per_table.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -720,6 +750,8 @@ test/t_zip1k_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip1k_to_file_per
 test/t_zip2k_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip2k_to_file_per_table	MYSQLD_DATADIR/test/t_zip2k_to_file_per_table.ibd
 test/t_zip4k_as_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip4k_as_file_per_table	MYSQLD_DATADIR/test/t_zip4k_as_file_per_table.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -735,6 +767,8 @@ test/t_zip2k_remote_in_s_2k	s_2k	165	5	Compressed	2048	General
 test/t_zip2k_to_file_per_table	test/t_zip2k_to_file_per_table	37	5	Compressed	2048	Single
 test/t_zip4k_as_file_per_table	test/t_zip4k_as_file_per_table	39	5	Compressed	4096	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -772,6 +806,8 @@ s_4k	General	DEFAULT	0	1	1	Any	s_4k.ibd
 test/t_zip1k_to_file_per_table	Single	DEFAULT	1024	1	1	Compressed	MYSQLD_DATADIR/test/t_zip1k_to_file_per_table.ibd
 test/t_zip2k_to_file_per_table	Single	DEFAULT	2048	1	1	Compressed	MYSQLD_DATADIR/test/t_zip2k_to_file_per_table.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -787,6 +823,8 @@ s_4k	TABLESPACE	InnoDB	NORMAL	s_4k	MYSQLD_DATADIR/s_4k.ibd
 test/t_zip1k_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip1k_to_file_per_table	MYSQLD_DATADIR/test/t_zip1k_to_file_per_table.ibd
 test/t_zip2k_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip2k_to_file_per_table	MYSQLD_DATADIR/test/t_zip2k_to_file_per_table.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -799,6 +837,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t_zip1k_to_file_per_table	test/t_zip1k_to_file_per_table	35	5	Compressed	1024	Single
 test/t_zip2k_to_file_per_table	test/t_zip2k_to_file_per_table	37	5	Compressed	2048	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single

--- a/mysql-test/suite/innodb/r/create_tablespace_64k.result
+++ b/mysql-test/suite/innodb/r/create_tablespace_64k.result
@@ -65,6 +65,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_64k	General	DEFAULT	0	1	1	Any	s_64k.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -76,6 +78,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_64k	TABLESPACE	InnoDB	NORMAL	s_64k	MYSQLD_DATADIR/s_64k.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -156,6 +160,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_64k	General	DEFAULT	0	1	1	Any	s_64k.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -167,6 +173,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_64k	TABLESPACE	InnoDB	NORMAL	s_64k	MYSQLD_DATADIR/s_64k.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -180,6 +188,8 @@ test/t_com_in_64k	s_64k	129	5	Compact	0	General
 test/t_dyn_in_64k	s_64k	161	5	Dynamic	0	General
 test/t_red_in_64k	s_64k	128	5	Redundant	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single

--- a/mysql-test/suite/innodb/r/create_tablespace_8k.result
+++ b/mysql-test/suite/innodb/r/create_tablespace_8k.result
@@ -50,6 +50,8 @@ s_2k	General	DEFAULT	2048	1	1	Compressed	s_2k.ibd
 s_4k	General	DEFAULT	4096	1	1	Compressed	s_4k.ibd
 s_8k	General	DEFAULT	0	1	1	Any	s_8k.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -64,6 +66,8 @@ s_2k	TABLESPACE	InnoDB	NORMAL	s_2k	MYSQLD_DATADIR/s_2k.ibd
 s_4k	TABLESPACE	InnoDB	NORMAL	s_4k	MYSQLD_DATADIR/s_4k.ibd
 s_8k	TABLESPACE	InnoDB	NORMAL	s_8k	MYSQLD_DATADIR/s_8k.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -335,6 +339,8 @@ s_2k	General	DEFAULT	2048	1	1	Compressed	s_2k.ibd
 s_4k	General	DEFAULT	4096	1	1	Compressed	s_4k.ibd
 s_8k	General	DEFAULT	0	1	1	Any	s_8k.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -349,6 +355,8 @@ s_2k	TABLESPACE	InnoDB	NORMAL	s_2k	MYSQLD_DATADIR/s_2k.ibd
 s_4k	TABLESPACE	InnoDB	NORMAL	s_4k	MYSQLD_DATADIR/s_4k.ibd
 s_8k	TABLESPACE	InnoDB	NORMAL	s_8k	MYSQLD_DATADIR/s_8k.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -382,6 +390,8 @@ test/t_zip4k_in_4k_as	s_4k	167	5	Compressed	4096	General
 test/t_zip4k_in_4k_from_1k	s_4k	167	5	Compressed	4096	General
 test/t_zip4k_in_4k_like	s_4k	167	5	Compressed	4096	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -407,6 +417,8 @@ s_2k	General	DEFAULT	2048	1	1	Compressed	s_2k.ibd
 s_4k	General	DEFAULT	4096	1	1	Compressed	s_4k.ibd
 s_8k	General	DEFAULT	0	1	1	Any	s_8k.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -421,6 +433,8 @@ s_2k	TABLESPACE	InnoDB	NORMAL	s_2k	MYSQLD_DATADIR/s_2k.ibd
 s_4k	TABLESPACE	InnoDB	NORMAL	s_4k	MYSQLD_DATADIR/s_4k.ibd
 s_8k	TABLESPACE	InnoDB	NORMAL	s_8k	MYSQLD_DATADIR/s_8k.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -454,6 +468,8 @@ test/t_zip4k_in_4k_as	s_4k	167	5	Compressed	4096	General
 test/t_zip4k_in_4k_from_1k	s_4k	167	5	Compressed	4096	General
 test/t_zip4k_in_4k_like	s_4k	167	5	Compressed	4096	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -543,6 +559,8 @@ test/t_zip4k_as_remote	Single	DEFAULT	4096	1	1	Compressed	MYSQL_TMP_DIR/test/t_z
 test/t_zip8k_as_file_per_table	Single	DEFAULT	DEFAULT	1	1	Compressed	MYSQLD_DATADIR/test/t_zip8k_as_file_per_table.ibd
 test/t_zip8k_as_remote	Single	DEFAULT	DEFAULT	1	1	Compressed	MYSQL_TMP_DIR/test/t_zip8k_as_remote.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -565,6 +583,8 @@ test/t_zip4k_as_remote	TABLESPACE	InnoDB	NORMAL	test/t_zip4k_as_remote	MYSQL_TMP
 test/t_zip8k_as_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip8k_as_file_per_table	MYSQLD_DATADIR/test/t_zip8k_as_file_per_table.ibd
 test/t_zip8k_as_remote	TABLESPACE	InnoDB	NORMAL	test/t_zip8k_as_remote	MYSQL_TMP_DIR/test/t_zip8k_as_remote.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -583,6 +603,8 @@ test/t_zip4k_as_remote	test/t_zip4k_as_remote	103	5	Compressed	4096	Single
 test/t_zip8k_as_file_per_table	test/t_zip8k_as_file_per_table	41	5	Compressed	8192	Single
 test/t_zip8k_as_remote	test/t_zip8k_as_remote	105	5	Compressed	8192	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -769,6 +791,8 @@ s_4k	General	DEFAULT	4096	1	1	Compressed	s_4k.ibd
 s_8k	General	DEFAULT	0	1	1	Any	s_8k.ibd
 test/t_zip8k_as_file_per_table	Single	DEFAULT	DEFAULT	1	1	Compressed	MYSQLD_DATADIR/test/t_zip8k_as_file_per_table.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -784,6 +808,8 @@ s_4k	TABLESPACE	InnoDB	NORMAL	s_4k	MYSQLD_DATADIR/s_4k.ibd
 s_8k	TABLESPACE	InnoDB	NORMAL	s_8k	MYSQLD_DATADIR/s_8k.ibd
 test/t_zip8k_as_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip8k_as_file_per_table	MYSQLD_DATADIR/test/t_zip8k_as_file_per_table.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -801,6 +827,8 @@ test/t_zip4k_in_s_4k	s_4k	167	5	Compressed	4096	General
 test/t_zip4k_remote_in_s_4k	s_4k	167	5	Compressed	4096	General
 test/t_zip8k_as_file_per_table	test/t_zip8k_as_file_per_table	41	5	Compressed	8192	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -910,6 +938,8 @@ test/t_zip2k_to_file_per_table	Single	DEFAULT	2048	1	1	Compressed	MYSQLD_DATADIR
 test/t_zip4k_to_file_per_table	Single	DEFAULT	4096	1	1	Compressed	MYSQLD_DATADIR/test/t_zip4k_to_file_per_table.ibd
 test/t_zip8k_as_file_per_table	Single	DEFAULT	DEFAULT	1	1	Compressed	MYSQLD_DATADIR/test/t_zip8k_as_file_per_table.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -928,6 +958,8 @@ test/t_zip2k_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip2k_to_file_per
 test/t_zip4k_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip4k_to_file_per_table	MYSQLD_DATADIR/test/t_zip4k_to_file_per_table.ibd
 test/t_zip8k_as_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip8k_as_file_per_table	MYSQLD_DATADIR/test/t_zip8k_as_file_per_table.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -945,6 +977,8 @@ test/t_zip4k_remote_in_s_4k	s_4k	167	5	Compressed	4096	General
 test/t_zip4k_to_file_per_table	test/t_zip4k_to_file_per_table	39	5	Compressed	4096	Single
 test/t_zip8k_as_file_per_table	test/t_zip8k_as_file_per_table	41	5	Compressed	8192	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -991,6 +1025,8 @@ test/t_zip1k_to_file_per_table	Single	DEFAULT	1024	1	1	Compressed	MYSQLD_DATADIR
 test/t_zip2k_to_file_per_table	Single	DEFAULT	2048	1	1	Compressed	MYSQLD_DATADIR/test/t_zip2k_to_file_per_table.ibd
 test/t_zip4k_to_file_per_table	Single	DEFAULT	4096	1	1	Compressed	MYSQLD_DATADIR/test/t_zip4k_to_file_per_table.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1008,6 +1044,8 @@ test/t_zip1k_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip1k_to_file_per
 test/t_zip2k_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip2k_to_file_per_table	MYSQLD_DATADIR/test/t_zip2k_to_file_per_table.ibd
 test/t_zip4k_to_file_per_table	TABLESPACE	InnoDB	NORMAL	test/t_zip4k_to_file_per_table	MYSQLD_DATADIR/test/t_zip4k_to_file_per_table.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1021,6 +1059,8 @@ test/t_zip1k_to_file_per_table	test/t_zip1k_to_file_per_table	35	5	Compressed	10
 test/t_zip2k_to_file_per_table	test/t_zip2k_to_file_per_table	37	5	Compressed	2048	Single
 test/t_zip4k_to_file_per_table	test/t_zip4k_to_file_per_table	39	5	Compressed	4096	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single

--- a/mysql-test/suite/innodb/r/create_tablespace_debug.result
+++ b/mysql-test/suite/innodb/r/create_tablespace_debug.result
@@ -13,6 +13,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -23,6 +25,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -49,6 +53,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	s1	161	4	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -62,6 +68,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	s1	161	4	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -115,6 +123,8 @@ test/t2	s1	161	4	Dynamic	0	General
 test/t3	innodb_system	161	4	Dynamic	0	System
 test/t4	test/t4	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -130,6 +140,8 @@ test/t2	s1	161	4	Dynamic	0	General
 test/t3	innodb_system	161	4	Dynamic	0	System
 test/t4	test/t4	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -185,6 +197,8 @@ test/tr2	s1	161	4	Dynamic	0	General
 test/tr3	innodb_system	161	4	Dynamic	0	System
 test/tr4	test/tr4	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -200,6 +214,8 @@ test/tr2	s1	161	4	Dynamic	0	General
 test/tr3	innodb_system	161	4	Dynamic	0	System
 test/tr4	test/tr4	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single

--- a/mysql-test/suite/innodb/r/create_tablespace_replication.result
+++ b/mysql-test/suite/innodb/r/create_tablespace_replication.result
@@ -20,6 +20,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	s_1	161	4	Dynamic	0	General
 test/t2	s_1	161	4	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -43,6 +45,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	s_1	161	4	Dynamic	0	General
 test/t2	s_1	161	4	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -74,6 +78,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single

--- a/mysql-test/suite/innodb/r/default_row_format.result
+++ b/mysql-test/suite/innodb/r/default_row_format.result
@@ -14,6 +14,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	0	5	Redundant	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -28,6 +30,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -42,6 +46,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	1	5	Compact	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -56,6 +62,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	0	5	Redundant	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -71,6 +79,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	35	5	Compressed	1024	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -136,6 +146,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	1	5	Compact	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -150,6 +162,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -164,6 +178,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	1	5	Compact	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -178,6 +194,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	0	5	Redundant	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -193,6 +211,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	35	5	Compressed	1024	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -258,6 +278,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -272,6 +294,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -286,6 +310,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	1	5	Compact	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -300,6 +326,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	0	5	Redundant	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -315,6 +343,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	35	5	Compressed	1024	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -381,6 +411,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	1	5	Compact	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -395,6 +427,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	1	6	Compact	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -414,6 +448,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	1	5	Compact	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -429,6 +465,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	33	6	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -447,6 +485,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	0	5	Redundant	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -462,6 +502,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	1	6	Compact	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -480,6 +522,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	0	5	Redundant	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -496,6 +540,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	0	6	Redundant	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -514,6 +560,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	1	5	Compact	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -529,6 +577,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	1	5	Compact	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single

--- a/mysql-test/suite/innodb/r/default_row_format_compatibility.result
+++ b/mysql-test/suite/innodb/r/default_row_format_compatibility.result
@@ -10,6 +10,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	test/tab	33	14	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -60,6 +62,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	test/tab	1	4	Compact	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -88,6 +92,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	test/tab	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -112,6 +118,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	test/tab	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -124,6 +132,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	test/tab	1	5	Compact	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -139,6 +149,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	test/tab	41	5	Compressed	8192	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -154,6 +166,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	test/tab	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single

--- a/mysql-test/suite/innodb/r/default_row_format_tablespace.result
+++ b/mysql-test/suite/innodb/r/default_row_format_tablespace.result
@@ -15,6 +15,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	test/tab	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -27,6 +29,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	test/tab	1	5	Compact	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -42,6 +46,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	test/tab	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -57,6 +63,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	test/tab	0	5	Redundant	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -80,6 +88,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	test/tab	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -111,6 +121,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	tblsp	161	5	Dynamic	0	General
 test/tab1	tblsp1	163	5	Compressed	1024	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -124,6 +136,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	tblsp	129	5	Compact	0	General
 test/tab1	tblsp1	163	5	Compressed	1024	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -140,6 +154,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	tblsp	161	5	Dynamic	0	General
 test/tab1	tblsp1	163	5	Compressed	1024	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -156,6 +172,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	tblsp	128	5	Redundant	0	General
 test/tab1	tblsp1	163	5	Compressed	1024	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -186,6 +204,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	tblsp	161	5	Dynamic	0	General
 test/tab1	tblsp1	163	5	Compressed	1024	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -212,6 +232,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	innodb_system	161	5	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -224,6 +246,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	innodb_system	129	5	Compact	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -239,6 +263,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	innodb_system	161	5	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -254,6 +280,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	innodb_system	128	5	Redundant	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -276,6 +304,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	innodb_system	161	5	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -302,6 +332,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	innodb_system	33	5	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -314,6 +346,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	innodb_system	129	5	Compact	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -329,6 +363,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	innodb_system	161	5	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -344,6 +380,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	innodb_system	128	5	Redundant	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -368,6 +406,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	innodb_system	161	5	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single

--- a/mysql-test/suite/innodb/r/discard_tablespace.result
+++ b/mysql-test/suite/innodb/r/discard_tablespace.result
@@ -12,6 +12,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -23,6 +25,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -34,6 +38,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQLD_DATADIR/test/t1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -46,6 +52,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -57,6 +65,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	Single	DEFAULT	0	0	0	Dynamic	MYSQLD_DATADIR/test/t1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -67,6 +77,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -79,6 +91,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t2	test/t2	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -90,6 +104,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t2	Single	DEFAULT	0	0	0	Dynamic	MYSQLD_DATADIR/test/t2.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -100,6 +116,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -112,6 +130,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t2	test/t2	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -123,6 +143,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t2	Single	DEFAULT	0	0	0	Dynamic	MYSQLD_DATADIR/test/t2.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -133,6 +155,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -146,6 +170,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	33	4	Dynamic	0	Single
 test/t2	test/t2	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -158,6 +184,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 test/t1	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t1.ibd
 test/t2	Single	DEFAULT	0	0	0	Dynamic	MYSQLD_DATADIR/test/t2.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -169,6 +197,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQLD_DATADIR/test/t1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -184,6 +214,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -195,6 +227,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -206,6 +240,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQLD_DATADIR/test/t1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -218,6 +254,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -229,6 +267,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	Single	DEFAULT	0	0	0	Dynamic	MYSQLD_DATADIR/test/t1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -239,6 +279,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -251,6 +293,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t2	test/t2	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -262,6 +306,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t2	Single	DEFAULT	0	0	0	Dynamic	MYSQLD_DATADIR/test/t2.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -272,6 +318,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -285,6 +333,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	33	4	Dynamic	0	Single
 test/t2	test/t2	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -297,6 +347,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 test/t1	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t1.ibd
 test/t2	Single	DEFAULT	0	0	0	Dynamic	MYSQLD_DATADIR/test/t2.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -308,6 +360,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQLD_DATADIR/test/t1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -323,6 +377,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1@002ft2	test/t1/t2	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -334,6 +390,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1/t2	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t1@002ft2.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -345,6 +403,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1/t2	TABLESPACE	InnoDB	NORMAL	test/t1/t2	MYSQLD_DATADIR/test/t1@002ft2.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -357,6 +417,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1@002ft2	test/t1/t2	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -368,6 +430,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1/t2	Single	DEFAULT	0	0	0	Dynamic	MYSQLD_DATADIR/test/t1@002ft2.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -378,6 +442,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -390,6 +456,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t3@005ct4@005ct5	test/t3\t4\t5	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -401,6 +469,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t3\t4\t5	Single	DEFAULT	0	0	0	Dynamic	MYSQLD_DATADIR/test/t3@005ct4@005ct5.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -411,6 +481,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -427,6 +499,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -438,6 +512,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -449,6 +525,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -461,6 +539,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -472,6 +552,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -482,6 +564,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -494,6 +578,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -505,6 +591,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -515,6 +603,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -532,6 +622,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -543,6 +635,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -554,6 +648,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -566,6 +662,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -577,6 +675,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -587,6 +687,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -599,6 +701,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -610,6 +714,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -620,6 +726,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -638,6 +746,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -649,6 +759,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -660,6 +772,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -672,6 +786,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -683,6 +799,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -693,6 +811,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -705,6 +825,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -716,6 +838,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -726,6 +850,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd

--- a/mysql-test/suite/innodb/r/hidden_directory_dotfile.result
+++ b/mysql-test/suite/innodb/r/hidden_directory_dotfile.result
@@ -27,6 +27,8 @@ test/t2	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/.other_dir/test/t2.ibd
 ts1	General	DEFAULT	0	1	1	Any	ts1.ibd
 ts2	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/.other_dir/ts2.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -41,6 +43,8 @@ test/t2	TABLESPACE	InnoDB	NORMAL	test/t2	MYSQL_TMP_DIR/.other_dir/test/t2.ibd
 ts1	TABLESPACE	InnoDB	NORMAL	ts1	MYSQLD_DATADIR/ts1.ibd
 ts2	TABLESPACE	InnoDB	NORMAL	ts2	MYSQL_TMP_DIR/.other_dir/ts2.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -62,6 +66,8 @@ test/t2	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t2.ibd
 ts1	General	DEFAULT	0	1	1	Any	ts1.ibd
 ts2	General	DEFAULT	0	1	1	Any	MYSQLD_DATADIR/ts2.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -76,6 +82,8 @@ test/t2	TABLESPACE	InnoDB	NORMAL	test/t2	MYSQLD_DATADIR/test/t2.ibd
 ts1	TABLESPACE	InnoDB	NORMAL	ts1	MYSQLD_DATADIR/ts1.ibd
 ts2	TABLESPACE	InnoDB	NORMAL	ts2	MYSQLD_DATADIR/ts2.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd

--- a/mysql-test/suite/innodb/r/innodb-index-online-fk.result
+++ b/mysql-test/suite/innodb/r/innodb-index-online-fk.result
@@ -139,6 +139,8 @@ NAME
 villagesql/extensions
 villagesql/custom_columns
 villagesql/custom_sp_params
+villagesql/custom_indexes
+villagesql/custom_index_columns
 villagesql/properties
 mtr/test_suppressions
 mtr/asserted_test_suppressions
@@ -339,6 +341,8 @@ NAME
 villagesql/extensions
 villagesql/custom_columns
 villagesql/custom_sp_params
+villagesql/custom_indexes
+villagesql/custom_index_columns
 villagesql/properties
 mtr/test_suppressions
 mtr/asserted_test_suppressions
@@ -368,6 +372,8 @@ NAME
 villagesql/extensions
 villagesql/custom_columns
 villagesql/custom_sp_params
+villagesql/custom_indexes
+villagesql/custom_index_columns
 villagesql/properties
 mtr/test_suppressions
 mtr/asserted_test_suppressions
@@ -408,6 +414,8 @@ NAME
 villagesql/extensions
 villagesql/custom_columns
 villagesql/custom_sp_params
+villagesql/custom_indexes
+villagesql/custom_index_columns
 villagesql/properties
 mtr/test_suppressions
 mtr/asserted_test_suppressions
@@ -448,6 +456,8 @@ NAME
 villagesql/extensions
 villagesql/custom_columns
 villagesql/custom_sp_params
+villagesql/custom_indexes
+villagesql/custom_index_columns
 villagesql/properties
 mtr/test_suppressions
 mtr/asserted_test_suppressions

--- a/mysql-test/suite/innodb/r/innodb_tablespace.result
+++ b/mysql-test/suite/innodb/r/innodb_tablespace.result
@@ -105,6 +105,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -116,6 +118,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -127,6 +131,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -141,6 +147,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -151,6 +159,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -161,6 +171,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -187,6 +199,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -198,6 +212,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -209,6 +225,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -231,6 +249,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -242,6 +262,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -253,6 +275,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -279,6 +303,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t2	test/t2	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -290,6 +316,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t2	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t2.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -301,6 +329,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t2	TABLESPACE	InnoDB	NORMAL	test/t2	MYSQL_TMP_DIR/alt_dir/test/t2.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -324,6 +354,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t2	test/t2	97	5	Dynamic	0	Single
 test/t3	test/t3	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -336,6 +368,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 test/t2	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t2.ibd
 test/t3	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t3.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -348,6 +382,8 @@ mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATA
 test/t2	TABLESPACE	InnoDB	NORMAL	test/t2	MYSQL_TMP_DIR/alt_dir/test/t2.ibd
 test/t3	TABLESPACE	InnoDB	NORMAL	test/t3	MYSQLD_DATADIR/test/t3.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -364,6 +400,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -374,6 +412,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -384,6 +424,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -477,6 +519,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -488,6 +532,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -520,6 +566,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -531,6 +579,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -593,6 +643,8 @@ test/emp#p#east	test/emp#p#east	97	7	Dynamic	0	Single
 test/emp#p#north	test/emp#p#north	97	7	Dynamic	0	Single
 test/emp#p#west	test/emp#p#west	97	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -606,6 +658,8 @@ test/emp#p#east	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_east/test/emp
 test/emp#p#north	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 test/emp#p#west	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -619,6 +673,8 @@ test/emp#p#east	TABLESPACE	InnoDB	NORMAL	test/emp#p#east	MYSQL_TMP_DIR/alt_dir_e
 test/emp#p#north	TABLESPACE	InnoDB	NORMAL	test/emp#p#north	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 test/emp#p#west	TABLESPACE	InnoDB	NORMAL	test/emp#p#west	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -658,6 +714,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/emp#p#east	test/emp#p#east	97	7	Dynamic	0	Single
 test/emp#p#north	test/emp#p#north	97	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -670,6 +728,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 test/emp#p#east	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_east/test/emp#p#east.ibd
 test/emp#p#north	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -682,6 +742,8 @@ mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATA
 test/emp#p#east	TABLESPACE	InnoDB	NORMAL	test/emp#p#east	MYSQL_TMP_DIR/alt_dir_east/test/emp#p#east.ibd
 test/emp#p#north	TABLESPACE	InnoDB	NORMAL	test/emp#p#north	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -723,6 +785,8 @@ test/emp#p#east	test/emp#p#east	97	7	Dynamic	0	Single
 test/emp#p#north	test/emp#p#north	97	7	Dynamic	0	Single
 test/emp#p#west	test/emp#p#west	97	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -736,6 +800,8 @@ test/emp#p#east	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_east/test/emp
 test/emp#p#north	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 test/emp#p#west	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -749,6 +815,8 @@ test/emp#p#east	TABLESPACE	InnoDB	NORMAL	test/emp#p#east	MYSQL_TMP_DIR/alt_dir_e
 test/emp#p#north	TABLESPACE	InnoDB	NORMAL	test/emp#p#north	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 test/emp#p#west	TABLESPACE	InnoDB	NORMAL	test/emp#p#west	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -791,6 +859,8 @@ test/emp#p#east	test/emp#p#east	97	7	Dynamic	0	Single
 test/emp#p#north	test/emp#p#north	97	7	Dynamic	0	Single
 test/emp#p#west	test/emp#p#west	97	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -804,6 +874,8 @@ test/emp#p#east	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_east/test/emp
 test/emp#p#north	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 test/emp#p#west	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -817,6 +889,8 @@ test/emp#p#east	TABLESPACE	InnoDB	NORMAL	test/emp#p#east	MYSQL_TMP_DIR/alt_dir_e
 test/emp#p#north	TABLESPACE	InnoDB	NORMAL	test/emp#p#north	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 test/emp#p#west	TABLESPACE	InnoDB	NORMAL	test/emp#p#west	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd

--- a/mysql-test/suite/innodb/r/known_dir_unique_undo.result
+++ b/mysql-test/suite/innodb/r/known_dir_unique_undo.result
@@ -312,6 +312,8 @@ test/tp3#p#p2#sp#s4	test/tp3#p#p2#sp#s4	97	5	Dynamic	0	Single
 test/tp3#p#p3#sp#s5	test/tp3#p#p3#sp#s5	97	5	Dynamic	0	Single
 test/tp3#p#p3#sp#s6	test/tp3#p#p3#sp#s6	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -333,6 +335,8 @@ test/tp3#p#p3#sp#s5	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/known_dir/test/tp
 test/tp3#p#p3#sp#s6	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/known_dir/test/tp3#p#p3#sp#s6.ibd
 ts1	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/known_dir/ts1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -354,6 +358,8 @@ test/tp3#p#p3#sp#s5	TABLESPACE	InnoDB	NORMAL	test/tp3#p#p3#sp#s5	MYSQL_TMP_DIR/k
 test/tp3#p#p3#sp#s6	TABLESPACE	InnoDB	NORMAL	test/tp3#p#p3#sp#s6	MYSQL_TMP_DIR/known_dir/test/tp3#p#p3#sp#s6.ibd
 ts1	TABLESPACE	InnoDB	NORMAL	ts1	MYSQL_TMP_DIR/known_dir/ts1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd

--- a/mysql-test/suite/innodb/r/known_directory.result
+++ b/mysql-test/suite/innodb/r/known_directory.result
@@ -355,6 +355,8 @@ test/tp4#p#p1#sp#s2	test/tp4#p#p1#sp#s2	97	5	Dynamic	0	Single
 test/tp4#p#p2#sp#s3	test/tp4#p#p2#sp#s3	97	5	Dynamic	0	Single
 test/tp4#p#p2#sp#s4	test/tp4#p#p2#sp#s4	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -385,6 +387,8 @@ test/tp4#p#p2#sp#s4	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/known_dir/test/tp
 ts1	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/known_dir/ts1.ibd
 ts2	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/undo_dir/ts2.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -415,6 +419,8 @@ test/tp4#p#p2#sp#s4	TABLESPACE	InnoDB	NORMAL	test/tp4#p#p2#sp#s4	MYSQL_TMP_DIR/k
 ts1	TABLESPACE	InnoDB	NORMAL	ts1	MYSQL_TMP_DIR/known_dir/ts1.ibd
 ts2	TABLESPACE	InnoDB	NORMAL	ts2	MYSQL_TMP_DIR/undo_dir/ts2.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd

--- a/mysql-test/suite/innodb/r/partition_autoinc.result
+++ b/mysql-test/suite/innodb/r/partition_autoinc.result
@@ -63,6 +63,8 @@ LOWER(path)
 ./test/t1#p#p5.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -109,6 +111,8 @@ LOWER(path)
 ./test/t1#p#p7.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -214,6 +218,8 @@ LOWER(path)
 ./test/t1#p#p3.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -252,6 +258,8 @@ LOWER(path)
 ./test/t1#p#p1.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -292,6 +300,8 @@ LOWER(path)
 ./test/t1#p#p3.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -313,6 +323,8 @@ LOWER(path)
 ./test/t1#p#p3.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -361,6 +373,8 @@ LOWER(path)
 ./test/t1#p#p1.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -423,6 +437,8 @@ LOWER(path)
 ./test/t1#p#p5.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -464,6 +480,8 @@ LOWER(path)
 ./test/t1#p#p7.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -540,6 +558,8 @@ LOWER(path)
 ./test/t1#p#p5.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -585,6 +605,8 @@ LOWER(path)
 ./test/t1#p#p1.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -670,6 +692,8 @@ LOWER(path)
 ./test/t1#p#p3.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -733,6 +757,8 @@ LOWER(path)
 ./test/t1#p#p32.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -801,6 +827,8 @@ LOWER(path)
 ./test/t1#p#p32.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -900,6 +928,8 @@ LOWER(path)
 ./test/tp.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -953,6 +983,8 @@ LOWER(path)
 ./test/tp.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -1073,6 +1105,8 @@ LOWER(path)
 ./test/t1#p#p3#sp#sp31.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -1148,6 +1182,8 @@ LOWER(path)
 ./test/t1#p#p2#sp#sp21.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -1226,6 +1262,8 @@ LOWER(path)
 ./test/t1#p#p22#sp#sp221.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd
@@ -1275,6 +1313,8 @@ LOWER(path)
 ./test/t1#p#p22#sp#sp221.ibd
 ./test/tr.ibd
 ./villagesql/custom_columns.ibd
+./villagesql/custom_indexes.ibd
+./villagesql/custom_index_columns.ibd
 ./villagesql/custom_sp_params.ibd
 ./villagesql/extensions.ibd
 ./villagesql/properties.ibd

--- a/mysql-test/suite/innodb/r/portability_tablespace.result
+++ b/mysql-test/suite/innodb/r/portability_tablespace.result
@@ -321,6 +321,8 @@ InnoDB	ts4
 InnoDB	undo_003
 InnoDB	undo_004
 InnoDB	villagesql/custom_columns
+InnoDB	villagesql/custom_index_columns
+InnoDB	villagesql/custom_indexes
 InnoDB	villagesql/custom_sp_params
 InnoDB	villagesql/extensions
 InnoDB	villagesql/properties

--- a/mysql-test/suite/innodb/r/tablespace_per_table.result
+++ b/mysql-test/suite/innodb/r/tablespace_per_table.result
@@ -114,6 +114,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -125,6 +127,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -136,6 +140,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -150,6 +156,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -160,6 +168,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -170,6 +180,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -197,6 +209,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -208,6 +222,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -219,6 +235,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -241,6 +259,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -252,6 +272,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -263,6 +285,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -286,6 +310,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t2	test/t2	97	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -297,6 +323,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t2	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t2.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -308,6 +336,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t2	TABLESPACE	InnoDB	NORMAL	test/t2	MYSQL_TMP_DIR/alt_dir/test/t2.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -331,6 +361,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t2	test/t2	97	5	Dynamic	0	Single
 test/t3	test/t3	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -343,6 +375,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 test/t2	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t2.ibd
 test/t3	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t3.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -355,6 +389,8 @@ mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATA
 test/t2	TABLESPACE	InnoDB	NORMAL	test/t2	MYSQL_TMP_DIR/alt_dir/test/t2.ibd
 test/t3	TABLESPACE	InnoDB	NORMAL	test/t3	MYSQLD_DATADIR/test/t3.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -371,6 +407,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -381,6 +419,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -391,6 +431,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -479,6 +521,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -490,6 +534,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -538,6 +584,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -549,6 +597,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 test/t1	TABLESPACE	InnoDB	NORMAL	test/t1	MYSQL_TMP_DIR/alt_dir/test/t1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -605,6 +655,8 @@ test/emp#p#east	test/emp#p#east	97	7	Dynamic	0	Single
 test/emp#p#north	test/emp#p#north	97	7	Dynamic	0	Single
 test/emp#p#west	test/emp#p#west	97	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -618,6 +670,8 @@ test/emp#p#east	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_east/test/emp
 test/emp#p#north	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 test/emp#p#west	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -631,6 +685,8 @@ test/emp#p#east	TABLESPACE	InnoDB	NORMAL	test/emp#p#east	MYSQL_TMP_DIR/alt_dir_e
 test/emp#p#north	TABLESPACE	InnoDB	NORMAL	test/emp#p#north	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 test/emp#p#west	TABLESPACE	InnoDB	NORMAL	test/emp#p#west	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -669,6 +725,8 @@ mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/emp#p#east	test/emp#p#east	97	7	Dynamic	0	Single
 test/emp#p#north	test/emp#p#north	97	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -681,6 +739,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 test/emp#p#east	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_east/test/emp#p#east.ibd
 test/emp#p#north	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -693,6 +753,8 @@ mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATA
 test/emp#p#east	TABLESPACE	InnoDB	NORMAL	test/emp#p#east	MYSQL_TMP_DIR/alt_dir_east/test/emp#p#east.ibd
 test/emp#p#north	TABLESPACE	InnoDB	NORMAL	test/emp#p#north	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -724,6 +786,8 @@ test/emp#p#east	test/emp#p#east	97	7	Dynamic	0	Single
 test/emp#p#north	test/emp#p#north	97	7	Dynamic	0	Single
 test/emp#p#west	test/emp#p#west	97	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -737,6 +801,8 @@ test/emp#p#east	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_east/test/emp
 test/emp#p#north	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 test/emp#p#west	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -750,6 +816,8 @@ test/emp#p#east	TABLESPACE	InnoDB	NORMAL	test/emp#p#east	MYSQL_TMP_DIR/alt_dir_e
 test/emp#p#north	TABLESPACE	InnoDB	NORMAL	test/emp#p#north	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 test/emp#p#west	TABLESPACE	InnoDB	NORMAL	test/emp#p#west	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -792,6 +860,8 @@ test/emp#p#east	test/emp#p#east	97	7	Dynamic	0	Single
 test/emp#p#north	test/emp#p#north	97	7	Dynamic	0	Single
 test/emp#p#west	test/emp#p#west	97	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -805,6 +875,8 @@ test/emp#p#east	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_east/test/emp
 test/emp#p#north	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 test/emp#p#west	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -818,6 +890,8 @@ test/emp#p#east	TABLESPACE	InnoDB	NORMAL	test/emp#p#east	MYSQL_TMP_DIR/alt_dir_e
 test/emp#p#north	TABLESPACE	InnoDB	NORMAL	test/emp#p#north	MYSQL_TMP_DIR/alt_dir_north/test/emp#p#north.ibd
 test/emp#p#west	TABLESPACE	InnoDB	NORMAL	test/emp#p#west	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd

--- a/mysql-test/suite/innodb/r/unknown_directory.result
+++ b/mysql-test/suite/innodb/r/unknown_directory.result
@@ -147,6 +147,8 @@ test/tsp1#p#p2#sp#s3	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/remote_dir/test/
 test/tsp1#p#p2#sp#s4	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/remote_dir/test/tsp1#p#p2#sp#s4.ibd
 ts1	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/remote_dir/ts1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -166,6 +168,8 @@ test/tsp1#p#p2#sp#s3	TABLESPACE	InnoDB	NORMAL	test/tsp1#p#p2#sp#s3	MYSQL_TMP_DIR
 test/tsp1#p#p2#sp#s4	TABLESPACE	InnoDB	NORMAL	test/tsp1#p#p2#sp#s4	MYSQL_TMP_DIR/remote_dir/test/tsp1#p#p2#sp#s4.ibd
 ts1	TABLESPACE	InnoDB	NORMAL	ts1	MYSQL_TMP_DIR/remote_dir/ts1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -216,6 +220,8 @@ test/tsp1#p#p2#sp#s3	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/remote_dir/test/
 test/tsp1#p#p2#sp#s4	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/remote_dir/test/tsp1#p#p2#sp#s4.ibd
 ts1	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/remote_dir/ts1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -235,6 +241,8 @@ test/tsp1#p#p2#sp#s3	TABLESPACE	InnoDB	NORMAL	test/tsp1#p#p2#sp#s3	MYSQL_TMP_DIR
 test/tsp1#p#p2#sp#s4	TABLESPACE	InnoDB	NORMAL	test/tsp1#p#p2#sp#s4	MYSQL_TMP_DIR/remote_dir/test/tsp1#p#p2#sp#s4.ibd
 ts1	TABLESPACE	InnoDB	NORMAL	ts1	MYSQL_TMP_DIR/remote_dir/ts1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -297,6 +305,8 @@ test/tsp1#p#p2#sp#s3	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/remote_dir/test/
 test/tsp1#p#p2#sp#s4	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/remote_dir/test/tsp1#p#p2#sp#s4.ibd
 ts1	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/remote_dir/ts1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -316,6 +326,8 @@ test/tsp1#p#p2#sp#s3	TABLESPACE	InnoDB	NORMAL	test/tsp1#p#p2#sp#s3	MYSQL_TMP_DIR
 test/tsp1#p#p2#sp#s4	TABLESPACE	InnoDB	NORMAL	test/tsp1#p#p2#sp#s4	MYSQL_TMP_DIR/remote_dir/test/tsp1#p#p2#sp#s4.ibd
 ts1	TABLESPACE	InnoDB	NORMAL	ts1	MYSQL_TMP_DIR/remote_dir/ts1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -349,6 +361,8 @@ test/tsp1#p#p2#sp#s3	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/remote_dir/test/
 test/tsp1#p#p2#sp#s4	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/remote_dir/test/tsp1#p#p2#sp#s4.ibd
 ts1	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/remote_dir/ts1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -368,6 +382,8 @@ test/tsp1#p#p2#sp#s3	TABLESPACE	InnoDB	NORMAL	test/tsp1#p#p2#sp#s3	MYSQL_TMP_DIR
 test/tsp1#p#p2#sp#s4	TABLESPACE	InnoDB	NORMAL	test/tsp1#p#p2#sp#s4	MYSQL_TMP_DIR/remote_dir/test/tsp1#p#p2#sp#s4.ibd
 ts1	TABLESPACE	InnoDB	NORMAL	ts1	MYSQL_TMP_DIR/remote_dir/ts1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -410,6 +426,8 @@ test/tsp1#p#p2#sp#s3	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/remote_dir/test/
 test/tsp1#p#p2#sp#s4	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/tsp1#p#p2#sp#s4.ibd
 ts1	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/remote_dir/ts1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -429,6 +447,8 @@ test/tsp1#p#p2#sp#s3	TABLESPACE	InnoDB	NORMAL	test/tsp1#p#p2#sp#s3	MYSQL_TMP_DIR
 test/tsp1#p#p2#sp#s4	TABLESPACE	InnoDB	NORMAL	test/tsp1#p#p2#sp#s4	MYSQLD_DATADIR/test/tsp1#p#p2#sp#s4.ibd
 ts1	TABLESPACE	InnoDB	NORMAL	ts1	MYSQL_TMP_DIR/remote_dir/ts1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -537,6 +557,8 @@ test/tsp1#p#p2#sp#s3	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/tsp1#p#p2#
 test/tsp1#p#p2#sp#s4	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/tsp1#p#p2#sp#s4.ibd
 ts1	General	DEFAULT	0	1	1	Any	MYSQL_TMP_DIR/remote_dir/ts1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -556,6 +578,8 @@ test/tsp1#p#p2#sp#s3	TABLESPACE	InnoDB	NORMAL	test/tsp1#p#p2#sp#s3	MYSQLD_DATADI
 test/tsp1#p#p2#sp#s4	TABLESPACE	InnoDB	NORMAL	test/tsp1#p#p2#sp#s4	MYSQLD_DATADIR/test/tsp1#p#p2#sp#s4.ibd
 ts1	TABLESPACE	InnoDB	NORMAL	ts1	MYSQL_TMP_DIR/remote_dir/ts1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd

--- a/mysql-test/suite/innodb_fts/r/tablespace_location.result
+++ b/mysql-test/suite/innodb_fts/r/tablespace_location.result
@@ -24,6 +24,8 @@ mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppr
 s_def	General	DEFAULT	0	1	1	Any	s_def.ibd
 s_zip	General	DEFAULT	2048	1	1	Compressed	s_zip.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -36,6 +38,8 @@ mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATA
 s_def	TABLESPACE	InnoDB	NORMAL	s_def	MYSQLD_DATADIR/s_def.ibd
 s_zip	TABLESPACE	InnoDB	NORMAL	s_zip	MYSQLD_DATADIR/s_zip.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -62,6 +66,8 @@ test/fts_aux_deleted	s_def	128	4	Redundant	0	General
 test/fts_aux_deleted_cache	s_def	128	4	Redundant	0	General
 test/t1	s_def	128	6	Redundant	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -98,6 +104,8 @@ test/fts_aux_deleted	s_def	128	4	Redundant	0	General
 test/fts_aux_deleted_cache	s_def	128	4	Redundant	0	General
 test/t1	s_def	128	6	Redundant	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -138,6 +146,8 @@ test/fts_aux_deleted	s_def	129	4	Compact	0	General
 test/fts_aux_deleted_cache	s_def	129	4	Compact	0	General
 test/t1	s_def	129	6	Compact	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -174,6 +184,8 @@ test/fts_aux_deleted	s_def	129	4	Compact	0	General
 test/fts_aux_deleted_cache	s_def	129	4	Compact	0	General
 test/t1	s_def	129	6	Compact	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -214,6 +226,8 @@ test/fts_aux_deleted	s_def	161	4	Dynamic	0	General
 test/fts_aux_deleted_cache	s_def	161	4	Dynamic	0	General
 test/t1	s_def	161	6	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -250,6 +264,8 @@ test/fts_aux_deleted	s_def	161	4	Dynamic	0	General
 test/fts_aux_deleted_cache	s_def	161	4	Dynamic	0	General
 test/t1	s_def	161	6	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -290,6 +306,8 @@ test/fts_aux_deleted	s_zip	165	4	Compressed	2048	General
 test/fts_aux_deleted_cache	s_zip	165	4	Compressed	2048	General
 test/t1	s_zip	165	6	Compressed	2048	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -326,6 +344,8 @@ test/fts_aux_deleted	s_zip	165	4	Compressed	2048	General
 test/fts_aux_deleted_cache	s_zip	165	4	Compressed	2048	General
 test/t1	s_zip	165	6	Compressed	2048	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -366,6 +386,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	33	4	Dynamic	0	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	33	4	Dynamic	0	Single
 test/t1	test/t1	33	6	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -402,6 +424,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	33	4	Dynamic	0	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	33	4	Dynamic	0	Single
 test/t1	test/t1	33	6	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -442,6 +466,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	37	4	Compressed	2048	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	37	4	Compressed	2048	Single
 test/t1	test/t1	37	6	Compressed	2048	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -478,6 +504,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	37	4	Compressed	2048	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	37	4	Compressed	2048	Single
 test/t1	test/t1	37	6	Compressed	2048	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -518,6 +546,8 @@ test/fts_aux_deleted	innodb_system	128	4	Redundant	0	System
 test/fts_aux_deleted_cache	innodb_system	128	4	Redundant	0	System
 test/t1	innodb_system	128	6	Redundant	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -554,6 +584,8 @@ test/fts_aux_deleted	innodb_system	128	4	Redundant	0	System
 test/fts_aux_deleted_cache	innodb_system	128	4	Redundant	0	System
 test/t1	innodb_system	128	6	Redundant	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -594,6 +626,8 @@ test/fts_aux_deleted	innodb_system	129	4	Compact	0	System
 test/fts_aux_deleted_cache	innodb_system	129	4	Compact	0	System
 test/t1	innodb_system	129	6	Compact	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -630,6 +664,8 @@ test/fts_aux_deleted	innodb_system	129	4	Compact	0	System
 test/fts_aux_deleted_cache	innodb_system	129	4	Compact	0	System
 test/t1	innodb_system	129	6	Compact	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -670,6 +706,8 @@ test/fts_aux_deleted	innodb_system	161	4	Dynamic	0	System
 test/fts_aux_deleted_cache	innodb_system	161	4	Dynamic	0	System
 test/t1	innodb_system	161	6	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -706,6 +744,8 @@ test/fts_aux_deleted	innodb_system	161	4	Dynamic	0	System
 test/fts_aux_deleted_cache	innodb_system	161	4	Dynamic	0	System
 test/t1	innodb_system	161	6	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -746,6 +786,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	33	4	Dynamic	0	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	33	4	Dynamic	0	Single
 test/t1	test/t1	33	6	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -774,6 +816,8 @@ test/fts_aux_deleted	innodb_system	33	4	Dynamic	0	System
 test/fts_aux_deleted_cache	innodb_system	33	4	Dynamic	0	System
 test/t1	innodb_system	33	6	Dynamic	0	System
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -803,6 +847,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	97	4	Dynamic	0	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	97	4	Dynamic	0	Single
 test/t1	test/t1	97	6	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -858,6 +904,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -883,6 +931,8 @@ test/fts_aux_deleted	s_def	161	4	Dynamic	0	General
 test/fts_aux_deleted_cache	s_def	161	4	Dynamic	0	General
 test/t1	s_def	161	6	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -907,6 +957,8 @@ test/fts_aux_deleted	s_def	129	4	Compact	0	General
 test/fts_aux_deleted_cache	s_def	129	4	Compact	0	General
 test/t1	s_def	129	7	Compact	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -943,6 +995,8 @@ test/fts_aux_deleted	s_def	129	4	Compact	0	General
 test/fts_aux_deleted_cache	s_def	129	4	Compact	0	General
 test/t1	s_def	129	7	Compact	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -972,6 +1026,8 @@ test/fts_aux_deleted	s_def	129	4	Compact	0	General
 test/fts_aux_deleted_cache	s_def	129	4	Compact	0	General
 test/t1	s_def	129	8	Compact	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1000,6 +1056,8 @@ test/fts_aux_deleted	s_def	129	4	Compact	0	General
 test/fts_aux_deleted_cache	s_def	129	4	Compact	0	General
 test/t1	s_def	129	8	Compact	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1024,6 +1082,8 @@ test/fts_aux_deleted	s_def	129	4	Compact	0	General
 test/fts_aux_deleted_cache	s_def	129	4	Compact	0	General
 test/t1	s_def	129	8	Compact	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1054,6 +1114,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	33	4	Dynamic	0	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	33	4	Dynamic	0	Single
 test/t1	test/t1	33	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1090,6 +1152,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	33	4	Dynamic	0	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	33	4	Dynamic	0	Single
 test/t1	test/t1	33	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1119,6 +1183,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	33	4	Dynamic	0	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	33	4	Dynamic	0	Single
 test/t1	test/t1	33	8	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1147,6 +1213,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	33	4	Dynamic	0	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	33	4	Dynamic	0	Single
 test/t1	test/t1	33	8	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1171,6 +1239,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	33	4	Dynamic	0	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	33	4	Dynamic	0	Single
 test/t1	test/t1	33	8	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single

--- a/mysql-test/suite/innodb_fts/r/tablespace_location_error.result
+++ b/mysql-test/suite/innodb_fts/r/tablespace_location_error.result
@@ -10,6 +10,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -25,6 +27,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -38,6 +42,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -55,6 +61,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -72,6 +80,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	test/t1	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -111,6 +121,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	33	4	Dynamic	0	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	33	4	Dynamic	0	Single
 test/t1	test/t1	33	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -150,6 +162,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	33	4	Dynamic	0	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	33	4	Dynamic	0	Single
 test/t1	test/t1	33	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -189,6 +203,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	33	4	Dynamic	0	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	33	4	Dynamic	0	Single
 test/t1	test/t1	33	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -227,6 +243,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	33	4	Dynamic	0	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	33	4	Dynamic	0	Single
 test/t1	test/t1	33	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -266,6 +284,8 @@ test/fts_aux_deleted	test/fts_aux_deleted	33	4	Dynamic	0	Single
 test/fts_aux_deleted_cache	test/fts_aux_deleted_cache	33	4	Dynamic	0	Single
 test/t1	test/t1	33	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -292,6 +312,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_def	General	DEFAULT	0	1	1	Any	s_def.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -303,6 +325,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s_def	TABLESPACE	InnoDB	NORMAL	s_def	MYSQLD_DATADIR/s_def.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -318,6 +342,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -333,6 +359,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -346,6 +374,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	s_def	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -362,6 +392,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	s_def	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -378,6 +410,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/t1	s_def	161	5	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -416,6 +450,8 @@ test/fts_aux_deleted	s_def	161	4	Dynamic	0	General
 test/fts_aux_deleted_cache	s_def	161	4	Dynamic	0	General
 test/t1	s_def	161	7	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -443,6 +479,8 @@ test/fts_aux_deleted	s_def	161	4	Dynamic	0	General
 test/fts_aux_deleted_cache	s_def	161	4	Dynamic	0	General
 test/t1	s_def	161	7	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -470,6 +508,8 @@ test/fts_aux_deleted	s_def	161	4	Dynamic	0	General
 test/fts_aux_deleted_cache	s_def	161	4	Dynamic	0	General
 test/t1	s_def	161	7	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -496,6 +536,8 @@ test/fts_aux_deleted	s_def	161	4	Dynamic	0	General
 test/fts_aux_deleted_cache	s_def	161	4	Dynamic	0	General
 test/t1	s_def	161	7	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -523,6 +565,8 @@ test/fts_aux_deleted	s_def	161	4	Dynamic	0	General
 test/fts_aux_deleted_cache	s_def	161	4	Dynamic	0	General
 test/t1	s_def	161	7	Dynamic	0	General
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single

--- a/mysql-test/suite/innodb_zip/r/16k.result
+++ b/mysql-test/suite/innodb_zip/r/16k.result
@@ -49,6 +49,8 @@ test/t2	Single	DEFAULT	0	1	1	Compact or Redundant	MYSQLD_DATADIR/test/t2.ibd
 test/t3	Single	DEFAULT	8192	1	1	Compressed	MYSQLD_DATADIR/test/t3.ibd
 test/t4	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t4.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -63,6 +65,8 @@ test/t2	TABLESPACE	InnoDB	NORMAL	test/t2	MYSQLD_DATADIR/test/t2.ibd
 test/t3	TABLESPACE	InnoDB	NORMAL	test/t3	MYSQLD_DATADIR/test/t3.ibd
 test/t4	TABLESPACE	InnoDB	NORMAL	test/t4	MYSQLD_DATADIR/test/t4.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd

--- a/mysql-test/suite/innodb_zip/r/4k.result
+++ b/mysql-test/suite/innodb_zip/r/4k.result
@@ -49,6 +49,8 @@ test/t2	Single	DEFAULT	0	1	1	Compact or Redundant	MYSQLD_DATADIR/test/t2.ibd
 test/t3	Single	DEFAULT	2048	1	1	Compressed	MYSQLD_DATADIR/test/t3.ibd
 test/t4	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t4.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -63,6 +65,8 @@ test/t2	TABLESPACE	InnoDB	NORMAL	test/t2	MYSQLD_DATADIR/test/t2.ibd
 test/t3	TABLESPACE	InnoDB	NORMAL	test/t3	MYSQLD_DATADIR/test/t3.ibd
 test/t4	TABLESPACE	InnoDB	NORMAL	test/t4	MYSQLD_DATADIR/test/t4.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd

--- a/mysql-test/suite/innodb_zip/r/8k.result
+++ b/mysql-test/suite/innodb_zip/r/8k.result
@@ -49,6 +49,8 @@ test/t2	Single	DEFAULT	0	1	1	Compact or Redundant	MYSQLD_DATADIR/test/t2.ibd
 test/t3	Single	DEFAULT	4096	1	1	Compressed	MYSQLD_DATADIR/test/t3.ibd
 test/t4	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/test/t4.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -63,6 +65,8 @@ test/t2	TABLESPACE	InnoDB	NORMAL	test/t2	MYSQLD_DATADIR/test/t2.ibd
 test/t3	TABLESPACE	InnoDB	NORMAL	test/t3	MYSQLD_DATADIR/test/t3.ibd
 test/t4	TABLESPACE	InnoDB	NORMAL	test/t4	MYSQLD_DATADIR/test/t4.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd

--- a/mysql-test/suite/innodb_zip/r/restart.result
+++ b/mysql-test/suite/innodb_zip/r/restart.result
@@ -266,6 +266,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -289,6 +291,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s1_restart	General	DEFAULT	0	1	1	Any	s1_restart.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -312,6 +316,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s1_restart	TABLESPACE	InnoDB	NORMAL	s1_restart	MYSQLD_DATADIR/s1_restart.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -502,6 +508,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -525,6 +533,8 @@ mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s1_restart	General	DEFAULT	0	1	1	Any	s1_restart.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -548,6 +558,8 @@ mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_g
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 s1_restart	TABLESPACE	InnoDB	NORMAL	s1_restart	MYSQLD_DATADIR/s1_restart.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -579,6 +591,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -598,6 +612,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -694,6 +710,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -713,6 +731,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -803,6 +823,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -822,6 +844,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -913,6 +937,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -932,6 +958,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1023,6 +1051,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1042,6 +1072,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1136,6 +1168,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1155,6 +1189,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1330,6 +1366,8 @@ mtr/global_suppressions	mtr/global_suppressions	33	4	Dynamic	0	Single
 mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	Dynamic	0	Single
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -1349,6 +1387,8 @@ mtr/global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/global_s
 mtr/test_ignored_global_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -1368,6 +1408,8 @@ mtr/global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/global_suppressions	MYSQLD_
 mtr/test_ignored_global_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_ignored_global_suppressions	MYSQLD_DATADIR/mtr/test_ignored_global_suppressions.ibd
 mtr/test_suppressions	TABLESPACE	InnoDB	NORMAL	mtr/test_suppressions	MYSQLD_DATADIR/mtr/test_suppressions.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd

--- a/mysql-test/suite/parts/r/partition_reorganize_innodb.result
+++ b/mysql-test/suite/parts/r/partition_reorganize_innodb.result
@@ -56,6 +56,8 @@ test/emp#p#northeast#sp#ne1	test/emp#p#northeast#sp#ne1	97	7	Dynamic	0	Single
 test/emp#p#southwest#sp#sw2	test/emp#p#southwest#sp#sw2	97	7	Dynamic	0	Single
 test/emp#p#southwest#sp#sw3	test/emp#p#southwest#sp#sw3	97	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -70,6 +72,8 @@ test/emp#p#northeast#sp#ne1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_n
 test/emp#p#southwest#sp#sw2	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_southwest/test/emp#p#southwest#sp#sw2.ibd
 test/emp#p#southwest#sp#sw3	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_southwest/test/emp#p#southwest#sp#sw3.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -84,6 +88,8 @@ test/emp#p#northeast#sp#ne1	TABLESPACE	InnoDB	NORMAL	test/emp#p#northeast#sp#ne1
 test/emp#p#southwest#sp#sw2	TABLESPACE	InnoDB	NORMAL	test/emp#p#southwest#sp#sw2	MYSQL_TMP_DIR/alt_dir_southwest/test/emp#p#southwest#sp#sw2.ibd
 test/emp#p#southwest#sp#sw3	TABLESPACE	InnoDB	NORMAL	test/emp#p#southwest#sp#sw3	MYSQL_TMP_DIR/alt_dir_southwest/test/emp#p#southwest#sp#sw3.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -158,6 +164,8 @@ test/emp#p#south#sp#s1	test/emp#p#south#sp#s1	97	7	Dynamic	0	Single
 test/emp#p#west#sp#w0	test/emp#p#west#sp#w0	97	7	Dynamic	0	Single
 test/emp#p#west#sp#w1	test/emp#p#west#sp#w1	97	7	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -176,6 +184,8 @@ test/emp#p#south#sp#s1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_south/
 test/emp#p#west#sp#w0	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west#sp#w0.ibd
 test/emp#p#west#sp#w1	Single	DEFAULT	0	1	1	Dynamic	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west#sp#w1.ibd
 villagesql/custom_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	Single	DEFAULT	0	1	1	Dynamic	MYSQLD_DATADIR/villagesql/properties.ibd
@@ -194,6 +204,8 @@ test/emp#p#south#sp#s1	TABLESPACE	InnoDB	NORMAL	test/emp#p#south#sp#s1	MYSQL_TMP
 test/emp#p#west#sp#w0	TABLESPACE	InnoDB	NORMAL	test/emp#p#west#sp#w0	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west#sp#w0.ibd
 test/emp#p#west#sp#w1	TABLESPACE	InnoDB	NORMAL	test/emp#p#west#sp#w1	MYSQL_TMP_DIR/alt_dir_west/test/emp#p#west#sp#w1.ibd
 villagesql/custom_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_columns	MYSQLD_DATADIR/villagesql/custom_columns.ibd
+villagesql/custom_indexes	TABLESPACE	InnoDB	NORMAL	villagesql/custom_indexes	MYSQLD_DATADIR/villagesql/custom_indexes.ibd
+villagesql/custom_index_columns	TABLESPACE	InnoDB	NORMAL	villagesql/custom_index_columns	MYSQLD_DATADIR/villagesql/custom_index_columns.ibd
 villagesql/custom_sp_params	TABLESPACE	InnoDB	NORMAL	villagesql/custom_sp_params	MYSQLD_DATADIR/villagesql/custom_sp_params.ibd
 villagesql/extensions	TABLESPACE	InnoDB	NORMAL	villagesql/extensions	MYSQLD_DATADIR/villagesql/extensions.ibd
 villagesql/properties	TABLESPACE	InnoDB	NORMAL	villagesql/properties	MYSQLD_DATADIR/villagesql/properties.ibd

--- a/mysql-test/suite/rpl/r/default_row_format_01.result
+++ b/mysql-test/suite/rpl/r/default_row_format_01.result
@@ -39,6 +39,8 @@ test/tab#p#p0	test/tab#p#p0	33	6	Dynamic	0	Single
 test/tab#p#p1	test/tab#p#p1	33	6	Dynamic	0	Single
 test/tab1	test/tab1	33	5	Dynamic	0	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -68,6 +70,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	test/tab	41	5	Compressed	8192	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single
@@ -83,6 +87,8 @@ mtr/test_ignored_global_suppressions	mtr/test_ignored_global_suppressions	33	4	D
 mtr/test_suppressions	mtr/test_suppressions	33	4	Dynamic	0	Single
 test/tab	test/tab	41	5	Compressed	8192	Single
 villagesql/custom_columns	villagesql/custom_columns	33	10	Dynamic	0	Single
+villagesql/custom_indexes	villagesql/custom_indexes	33	11	Dynamic	0	Single
+villagesql/custom_index_columns	villagesql/custom_index_columns	33	9	Dynamic	0	Single
 villagesql/custom_sp_params	villagesql/custom_sp_params	33	10	Dynamic	0	Single
 villagesql/extensions	villagesql/extensions	33	6	Dynamic	0	Single
 villagesql/properties	villagesql/properties	33	6	Dynamic	0	Single

--- a/mysql-test/suite/villagesql/startup/r/upgrade_paths_equivalent.result
+++ b/mysql-test/suite/villagesql/startup/r/upgrade_paths_equivalent.result
@@ -9,7 +9,7 @@ SELECT COUNT(*) AS properties_table_exists
 FROM mysql.tables
 WHERE schema_id = @villagesql_schema_id;
 properties_table_exists
-4
+6
 # Dump fresh state (excluding timestamp columns)
 # Verify INFORMATION_SCHEMA.EXTENSIONS view exists and is queryable
 # Verify INFORMATION_SCHEMA.COLUMNS view depends on villagesql.custom_columns
@@ -29,7 +29,7 @@ SELECT COUNT(*) AS properties_table_exists
 FROM mysql.tables
 WHERE schema_id = @villagesql_schema_id;
 properties_table_exists
-4
+6
 # Dump fresh install state (excluding timestamp columns)
 # Verify INFORMATION_SCHEMA.EXTENSIONS view exists and is queryable
 # Verify INFORMATION_SCHEMA.COLUMNS view depends on villagesql.custom_columns

--- a/unittest/gunit/villagesql/CMakeLists.txt
+++ b/unittest/gunit/villagesql/CMakeLists.txt
@@ -19,6 +19,7 @@
 SET(VILLAGESQL_UNIT_TESTS
   abi_v1_check-t
   abi_v2_check-t
+  custom_indexes-t
   semver-t
   type_context-t
   type_descriptor-t
@@ -61,6 +62,7 @@ ENDMACRO()
 # Add all VillageSQL unit tests
 ADD_VILLAGESQL_TEST(abi_v1_check-t)
 ADD_VILLAGESQL_TEST(abi_v2_check-t)
+ADD_VILLAGESQL_TEST(custom_indexes-t)
 ADD_VILLAGESQL_TEST(semver-t)
 ADD_VILLAGESQL_TEST(type_context-t)
 ADD_VILLAGESQL_TEST(type_descriptor-t)

--- a/unittest/gunit/villagesql/custom_indexes-t.cc
+++ b/unittest/gunit/villagesql/custom_indexes-t.cc
@@ -1,0 +1,250 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "unittest/gunit/test_utils.h"
+#include "villagesql/schema/systable/custom_index_columns.h"
+#include "villagesql/schema/systable/custom_indexes.h"
+#include "villagesql/schema/systable/helpers.h"
+#include "villagesql/schema/victionary_client.h"
+
+namespace villagesql_unittest {
+
+using namespace villagesql;
+
+// ---- Structural tests (no VictionaryClient) --------------------------------
+
+class CustomIndexesTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    villagesql::test_set_lower_case_table_names(0);
+    system_charset_info = &my_charset_utf8mb4_0900_ai_ci;
+  }
+};
+
+TEST_F(CustomIndexesTest, IndexKeyNormalization) {
+  villagesql::test_set_lower_case_table_names(1);
+
+  IndexKey key("MyDB", "MyTable", "MyIndex");
+  EXPECT_EQ(key.str(), "mydb.mytable.myindex");
+  EXPECT_EQ(key.db(), "MyDB");
+  EXPECT_EQ(key.table(), "MyTable");
+  EXPECT_EQ(key.index_name(), "MyIndex");
+}
+
+TEST_F(CustomIndexesTest, IndexKeyCaseSensitive) {
+  villagesql::test_set_lower_case_table_names(0);
+
+  IndexKey key("MyDB", "MyTable", "MyIndex");
+  EXPECT_EQ(key.str(), "MyDB.MyTable.MyIndex");
+}
+
+TEST_F(CustomIndexesTest, IndexKeyPrefix) {
+  villagesql::test_set_lower_case_table_names(1);
+
+  IndexKeyPrefix prefix("MyDB", "MyTable");
+  EXPECT_EQ(prefix.str(), "mydb.mytable.");
+
+  std::string key1 = IndexKey("MyDB", "MyTable", "idx1").str();
+  std::string key2 = IndexKey("MyDB", "MyTable", "idx2").str();
+  std::string other = IndexKey("MyDB", "OtherTable", "idx1").str();
+
+  EXPECT_EQ(key1.substr(0, prefix.str().size()), prefix.str());
+  EXPECT_EQ(key2.substr(0, prefix.str().size()), prefix.str());
+  EXPECT_NE(other.substr(0, prefix.str().size()), prefix.str());
+}
+
+TEST_F(CustomIndexesTest, IndexColumnKeyBasics) {
+  IndexColumnKey key(42, 3);
+  EXPECT_EQ(key.str(), "42.3");
+  EXPECT_EQ(key.index_id(), 42u);
+  EXPECT_EQ(key.key_position(), 3u);
+}
+
+TEST_F(CustomIndexesTest, IndexColumnKeyPrefixOrdering) {
+  // The prefix "42." must match "42.0", "42.1", ... but NOT "420.0".
+  // This relies on ASCII ordering: '.'(46) < '0'(48), so "42/" (upper bound)
+  // correctly excludes "420.*" since '0'(48) > '/'(47).
+  IndexColumnKeyPrefix prefix(42);
+  EXPECT_EQ(prefix.str(), "42.");
+
+  std::string col0 = IndexColumnKey(42, 0).str();    // "42.0"
+  std::string col9 = IndexColumnKey(42, 9).str();    // "42.9"
+  std::string other = IndexColumnKey(420, 0).str();  // "420.0"
+
+  EXPECT_LT(prefix.str(), col0);
+  EXPECT_LT(col0, col9);
+
+  std::string upper = prefix.str();
+  upper.back() = '/';  // '.' + 1 == '/'
+  EXPECT_EQ(upper, "42/");
+
+  EXPECT_GT(other, upper);  // "420.0" excluded by upper bound
+  EXPECT_LT(col9, upper);   // "42.9" included
+}
+
+TEST_F(CustomIndexesTest, IndexEntryDefaults) {
+  IndexEntry entry;
+  EXPECT_EQ(entry.index_id, 0u);
+  EXPECT_EQ(entry.index_type_parameters, "{}");
+}
+
+TEST_F(CustomIndexesTest, IndexEntryFullConstruction) {
+  IndexEntry entry(IndexKey("db", "tbl", "idx"), 7, "my_ext", "1.0", "hnsw",
+                   R"({"dim":128})");
+  EXPECT_EQ(entry.index_id, 7u);
+  EXPECT_EQ(entry.extension_name, "my_ext");
+  EXPECT_EQ(entry.extension_version, "1.0");
+  EXPECT_EQ(entry.index_type_name, "hnsw");
+  EXPECT_EQ(entry.index_type_parameters, R"({"dim":128})");
+  EXPECT_EQ(entry.db_name(), "db");
+  EXPECT_EQ(entry.table_name(), "tbl");
+  EXPECT_EQ(entry.index_name(), "idx");
+}
+
+TEST_F(CustomIndexesTest, IndexColumnEntryConstruction) {
+  IndexColumnEntry entry(IndexColumnKey(10, 0), "embedding", "vec_ext", "2.0",
+                         "cosine_profile");
+  EXPECT_EQ(entry.index_id(), 10u);
+  EXPECT_EQ(entry.key_position(), 0u);
+  EXPECT_EQ(entry.column_name, "embedding");
+  EXPECT_EQ(entry.profile_extension_name, "vec_ext");
+  EXPECT_EQ(entry.profile_extension_version, "2.0");
+  EXPECT_EQ(entry.profile_name, "cosine_profile");
+}
+
+// ---- VictionaryClient integration tests ------------------------------------
+
+class CustomIndexesVictionaryTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    client_ = &VictionaryClient::instance();
+    if (!client_->is_initialized()) {
+      ASSERT_FALSE(client_->init_for_testing());
+    }
+    client_->clear_all_tables();
+    system_charset_info = &my_charset_utf8mb4_0900_ai_ci;
+  }
+
+  void TearDown() override { client_->clear_all_tables(); }
+
+  VictionaryClient *client_;
+};
+
+// Test IndexColumnKeyPrefix ASCII ordering correctness end-to-end.
+// "42." must match "42.0", "42.1", etc. but must NOT match "420.*" entries
+// because '0'(48) > '.'(46) so "420" > "42/" (the upper bound for "42.").
+TEST_F(CustomIndexesVictionaryTest, IndexColumnKeyPrefixExcludesLongerIds) {
+  THD *fake_thd = reinterpret_cast<THD *>(0xB001);
+
+  {
+    auto guard = client_->get_write_lock();
+
+    IndexColumnEntry e1(IndexColumnKey(42, 0), "col_a", "ext", "1.0", "prof");
+    IndexColumnEntry e2(IndexColumnKey(42, 1), "col_b", "ext", "1.0", "prof");
+    IndexColumnEntry e3(IndexColumnKey(420, 0), "col_c", "ext", "1.0", "prof");
+    IndexColumnEntry e4(IndexColumnKey(421, 0), "col_d", "ext", "1.0", "prof");
+    IndexColumnEntry e5(IndexColumnKey(4, 2), "col_e", "ext", "1.0", "prof");
+
+    client_->custom_index_columns().MarkForInsertion(*fake_thd, std::move(e1));
+    client_->custom_index_columns().MarkForInsertion(*fake_thd, std::move(e2));
+    client_->custom_index_columns().MarkForInsertion(*fake_thd, std::move(e3));
+    client_->custom_index_columns().MarkForInsertion(*fake_thd, std::move(e4));
+    client_->custom_index_columns().MarkForInsertion(*fake_thd, std::move(e5));
+  }
+  client_->commit_all_tables(fake_thd);
+
+  {
+    auto guard = client_->get_read_lock();
+    auto results = client_->GetColumnsForIndex(42);
+    EXPECT_EQ(results.size(), 2u);
+    for (const auto *e : results) EXPECT_EQ(e->index_id(), 42u);
+
+    EXPECT_EQ(client_->GetColumnsForIndex(420).size(), 1u);
+    EXPECT_EQ(client_->GetColumnsForIndex(4).size(), 1u);
+  }
+}
+
+// Test allocate_index_id produces strictly increasing unique IDs.
+TEST_F(CustomIndexesVictionaryTest, AllocateIndexId) {
+  uint64_t id1 = client_->allocate_index_id();
+  uint64_t id2 = client_->allocate_index_id();
+  uint64_t id3 = client_->allocate_index_id();
+
+  EXPECT_LT(id1, id2);
+  EXPECT_LT(id2, id3);
+  EXPECT_EQ(id2, id1 + 1);
+  EXPECT_EQ(id3, id2 + 1);
+}
+
+// Test GetCustomIndexesForTable end-to-end.
+TEST_F(CustomIndexesVictionaryTest, GetCustomIndexesForTable) {
+  THD *fake_thd = reinterpret_cast<THD *>(0xB002);
+
+  {
+    auto guard = client_->get_write_lock();
+
+    uint64_t id1 = client_->allocate_index_id();
+    IndexEntry e1(IndexKey("testdb", "t1", "idx_vec"), id1, "ext", "1.0",
+                  "VECTOR_INDEX");
+
+    uint64_t id2 = client_->allocate_index_id();
+    IndexEntry e2(IndexKey("testdb", "t1", "idx_hash"), id2, "ext", "1.0",
+                  "HASH_INDEX");
+
+    uint64_t id3 = client_->allocate_index_id();
+    IndexEntry e3(IndexKey("testdb", "t2", "idx_vec"), id3, "ext", "1.0",
+                  "VECTOR_INDEX");
+
+    client_->custom_indexes().MarkForInsertion(*fake_thd, std::move(e1));
+    client_->custom_indexes().MarkForInsertion(*fake_thd, std::move(e2));
+    client_->custom_indexes().MarkForInsertion(*fake_thd, std::move(e3));
+  }
+  client_->commit_all_tables(fake_thd);
+
+  {
+    auto guard = client_->get_read_lock();
+    EXPECT_EQ(client_->GetCustomIndexesForTable("testdb", "t1").size(), 2u);
+    EXPECT_EQ(client_->GetCustomIndexesForTable("testdb", "t2").size(), 1u);
+    EXPECT_TRUE(
+        client_->GetCustomIndexesForTable("testdb", "no_such_table").empty());
+  }
+}
+
+// Test that staging an index entry only marks the index maps dirty.
+TEST_F(CustomIndexesVictionaryTest, IndexOnlyHasUncommittedOnIndexMaps) {
+  THD *fake_thd = reinterpret_cast<THD *>(0xB003);
+
+  uint64_t id = client_->allocate_index_id();
+  IndexEntry entry(IndexKey("db", "t", "idx"), id, "ext", "1.0", "MY_INDEX");
+
+  {
+    auto guard = client_->get_write_lock();
+    client_->custom_indexes().MarkForInsertion(*fake_thd, std::move(entry));
+
+    EXPECT_TRUE(client_->custom_indexes().has_uncommitted(fake_thd));
+    EXPECT_FALSE(client_->custom_index_columns().has_uncommitted(fake_thd));
+    EXPECT_FALSE(client_->columns().has_uncommitted(fake_thd));
+    EXPECT_FALSE(client_->properties().has_uncommitted(fake_thd));
+  }
+
+  client_->rollback_all_tables(fake_thd);
+}
+
+}  // namespace villagesql_unittest

--- a/villagesql/schema/CMakeLists.txt
+++ b/villagesql/schema/CMakeLists.txt
@@ -23,6 +23,8 @@ SET(VILLAGESQL_SCHEMA_SOURCES
   descriptor/type_context.cc
   descriptor/type_descriptor.cc
   systable/custom_columns.cc
+  systable/custom_index_columns.cc
+  systable/custom_indexes.cc
   systable/custom_sp_params.cc
   systable/extensions.cc
   systable/helpers.cc

--- a/villagesql/schema/schema_manager.cc
+++ b/villagesql/schema/schema_manager.cc
@@ -65,6 +65,8 @@ const char *SchemaManager::PROPERTIES_TABLE_NAME = "properties";
 const char *SchemaManager::COLUMNS_TABLE_NAME = "custom_columns";
 const char *SchemaManager::SP_PARAMS_TABLE_NAME = "custom_sp_params";
 const char *SchemaManager::EXTENSIONS_TABLE_NAME = "extensions";
+const char *SchemaManager::INDEXES_TABLE_NAME = "custom_indexes";
+const char *SchemaManager::INDEX_COLUMNS_TABLE_NAME = "custom_index_columns";
 
 // Define expected structures for all VillageSQL system tables
 namespace {
@@ -240,12 +242,65 @@ static const TABLE_FIELD_TYPE extensions_fields[] = {
      {nullptr, 0}}};
 static const TABLE_FIELD_DEF extensions_def = {3, extensions_fields};
 
+// Define expected structure for custom_indexes table
+static const TABLE_FIELD_TYPE custom_indexes_fields[] = {
+    {{STRING_WITH_LEN("index_id")},
+     {STRING_WITH_LEN("bigint unsigned")},
+     {nullptr, 0}},
+    {{STRING_WITH_LEN("db_name")},
+     {STRING_WITH_LEN("varchar(64)")},
+     {nullptr, 0}},
+    {{STRING_WITH_LEN("table_name")},
+     {STRING_WITH_LEN("varchar(64)")},
+     {nullptr, 0}},
+    {{STRING_WITH_LEN("index_name")},
+     {STRING_WITH_LEN("varchar(64)")},
+     {nullptr, 0}},
+    {{STRING_WITH_LEN("extension_name")},
+     {STRING_WITH_LEN("varchar(64)")},
+     {nullptr, 0}},
+    {{STRING_WITH_LEN("extension_version")},
+     {STRING_WITH_LEN("varchar(64)")},
+     {nullptr, 0}},
+    {{STRING_WITH_LEN("index_type_name")},
+     {STRING_WITH_LEN("varchar(64)")},
+     {nullptr, 0}},
+    {{STRING_WITH_LEN("index_type_parameters")},
+     {STRING_WITH_LEN("json")},
+     {nullptr, 0}}};
+static const TABLE_FIELD_DEF custom_indexes_def = {8, custom_indexes_fields};
+
+// Define expected structure for custom_index_columns table
+static const TABLE_FIELD_TYPE custom_index_columns_fields[] = {
+    {{STRING_WITH_LEN("index_id")},
+     {STRING_WITH_LEN("bigint unsigned")},
+     {nullptr, 0}},
+    {{STRING_WITH_LEN("key_position")},
+     {STRING_WITH_LEN("int unsigned")},
+     {nullptr, 0}},
+    {{STRING_WITH_LEN("column_name")},
+     {STRING_WITH_LEN("varchar(64)")},
+     {nullptr, 0}},
+    {{STRING_WITH_LEN("extension_name")},
+     {STRING_WITH_LEN("varchar(64)")},
+     {nullptr, 0}},
+    {{STRING_WITH_LEN("extension_version")},
+     {STRING_WITH_LEN("varchar(64)")},
+     {nullptr, 0}},
+    {{STRING_WITH_LEN("profile_name")},
+     {STRING_WITH_LEN("varchar(64)")},
+     {nullptr, 0}}};
+static const TABLE_FIELD_DEF custom_index_columns_def = {
+    6, custom_index_columns_fields};
+
 // List of all VillageSQL tables to validate and mark as hidden.
 static const VillageSQL_table tables_to_check[] = {
     {SchemaManager::PROPERTIES_TABLE_NAME, &properties_def},
     {SchemaManager::COLUMNS_TABLE_NAME, &columns_def},
     {SchemaManager::SP_PARAMS_TABLE_NAME, &sp_params_def},
-    {SchemaManager::EXTENSIONS_TABLE_NAME, &extensions_def}};
+    {SchemaManager::EXTENSIONS_TABLE_NAME, &extensions_def},
+    {SchemaManager::INDEXES_TABLE_NAME, &custom_indexes_def},
+    {SchemaManager::INDEX_COLUMNS_TABLE_NAME, &custom_index_columns_def}};
 
 /**
  * Validate all VillageSQL system tables exist and have the correct structure

--- a/villagesql/schema/schema_manager.h
+++ b/villagesql/schema/schema_manager.h
@@ -37,6 +37,8 @@ class SchemaManager {
   static const char *COLUMNS_TABLE_NAME;
   static const char *SP_PARAMS_TABLE_NAME;
   static const char *EXTENSIONS_TABLE_NAME;
+  static const char *INDEXES_TABLE_NAME;
+  static const char *INDEX_COLUMNS_TABLE_NAME;
 
   // Maximum length of a name (extension name, type name, etc.) as stored in
   // the schema (matches the VARCHAR(64) columns in the system tables).

--- a/villagesql/schema/systable/custom_index_columns.cc
+++ b/villagesql/schema/systable/custom_index_columns.cc
@@ -1,0 +1,205 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "villagesql/schema/systable/custom_index_columns.h"
+
+#include "my_inttypes.h"
+#include "scope_guard.h"
+#include "sql/field.h"
+#include "sql/table.h"
+#include "villagesql/include/error.h"
+#include "villagesql/schema/systable/helpers.h"
+
+namespace villagesql {
+
+// Field layout for villagesql.custom_index_columns:
+//   field[0] = index_id               BIGINT UNSIGNED
+//   field[1] = key_position           INT UNSIGNED
+//   field[2] = column_name            VARCHAR(64)
+//   field[3] = extension_name         VARCHAR(64)   (profile's extension)
+//   field[4] = extension_version      VARCHAR(64)   (profile's extension)
+//   field[5] = profile_name           VARCHAR(64)
+//
+// Key layout:
+//   key_info[0] = PRIMARY KEY (index_id, key_position)
+//
+// All operations use the PRIMARY KEY for lookups.
+// update_in_table supports updating non-key fields (e.g. profile rebinding
+// after an extension upgrade). The key (index_id, key_position) never changes.
+
+bool TableTraits<IndexColumnEntry>::read_from_table(TABLE &table,
+                                                    IndexColumnEntry &entry) {
+  Field **field = table.field;
+
+  uint64_t index_id = static_cast<uint64_t>(field[0]->val_int());
+  unsigned int key_pos = 0;
+  read_unsigned_field(field[1], key_pos);
+  entry.set_key(IndexColumnKey(index_id, static_cast<uint32_t>(key_pos)));
+
+  read_string_field(field[2], entry.column_name);
+  read_string_field(field[3], entry.profile_extension_name);
+  read_string_field(field[4], entry.profile_extension_version);
+  read_string_field(field[5], entry.profile_name);
+
+  return false;
+}
+
+bool TableTraits<IndexColumnEntry>::write_to_table(
+    TABLE &table, const IndexColumnEntry &entry) {
+  Field **field = table.field;
+
+  field[0]->store(static_cast<longlong>(entry.index_id()), true);
+  field[1]->store(static_cast<longlong>(entry.key_position()), true);
+  field[2]->store(entry.column_name.c_str(), entry.column_name.length(),
+                  &my_charset_utf8mb4_bin);
+  field[3]->store(entry.profile_extension_name.c_str(),
+                  entry.profile_extension_name.length(),
+                  &my_charset_utf8mb4_bin);
+  field[4]->store(entry.profile_extension_version.c_str(),
+                  entry.profile_extension_version.length(),
+                  &my_charset_utf8mb4_bin);
+  field[5]->store(entry.profile_name.c_str(), entry.profile_name.length(),
+                  &my_charset_utf8mb4_bin);
+
+  int error = table.file->ha_write_row(table.record[0]);
+  if (should_assert_if_true(error)) {
+    LogVSQL(ERROR_LEVEL,
+            "Failed to write row for index column (index_id=%" PRIu64
+            ", key_position=%u): error %d",
+            entry.index_id(), entry.key_position(), error);
+    return true;
+  }
+
+  return false;
+}
+
+bool TableTraits<IndexColumnEntry>::update_in_table(
+    TABLE &table, const IndexColumnEntry &entry, const std::string &old_key) {
+  std::string lookup_key = old_key.empty() ? entry.key().str() : old_key;
+
+  // Parse key "index_id.key_position"
+  size_t dot = lookup_key.find('.');
+  if (should_assert_if_true(dot == std::string::npos)) {
+    LogVSQL(ERROR_LEVEL, "Invalid key format for index column update: %s",
+            lookup_key.c_str());
+    return true;
+  }
+
+  uint64_t old_index_id =
+      static_cast<uint64_t>(std::stoull(lookup_key.substr(0, dot)));
+  uint32_t old_key_position =
+      static_cast<uint32_t>(std::stoul(lookup_key.substr(dot + 1)));
+
+  Field **field = table.field;
+
+  // Set fields[0-1] for primary key lookup (key_info[0])
+  field[0]->store(static_cast<longlong>(old_index_id), true);
+  field[1]->store(static_cast<longlong>(old_key_position), true);
+
+  uchar key_buf[MAX_KEY_LENGTH];
+  key_copy(key_buf, table.record[0], table.key_info,
+           table.key_info->key_length);
+
+  store_record(&table, record[1]);
+
+  int error = table.file->ha_index_init(0, false);
+  if (error) {
+    LogVSQL(ERROR_LEVEL,
+            "Failed to init index for index column update: error %d", error);
+    return true;
+  }
+
+  auto index_end_guard =
+      create_scope_guard([&table]() { table.file->ha_index_end(); });
+
+  error = table.file->ha_index_read_map(table.record[0], key_buf, HA_WHOLE_KEY,
+                                        HA_READ_KEY_EXACT);
+  if (error) {
+    LogVSQL(ERROR_LEVEL, "Failed to find row for index column update: error %d",
+            error);
+    return true;
+  }
+
+  // Update all fields; key (index_id, key_position) is preserved
+  field[0]->store(static_cast<longlong>(entry.index_id()), true);
+  field[1]->store(static_cast<longlong>(entry.key_position()), true);
+  field[2]->store(entry.column_name.c_str(), entry.column_name.length(),
+                  &my_charset_utf8mb4_bin);
+  field[3]->store(entry.profile_extension_name.c_str(),
+                  entry.profile_extension_name.length(),
+                  &my_charset_utf8mb4_bin);
+  field[4]->store(entry.profile_extension_version.c_str(),
+                  entry.profile_extension_version.length(),
+                  &my_charset_utf8mb4_bin);
+  field[5]->store(entry.profile_name.c_str(), entry.profile_name.length(),
+                  &my_charset_utf8mb4_bin);
+
+  error = table.file->ha_update_row(table.record[1], table.record[0]);
+  if (error && error != HA_ERR_RECORD_IS_THE_SAME) {
+    LogVSQL(ERROR_LEVEL, "Failed to update index column row: error %d", error);
+    return true;
+  }
+
+  return false;
+}
+
+bool TableTraits<IndexColumnEntry>::delete_from_table(
+    TABLE &table, const IndexColumnEntry &entry) {
+  Field **field = table.field;
+
+  // Set fields[0-1] for primary key lookup (key_info[0])
+  field[0]->store(static_cast<longlong>(entry.index_id()), true);
+  field[1]->store(static_cast<longlong>(entry.key_position()), true);
+
+  uchar key_buf[MAX_KEY_LENGTH];
+  key_copy(key_buf, table.record[0], table.key_info,
+           table.key_info->key_length);
+
+  int error = table.file->ha_index_init(0, false);
+  if (error) {
+    LogVSQL(ERROR_LEVEL,
+            "Failed to init index for index column delete: error %d", error);
+    return true;
+  }
+
+  auto index_end_guard =
+      create_scope_guard([&table]() { table.file->ha_index_end(); });
+
+  error = table.file->ha_index_read_map(table.record[0], key_buf, HA_WHOLE_KEY,
+                                        HA_READ_KEY_EXACT);
+  if (error) {
+    if (error == HA_ERR_KEY_NOT_FOUND) {
+      LogVSQL(WARNING_LEVEL,
+              "Custom index column row not found for delete: "
+              "index_id=%" PRIu64 ", key_position=%u",
+              entry.index_id(), entry.key_position());
+      return false;
+    }
+    LogVSQL(ERROR_LEVEL, "Failed to find row for index column delete: error %d",
+            error);
+    return true;
+  }
+
+  error = table.file->ha_delete_row(table.record[0]);
+  if (error) {
+    LogVSQL(ERROR_LEVEL, "Failed to delete index column row: error %d", error);
+    return true;
+  }
+
+  return false;
+}
+
+}  // namespace villagesql

--- a/villagesql/schema/systable/custom_index_columns.h
+++ b/villagesql/schema/systable/custom_index_columns.h
@@ -1,0 +1,128 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef VILLAGESQL_SCHEMA_SYSTABLE_CUSTOM_INDEX_COLUMNS_H_
+#define VILLAGESQL_SCHEMA_SYSTABLE_CUSTOM_INDEX_COLUMNS_H_
+
+#include <cstdint>
+#include <string>
+
+#include "villagesql/schema/systable/helpers.h"
+
+struct TABLE;
+
+namespace villagesql {
+
+template <typename EntryType>
+struct TableTraits;
+
+// Prefix key for querying all column bindings for a given index_id.
+// Format: "index_id_string."  (e.g. "42.")
+// ASCII ordering ensures "42." < "42.N" < "42/" so prefix scan is exact.
+struct IndexColumnKeyPrefix {
+ public:
+  explicit IndexColumnKeyPrefix(uint64_t index_id)
+      : prefix_(std::to_string(index_id) + ".") {}
+
+  const std::string &str() const { return prefix_; }
+
+ private:
+  std::string prefix_;
+};
+
+// Key for custom_index_columns table entries.
+// Format: "index_id_string.key_position_string"  (e.g. "42.0")
+struct IndexColumnKey {
+ public:
+  IndexColumnKey() = default;
+
+  IndexColumnKey(uint64_t index_id, uint32_t key_position)
+      : index_id_(index_id),
+        key_position_(key_position),
+        key_str_(std::to_string(index_id) + "." +
+                 std::to_string(key_position)) {}
+
+  const std::string &str() const { return key_str_; }
+
+  uint64_t index_id() const { return index_id_; }
+  uint32_t key_position() const { return key_position_; }
+
+  bool operator<(const IndexColumnKey &other) const {
+    return key_str_ < other.key_str_;
+  }
+  bool operator==(const IndexColumnKey &other) const {
+    return key_str_ == other.key_str_;
+  }
+
+ private:
+  uint64_t index_id_{0};
+  uint32_t key_position_{0};
+  std::string key_str_;
+};
+
+// Entry for custom_index_columns system table.
+// Stores per-column profile bindings for a VillageSQL custom index.
+struct IndexColumnEntry {
+ public:
+  using key_type = IndexColumnKey;
+  using key_prefix_type = IndexColumnKeyPrefix;
+
+  // Non-key fields (public)
+  std::string column_name;
+  std::string profile_extension_name;
+  std::string profile_extension_version;
+  std::string profile_name;
+
+  IndexColumnEntry() = default;
+
+  explicit IndexColumnEntry(IndexColumnKey key) : key_(std::move(key)) {}
+
+  IndexColumnEntry(IndexColumnKey key, std::string col_name,
+                   std::string prof_ext_name, std::string prof_ext_version,
+                   std::string prof_name)
+      : column_name(std::move(col_name)),
+        profile_extension_name(std::move(prof_ext_name)),
+        profile_extension_version(std::move(prof_ext_version)),
+        profile_name(std::move(prof_name)),
+        key_(std::move(key)) {}
+
+  const IndexColumnKey &key() const { return key_; }
+  uint64_t index_id() const { return key_.index_id(); }
+  uint32_t key_position() const { return key_.key_position(); }
+
+ protected:
+  void set_key(IndexColumnKey key) { key_ = std::move(key); }
+  friend struct TableTraits<IndexColumnEntry>;
+
+ private:
+  IndexColumnKey key_;
+};
+
+// TableTraits specialization for IndexColumnEntry.
+// delete_from_table and update_in_table use the PRIMARY KEY (index_id,
+// key_position) = key_info[0].
+template <>
+struct TableTraits<IndexColumnEntry> {
+  static bool read_from_table(TABLE &table, IndexColumnEntry &entry);
+  static bool write_to_table(TABLE &table, const IndexColumnEntry &entry);
+  static bool update_in_table(TABLE &table, const IndexColumnEntry &entry,
+                              const std::string &old_key);
+  static bool delete_from_table(TABLE &table, const IndexColumnEntry &entry);
+};
+
+}  // namespace villagesql
+
+#endif  // VILLAGESQL_SCHEMA_SYSTABLE_CUSTOM_INDEX_COLUMNS_H_

--- a/villagesql/schema/systable/custom_indexes.cc
+++ b/villagesql/schema/systable/custom_indexes.cc
@@ -1,0 +1,225 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "villagesql/schema/systable/custom_indexes.h"
+
+#include "scope_guard.h"
+#include "sql/field.h"
+#include "sql/table.h"
+#include "villagesql/include/error.h"
+#include "villagesql/schema/systable/helpers.h"
+
+namespace villagesql {
+
+// Field layout for villagesql.custom_indexes:
+//   field[0] = index_id               BIGINT UNSIGNED
+//   field[1] = db_name                VARCHAR(64)
+//   field[2] = table_name             VARCHAR(64)
+//   field[3] = index_name             VARCHAR(64)
+//   field[4] = extension_name         VARCHAR(64)
+//   field[5] = extension_version      VARCHAR(64)
+//   field[6] = index_type_name        VARCHAR(64)
+//   field[7] = index_type_parameters  JSON
+//
+// Key layout:
+//   key_info[0] = PRIMARY KEY (index_id)
+//   key_info[1] = UNIQUE KEY idx_natural (db_name, table_name, index_name)
+//
+// update_in_table and delete_from_table use key_info[1] (the natural unique
+// key) because callers hold a natural key string, not index_id.
+
+bool TableTraits<IndexEntry>::read_from_table(TABLE &table, IndexEntry &entry) {
+  Field **field = table.field;
+
+  entry.index_id = static_cast<uint64_t>(field[0]->val_int());
+
+  std::string db, tbl, idx;
+  read_string_field(field[1], db);
+  read_string_field(field[2], tbl);
+  read_string_field(field[3], idx);
+  entry.set_key(IndexKey(std::move(db), std::move(tbl), std::move(idx)));
+
+  read_string_field(field[4], entry.extension_name);
+  read_string_field(field[5], entry.extension_version);
+  read_string_field(field[6], entry.index_type_name);
+  read_string_field(field[7], entry.index_type_parameters);
+
+  return false;
+}
+
+bool TableTraits<IndexEntry>::write_to_table(TABLE &table,
+                                             const IndexEntry &entry) {
+  Field **field = table.field;
+
+  field[0]->store(static_cast<longlong>(entry.index_id), true);
+  field[1]->store(entry.db_name().c_str(), entry.db_name().length(),
+                  &my_charset_utf8mb4_bin);
+  field[2]->store(entry.table_name().c_str(), entry.table_name().length(),
+                  &my_charset_utf8mb4_bin);
+  field[3]->store(entry.index_name().c_str(), entry.index_name().length(),
+                  &my_charset_utf8mb4_bin);
+  field[4]->store(entry.extension_name.c_str(), entry.extension_name.length(),
+                  &my_charset_utf8mb4_bin);
+  field[5]->store(entry.extension_version.c_str(),
+                  entry.extension_version.length(), &my_charset_utf8mb4_bin);
+  field[6]->store(entry.index_type_name.c_str(), entry.index_type_name.length(),
+                  &my_charset_utf8mb4_bin);
+  field[7]->store(entry.index_type_parameters.c_str(),
+                  entry.index_type_parameters.length(),
+                  &my_charset_utf8mb4_bin);
+
+  int error = table.file->ha_write_row(table.record[0]);
+  if (should_assert_if_true(error)) {
+    LogVSQL(ERROR_LEVEL,
+            "Failed to write row for index '%s' in table '%s.%s': error %d",
+            entry.index_name().c_str(), entry.db_name().c_str(),
+            entry.table_name().c_str(), error);
+    return true;
+  }
+
+  return false;
+}
+
+bool TableTraits<IndexEntry>::update_in_table(TABLE &table,
+                                              const IndexEntry &entry,
+                                              const std::string &old_key) {
+  std::string lookup_key = old_key.empty() ? entry.key().str() : old_key;
+
+  // Parse natural key "db.table.index_name"
+  size_t first_dot = lookup_key.find('.');
+  size_t second_dot = lookup_key.find('.', first_dot + 1);
+  if (should_assert_if_true(first_dot == std::string::npos ||
+                            second_dot == std::string::npos)) {
+    LogVSQL(ERROR_LEVEL, "Invalid key format for index update: %s",
+            lookup_key.c_str());
+    return true;
+  }
+
+  std::string old_db = lookup_key.substr(0, first_dot);
+  std::string old_table =
+      lookup_key.substr(first_dot + 1, second_dot - first_dot - 1);
+  std::string old_index = lookup_key.substr(second_dot + 1);
+
+  Field **field = table.field;
+
+  // Set fields[1-3] for natural unique key lookup (key_info[1])
+  field[1]->store(old_db.c_str(), old_db.length(), &my_charset_utf8mb4_bin);
+  field[2]->store(old_table.c_str(), old_table.length(),
+                  &my_charset_utf8mb4_bin);
+  field[3]->store(old_index.c_str(), old_index.length(),
+                  &my_charset_utf8mb4_bin);
+
+  uchar key_buf[MAX_KEY_LENGTH];
+  key_copy(key_buf, table.record[0], &table.key_info[1],
+           table.key_info[1].key_length);
+
+  store_record(&table, record[1]);
+
+  int error = table.file->ha_index_init(1, false);
+  if (error) {
+    LogVSQL(ERROR_LEVEL, "Failed to init index for index update: error %d",
+            error);
+    return true;
+  }
+
+  auto index_end_guard =
+      create_scope_guard([&table]() { table.file->ha_index_end(); });
+
+  error = table.file->ha_index_read_map(table.record[0], key_buf, HA_WHOLE_KEY,
+                                        HA_READ_KEY_EXACT);
+  if (error) {
+    LogVSQL(ERROR_LEVEL, "Failed to find row for index update: error %d",
+            error);
+    return true;
+  }
+
+  // Update all fields; index_id is preserved (rename does not change it)
+  field[0]->store(static_cast<longlong>(entry.index_id), true);
+  field[1]->store(entry.db_name().c_str(), entry.db_name().length(),
+                  &my_charset_utf8mb4_bin);
+  field[2]->store(entry.table_name().c_str(), entry.table_name().length(),
+                  &my_charset_utf8mb4_bin);
+  field[3]->store(entry.index_name().c_str(), entry.index_name().length(),
+                  &my_charset_utf8mb4_bin);
+  field[4]->store(entry.extension_name.c_str(), entry.extension_name.length(),
+                  &my_charset_utf8mb4_bin);
+  field[5]->store(entry.extension_version.c_str(),
+                  entry.extension_version.length(), &my_charset_utf8mb4_bin);
+  field[6]->store(entry.index_type_name.c_str(), entry.index_type_name.length(),
+                  &my_charset_utf8mb4_bin);
+  field[7]->store(entry.index_type_parameters.c_str(),
+                  entry.index_type_parameters.length(),
+                  &my_charset_utf8mb4_bin);
+
+  error = table.file->ha_update_row(table.record[1], table.record[0]);
+  if (error && error != HA_ERR_RECORD_IS_THE_SAME) {
+    LogVSQL(ERROR_LEVEL, "Failed to update index row: error %d", error);
+    return true;
+  }
+
+  return false;
+}
+
+bool TableTraits<IndexEntry>::delete_from_table(TABLE &table,
+                                                const IndexEntry &entry) {
+  Field **field = table.field;
+
+  // Set fields[1-3] for natural unique key lookup (key_info[1])
+  field[1]->store(entry.db_name().c_str(), entry.db_name().length(),
+                  &my_charset_utf8mb4_bin);
+  field[2]->store(entry.table_name().c_str(), entry.table_name().length(),
+                  &my_charset_utf8mb4_bin);
+  field[3]->store(entry.index_name().c_str(), entry.index_name().length(),
+                  &my_charset_utf8mb4_bin);
+
+  uchar key_buf[MAX_KEY_LENGTH];
+  key_copy(key_buf, table.record[0], &table.key_info[1],
+           table.key_info[1].key_length);
+
+  int error = table.file->ha_index_init(1, false);
+  if (error) {
+    LogVSQL(ERROR_LEVEL, "Failed to init index for index delete: error %d",
+            error);
+    return true;
+  }
+
+  auto index_end_guard =
+      create_scope_guard([&table]() { table.file->ha_index_end(); });
+
+  error = table.file->ha_index_read_map(table.record[0], key_buf, HA_WHOLE_KEY,
+                                        HA_READ_KEY_EXACT);
+  if (error) {
+    if (error == HA_ERR_KEY_NOT_FOUND) {
+      LogVSQL(WARNING_LEVEL, "Custom index row not found for delete: %s.%s.%s",
+              entry.db_name().c_str(), entry.table_name().c_str(),
+              entry.index_name().c_str());
+      return false;
+    }
+    LogVSQL(ERROR_LEVEL, "Failed to find row for index delete: error %d",
+            error);
+    return true;
+  }
+
+  error = table.file->ha_delete_row(table.record[0]);
+  if (error) {
+    LogVSQL(ERROR_LEVEL, "Failed to delete index row: error %d", error);
+    return true;
+  }
+
+  return false;
+}
+
+}  // namespace villagesql

--- a/villagesql/schema/systable/custom_indexes.h
+++ b/villagesql/schema/systable/custom_indexes.h
@@ -1,0 +1,150 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef VILLAGESQL_SCHEMA_SYSTABLE_CUSTOM_INDEXES_H_
+#define VILLAGESQL_SCHEMA_SYSTABLE_CUSTOM_INDEXES_H_
+
+#include <cstdint>
+#include <string>
+
+#include "villagesql/schema/systable/helpers.h"
+
+struct TABLE;
+
+namespace villagesql {
+
+template <typename EntryType>
+struct TableTraits;
+
+// Prefix key for querying all custom indexes for a db.table.
+// Format: "normalized_db.normalized_table."
+struct IndexKeyPrefix {
+ public:
+  // If table_name is empty, produces "db." prefix for all tables in that db.
+  IndexKeyPrefix(std::string db_name, std::string table_name)
+      : db_(std::move(db_name)),
+        table_(std::move(table_name)),
+        normalized_prefix_(
+            normalize_database_name(db_) + "." +
+            (table_.empty() ? "" : normalize_table_name(table_) + ".")) {}
+
+  const std::string &str() const { return normalized_prefix_; }
+  const std::string &db() const { return db_; }
+  const std::string &table() const { return table_; }
+
+ private:
+  std::string db_;
+  std::string table_;
+  std::string normalized_prefix_;
+};
+
+// Key for custom_indexes table entries (natural key).
+// Format: "normalized_db.normalized_table.normalized_index_name"
+struct IndexKey {
+ public:
+  IndexKey() = default;
+
+  IndexKey(std::string db_name, std::string table_name, std::string index_name)
+      : db_(std::move(db_name)),
+        table_(std::move(table_name)),
+        index_(std::move(index_name)),
+        normalized_key_(normalize_database_name(db_) + "." +
+                        normalize_table_name(table_) + "." +
+                        normalize_index_name(index_)) {}
+
+  const std::string &str() const { return normalized_key_; }
+
+  const std::string &db() const { return db_; }
+  const std::string &table() const { return table_; }
+  const std::string &index_name() const { return index_; }
+
+  bool operator<(const IndexKey &other) const {
+    return normalized_key_ < other.normalized_key_;
+  }
+  bool operator==(const IndexKey &other) const {
+    return normalized_key_ == other.normalized_key_;
+  }
+
+ private:
+  std::string db_;
+  std::string table_;
+  std::string index_;
+  std::string normalized_key_;
+};
+
+// Entry for custom_indexes system table.
+// The natural in-memory key is "db.table.index_name". index_id is the physical
+// surrogate primary key, assigned by VictionaryClient::allocate_index_id()
+// before MarkForInsertion so it is known at staging time.
+struct IndexEntry {
+ public:
+  using key_type = IndexKey;
+  using key_prefix_type = IndexKeyPrefix;
+
+  // Surrogate primary key in the physical table.
+  uint64_t index_id{0};
+
+  // Non-key data (public)
+  std::string extension_name;
+  std::string extension_version;
+  std::string index_type_name;
+  std::string index_type_parameters = "{}";  // JSON-serialized parameters
+
+  IndexEntry() = default;
+
+  explicit IndexEntry(IndexKey key) : key_(std::move(key)) {}
+
+  IndexEntry(IndexKey key, uint64_t id, std::string ext_name,
+             std::string ext_version, std::string type_name,
+             std::string type_params = "{}")
+      : index_id(id),
+        extension_name(std::move(ext_name)),
+        extension_version(std::move(ext_version)),
+        index_type_name(std::move(type_name)),
+        index_type_parameters(std::move(type_params)),
+        key_(std::move(key)) {}
+
+  const IndexKey &key() const { return key_; }
+
+  const std::string &db_name() const { return key_.db(); }
+  const std::string &table_name() const { return key_.table(); }
+  const std::string &index_name() const { return key_.index_name(); }
+
+ protected:
+  void set_key(IndexKey key) { key_ = std::move(key); }
+  friend struct TableTraits<IndexEntry>;
+
+ private:
+  IndexKey key_;
+};
+
+// TableTraits specialization for IndexEntry.
+// delete_from_table and update_in_table use the UNIQUE KEY idx_natural
+// (db_name, table_name, index_name) = key_info[1] for lookups, since the
+// natural key is what callers have; index_id is the physical PK but is not
+// known for DELETE-by-key temp entries.
+template <>
+struct TableTraits<IndexEntry> {
+  static bool read_from_table(TABLE &table, IndexEntry &entry);
+  static bool write_to_table(TABLE &table, const IndexEntry &entry);
+  static bool update_in_table(TABLE &table, const IndexEntry &entry,
+                              const std::string &old_key);
+  static bool delete_from_table(TABLE &table, const IndexEntry &entry);
+};
+
+}  // namespace villagesql
+
+#endif  // VILLAGESQL_SCHEMA_SYSTABLE_CUSTOM_INDEXES_H_

--- a/villagesql/schema/systable/helpers.cc
+++ b/villagesql/schema/systable/helpers.cc
@@ -200,6 +200,13 @@ std::string normalize_type_name(const std::string &name) {
   return casedn(&my_charset_utf8mb4_0900_ai_ci, name);
 }
 
+std::string normalize_index_name(const std::string &name) {
+  if (::lower_case_table_names == 0) {
+    return name;
+  }
+  return casedn(get_identifier_charset(), name);
+}
+
 // ===== Test utilities =====
 void test_set_lower_case_table_names(int value) {
   ::lower_case_table_names = value;

--- a/villagesql/schema/systable/helpers.h
+++ b/villagesql/schema/systable/helpers.h
@@ -51,6 +51,9 @@ std::string normalize_extension_name(const std::string &name);
 // Type names: Always case-insensitive (like SQL type names)
 std::string normalize_type_name(const std::string &name);
 
+// Index names: Follow lower_case_table_names setting (same as table names)
+std::string normalize_index_name(const std::string &name);
+
 // Build a qualified base name string "extension_name.type_name".
 inline std::string make_qualified_base_name(std::string_view extension_name,
                                             std::string_view type_name) {

--- a/villagesql/schema/victionary_client.cc
+++ b/villagesql/schema/victionary_client.cc
@@ -16,6 +16,7 @@
 
 #include "villagesql/schema/victionary_client.h"
 
+#include "my_inttypes.h"
 #include "scope_guard.h"
 #include "sql/auth/auth_common.h"
 #include "sql/auth/sql_security_ctx.h"
@@ -153,6 +154,8 @@ void VictionaryClient::commit_all_tables(THD *thd) {
   m_extension_descriptors.commit(thd);
   m_type_contexts.commit(thd);
   m_funcs.commit(thd);
+  m_custom_indexes.commit(thd);
+  m_custom_index_columns.commit(thd);
 }
 
 void VictionaryClient::rollback_all_tables(THD *thd) {
@@ -168,6 +171,8 @@ void VictionaryClient::rollback_all_tables(THD *thd) {
   m_extension_descriptors.rollback(thd);
   m_type_contexts.rollback(thd);
   m_funcs.rollback(thd);
+  m_custom_indexes.rollback(thd);
+  m_custom_index_columns.rollback(thd);
 }
 
 bool VictionaryClient::write_all_uncommitted_entries(THD *thd) {
@@ -215,6 +220,18 @@ bool VictionaryClient::write_all_uncommitted_entries(THD *thd) {
           SchemaManager::EXTENSIONS_TABLE_NAME)) {
     error = true;
   }
+  // custom_indexes must be written before custom_index_columns so the parent
+  // row exists when the per-column rows reference it.
+  if (m_custom_indexes.write_uncommitted_to_table(
+          thd, SchemaManager::VILLAGESQL_SCHEMA_NAME,
+          SchemaManager::INDEXES_TABLE_NAME)) {
+    error = true;
+  }
+  if (m_custom_index_columns.write_uncommitted_to_table(
+          thd, SchemaManager::VILLAGESQL_SCHEMA_NAME,
+          SchemaManager::INDEX_COLUMNS_TABLE_NAME)) {
+    error = true;
+  }
 
   // Errors are already set by write_uncommitted_to_table and TableTraits
   // functions
@@ -253,8 +270,47 @@ bool VictionaryClient::reload_all_tables(THD *thd) {
                                     SchemaManager::SP_PARAMS_TABLE_NAME)) {
     error = true;
   }
+  if (m_custom_indexes.reload_from_table(thd,
+                                         SchemaManager::VILLAGESQL_SCHEMA_NAME,
+                                         SchemaManager::INDEXES_TABLE_NAME)) {
+    error = true;
+  }
+  // Seed the index_id counter from the maximum existing id so that
+  // allocate_index_id() always produces a value greater than any persisted id.
+  init_index_id_counter();
+  if (m_custom_index_columns.reload_from_table(
+          thd, SchemaManager::VILLAGESQL_SCHEMA_NAME,
+          SchemaManager::INDEX_COLUMNS_TABLE_NAME)) {
+    error = true;
+  }
 
   return error;
+}
+
+std::vector<const IndexEntry *> VictionaryClient::GetCustomIndexesForTable(
+    const std::string &db_name, const std::string &table_name) const {
+  if (!m_initialized.load()) return {};
+  return m_custom_indexes.get_prefix_committed(
+      IndexKeyPrefix(db_name, table_name));
+}
+
+std::vector<const IndexColumnEntry *> VictionaryClient::GetColumnsForIndex(
+    uint64_t index_id) const {
+  if (!m_initialized.load()) return {};
+  return m_custom_index_columns.get_prefix_committed(
+      IndexColumnKeyPrefix(index_id));
+}
+
+void VictionaryClient::init_index_id_counter() {
+  // Must be called while holding write lock (reload_all_tables holds it).
+  uint64_t max_id = 0;
+  for (const IndexEntry *entry : m_custom_indexes.get_all_committed()) {
+    if (entry->index_id > max_id) max_id = entry->index_id;
+  }
+  m_next_index_id.store(max_id);
+  LogVSQL(INFORMATION_LEVEL,
+          "Index ID counter initialized to %" PRIu64 " (max existing id)",
+          max_id);
 }
 
 void VictionaryClient::clear_all_tables() {
@@ -272,6 +328,8 @@ void VictionaryClient::clear_all_tables() {
   m_extension_descriptors.clear();
   m_type_contexts.clear();
   m_funcs.clear();
+  m_custom_indexes.clear();
+  m_custom_index_columns.clear();
 
   LogVSQL(INFORMATION_LEVEL, "Cleared all system table metadata");
 }

--- a/villagesql/schema/victionary_client.h
+++ b/villagesql/schema/victionary_client.h
@@ -46,14 +46,17 @@
 #include "villagesql/schema/descriptor/type_context.h"
 #include "villagesql/schema/descriptor/type_descriptor.h"
 #include "villagesql/schema/systable/custom_columns.h"
+#include "villagesql/schema/systable/custom_index_columns.h"
+#include "villagesql/schema/systable/custom_indexes.h"
 #include "villagesql/schema/systable/custom_sp_params.h"
 #include "villagesql/schema/systable/extensions.h"
 #include "villagesql/schema/systable/properties.h"
 #include "villagesql/schema/util.h"
 
-// Forward declaration for friend class
+// Forward declarations for friend classes
 namespace villagesql_unittest {
 class VictionaryClientTest;
+class CustomIndexesVictionaryTest;
 }
 
 namespace villagesql {
@@ -681,6 +684,10 @@ class VictionaryClient {
   }
   ExtensionObjectMap<TypeContext> &type_contexts() { return m_type_contexts; }
   ExtensionObjectMap<FuncDescriptor> &funcs() { return m_funcs; }
+  SystemTableMap<IndexEntry> &custom_indexes() { return m_custom_indexes; }
+  SystemTableMap<IndexColumnEntry> &custom_index_columns() {
+    return m_custom_index_columns;
+  }
 
   const SystemTableMap<PropertyEntry> &properties() const {
     return m_properties;
@@ -700,6 +707,12 @@ class VictionaryClient {
     return m_type_contexts;
   }
   const ExtensionObjectMap<FuncDescriptor> &funcs() const { return m_funcs; }
+  const SystemTableMap<IndexEntry> &custom_indexes() const {
+    return m_custom_indexes;
+  }
+  const SystemTableMap<IndexColumnEntry> &custom_index_columns() const {
+    return m_custom_index_columns;
+  }
 
   // ===== Convenience query methods =====
 
@@ -714,6 +727,24 @@ class VictionaryClient {
   // Returns vector of pointers to SpParamEntry (valid while lock is held)
   std::vector<const SpParamEntry *> GetCustomSpParamsForSP(
       const std::string &db_name, const std::string &sp_name) const;
+
+  // Get all custom indexes for a table.
+  // Caller must hold at least read lock.
+  // Returns vector of pointers (valid while lock is held).
+  std::vector<const IndexEntry *> GetCustomIndexesForTable(
+      const std::string &db_name, const std::string &table_name) const;
+
+  // Get all per-column profile bindings for a custom index.
+  // Caller must hold at least read lock.
+  // Returns vector of pointers (valid while lock is held).
+  std::vector<const IndexColumnEntry *> GetColumnsForIndex(
+      uint64_t index_id) const;
+
+  // Allocate a unique index_id for a new custom index. The counter is
+  // initialized at startup from MAX(index_id) in custom_indexes so the
+  // returned value is safe to use as the physical primary key before
+  // MarkForInsertion is called. Thread-safe: uses atomic increment.
+  uint64_t allocate_index_id() { return ++m_next_index_id; }
 
   // ===== Transaction lifecycle - operates on ALL tables =====
 
@@ -796,7 +827,9 @@ class VictionaryClient {
         m_type_descriptors(&m_lock),
         m_extension_descriptors(&m_lock),
         m_type_contexts(&m_lock),
-        m_funcs(&m_lock) {}
+        m_funcs(&m_lock),
+        m_custom_indexes(&m_lock),
+        m_custom_index_columns(&m_lock) {}
   ~VictionaryClient();
 
   // Disable copy and assignment
@@ -807,6 +840,11 @@ class VictionaryClient {
   // init(). Returns false on success, true on error.
   bool reload_all_tables(THD *thd);
 
+  // Seed m_next_index_id from the maximum index_id present in m_custom_indexes.
+  // Called once after m_custom_indexes is loaded during reload_all_tables.
+  // Requires write lock (already held by reload_all_tables).
+  void init_index_id_counter();
+
   // Initialize for unit testing without loading from database tables.
   // This only initializes the lock and marks the client as initialized.
   // Returns false on success, true on error.
@@ -814,6 +852,7 @@ class VictionaryClient {
 
   // Friend classes
   friend class villagesql_unittest::VictionaryClientTest;
+  friend class villagesql_unittest::CustomIndexesVictionaryTest;
   friend class ReadLockGuard;
   friend class WriteLockGuard;
 
@@ -855,6 +894,16 @@ class VictionaryClient {
   ExtensionObjectMap<ExtensionDescriptor> m_extension_descriptors;
   ExtensionObjectMap<TypeContext> m_type_contexts;
   ExtensionObjectMap<FuncDescriptor> m_funcs;
+
+  // Custom index maps
+  SystemTableMap<IndexEntry> m_custom_indexes;
+  SystemTableMap<IndexColumnEntry> m_custom_index_columns;
+
+  // Server-assigned surrogate key counter for custom_indexes.index_id.
+  // Initialized from MAX(index_id) in custom_indexes at startup.
+  // allocate_index_id() returns ++m_next_index_id (pre-increment, so first
+  // allocation after startup yields max+1).
+  std::atomic<uint64_t> m_next_index_id{0};
 };
 
 // ===== Helper functions =====

--- a/villagesql/schema/victionary_client.h
+++ b/villagesql/schema/victionary_client.h
@@ -843,6 +843,15 @@ class VictionaryClient {
   // Seed m_next_index_id from the maximum index_id present in m_custom_indexes.
   // Called once after m_custom_indexes is loaded during reload_all_tables.
   // Requires write lock (already held by reload_all_tables).
+  //
+  // We manage the counter explicitly rather than using an AUTO_INCREMENT column
+  // because index_id must be known before the transaction commits: both
+  // custom_indexes and custom_index_columns are staged in memory together and
+  // written atomically at commit. With AUTO_INCREMENT the server only assigns
+  // the id at ha_write_row() time, so we would have to insert custom_indexes
+  // first, read the generated id back from uncommitted storage, and then
+  // stage custom_index_columns — adding complexity and a mid-transaction read.
+  // Pre-allocating via allocate_index_id() avoids that entirely.
   void init_index_id_counter();
 
   // Initialize for unit testing without loading from database tables.

--- a/villagesql/schema/villagesql_schema.sql.in
+++ b/villagesql/schema/villagesql_schema.sql.in
@@ -62,6 +62,33 @@ CREATE TABLE IF NOT EXISTS villagesql.custom_sp_params (
 ROW_FORMAT=DYNAMIC
 COMMENT='VillageSQL stored procedure/function parameters that use custom types';
 
+CREATE TABLE IF NOT EXISTS villagesql.custom_indexes (
+  index_id               BIGINT UNSIGNED NOT NULL COMMENT 'Server-assigned unique index identifier',
+  db_name                VARCHAR(64) NOT NULL COMMENT 'Database name',
+  table_name             VARCHAR(64) NOT NULL COMMENT 'Table name',
+  index_name             VARCHAR(64) NOT NULL COMMENT 'Index name',
+  extension_name         VARCHAR(64) NOT NULL COMMENT 'Extension providing the index type',
+  extension_version      VARCHAR(64) NOT NULL COMMENT 'Version of the extension',
+  index_type_name        VARCHAR(64) NOT NULL COMMENT 'Custom index type name from the extension',
+  index_type_parameters  JSON NOT NULL COMMENT 'Index type instantiation parameters as JSON',
+  PRIMARY KEY (index_id),
+  UNIQUE KEY idx_natural (db_name, table_name, index_name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ROW_FORMAT=DYNAMIC
+COMMENT='VillageSQL indexes that use custom index types';
+
+CREATE TABLE IF NOT EXISTS villagesql.custom_index_columns (
+  index_id          BIGINT UNSIGNED NOT NULL COMMENT 'FK to custom_indexes.index_id',
+  key_position      INT UNSIGNED NOT NULL COMMENT '0-based position of this column in the index key',
+  column_name       VARCHAR(64) NOT NULL COMMENT 'Name of the indexed column',
+  extension_name    VARCHAR(64) NOT NULL COMMENT 'Extension providing the index profile',
+  extension_version VARCHAR(64) NOT NULL COMMENT 'Version of the extension',
+  profile_name      VARCHAR(64) NOT NULL COMMENT 'Index profile name binding type to index algorithm',
+  PRIMARY KEY (index_id, key_position)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+ROW_FORMAT=DYNAMIC
+COMMENT='Per-column profile bindings for VillageSQL custom indexes';
+
 -- Store VillageSQL system properties (version, configuration, etc.)
 -- NOTE: THIS MUST BE THE FINAL TABLE IN THIS FILE!
 -- Reason: we detect a partial install by seeing the schema exists but


### PR DESCRIPTION
## Description

```sql
villagesql.custom_indexes:
  index_id               BIGINT UNSIGNED
  db_name                VARCHAR(64)
  table_name             VARCHAR(64)
  index_name             VARCHAR(64)
  extension_name         VARCHAR(64)
  extension_version      VARCHAR(64)
  index_type_name        VARCHAR(64)
  index_type_parameters  JSON
```

```sql
villagesql.custom_index_columns:
  index_id               BIGINT UNSIGNED
  key_position           INT UNSIGNED
  column_name            VARCHAR(64)
  extension_name         VARCHAR(64)
  extension_version      VARCHAR(64)
  profile_name           VARCHAR(64)
```

Fixes #384.