### PR TITLE
SQL syntax: Support custom index

### DIFF
--- a/mysql-test/suite/villagesql/index/r/alter_table_index.result
+++ b/mysql-test/suite/villagesql/index/r/alter_table_index.result
@@ -1,0 +1,25 @@
+CREATE TABLE t (id INT PRIMARY KEY, val INT);
+ALTER TABLE t ADD INDEX idx (id) USING EXTENDED(hnsw);
+ERROR HY000: Extended Index feature not yet implemented
+ALTER TABLE t ADD INDEX idx (id) USING EXTENDED(myext.hnsw);
+ERROR HY000: Extended Index feature not yet implemented
+ALTER TABLE t ADD INDEX idx (id) USING EXTENDED(hnsw) WITH (M = 16, metric = 'l2');
+ERROR HY000: Extended Index feature not yet implemented
+ALTER TABLE t ADD INDEX idx (id) WITH (M = 16);
+ERROR HY000: Extended Index feature not yet implemented
+ALTER TABLE t ADD INDEX idx (id hnsw_l2_profile) USING EXTENDED(hnsw);
+ERROR HY000: Extended Index feature not yet implemented
+ALTER TABLE t ADD INDEX idx (id hnsw_l2_profile) USING EXTENDED(myext.hnsw) WITH (M = 16, metric = 'l2');
+ERROR HY000: Extended Index feature not yet implemented
+ALTER TABLE t ADD INDEX idx (id myext.hnsw_l2_profile) USING EXTENDED(hnsw);
+ERROR HY000: Extended Index feature not yet implemented
+ALTER TABLE t ADD INDEX idx (id myext.hnsw_l2_profile) USING EXTENDED(myext.hnsw) WITH (M = 16, metric = 'l2');
+ERROR HY000: Extended Index feature not yet implemented
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `id` int NOT NULL,
+  `val` int DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t;

--- a/mysql-test/suite/villagesql/index/r/create_index.result
+++ b/mysql-test/suite/villagesql/index/r/create_index.result
@@ -1,0 +1,31 @@
+CREATE TABLE t (id INT PRIMARY KEY, val INT);
+CREATE INDEX idx ON t (id) USING EXTENDED(hnsw);
+ERROR HY000: Extended Index feature not yet implemented
+CREATE INDEX idx ON t (id) USING EXTENDED(myext.hnsw);
+ERROR HY000: Extended Index feature not yet implemented
+CREATE INDEX idx ON t (id) USING EXTENDED(hnsw) WITH (M = 16);
+ERROR HY000: Extended Index feature not yet implemented
+CREATE INDEX idx ON t (id) USING EXTENDED(hnsw) WITH (metric = 'l2');
+ERROR HY000: Extended Index feature not yet implemented
+CREATE INDEX idx ON t (id) USING EXTENDED(hnsw) WITH (metric = l2);
+ERROR HY000: Extended Index feature not yet implemented
+CREATE INDEX idx ON t (id) USING EXTENDED(myext.hnsw) WITH (M = 16, ef_construction = 200, metric = 'l2', space = cosine);
+ERROR HY000: Extended Index feature not yet implemented
+CREATE INDEX idx ON t (id) WITH (M = 16);
+ERROR HY000: Extended Index feature not yet implemented
+CREATE INDEX idx ON t (id hnsw_l2_profile) USING EXTENDED(hnsw);
+ERROR HY000: Extended Index feature not yet implemented
+CREATE INDEX idx ON t (id hnsw_l2_profile) USING EXTENDED(myext.hnsw) WITH (M = 16, metric = 'l2');
+ERROR HY000: Extended Index feature not yet implemented
+CREATE INDEX idx ON t (id myext.hnsw_l2_profile) USING EXTENDED(hnsw);
+ERROR HY000: Extended Index feature not yet implemented
+CREATE INDEX idx ON t (id myext.hnsw_l2_profile) USING EXTENDED(myext.hnsw) WITH (M = 16, metric = 'l2');
+ERROR HY000: Extended Index feature not yet implemented
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `id` int NOT NULL,
+  `val` int DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t;

--- a/mysql-test/suite/villagesql/index/r/create_table_index.result
+++ b/mysql-test/suite/villagesql/index/r/create_table_index.result
@@ -1,0 +1,44 @@
+CREATE TABLE t1 (id INT PRIMARY KEY, INDEX idx (id) USING EXTENDED(hnsw));
+ERROR HY000: Extended Index feature not yet implemented
+SHOW CREATE TABLE t1;
+ERROR 42S02: Table 'test.t1' doesn't exist
+CREATE TABLE t2 (id INT PRIMARY KEY, INDEX idx (id) USING EXTENDED(myext.hnsw));
+ERROR HY000: Extended Index feature not yet implemented
+SHOW CREATE TABLE t2;
+ERROR 42S02: Table 'test.t2' doesn't exist
+CREATE TABLE t3 (
+id INT PRIMARY KEY,
+INDEX idx (id) USING EXTENDED(hnsw) WITH (M = 16, metric = 'l2')
+);
+ERROR HY000: Extended Index feature not yet implemented
+SHOW CREATE TABLE t3;
+ERROR 42S02: Table 'test.t3' doesn't exist
+CREATE TABLE t4 (id INT PRIMARY KEY, INDEX idx (id) WITH (M = 16));
+ERROR HY000: Extended Index feature not yet implemented
+SHOW CREATE TABLE t4;
+ERROR 42S02: Table 'test.t4' doesn't exist
+CREATE TABLE t5 (id INT PRIMARY KEY, INDEX idx (id hnsw_l2_profile) USING EXTENDED(hnsw));
+ERROR HY000: Extended Index feature not yet implemented
+SHOW CREATE TABLE t5;
+ERROR 42S02: Table 'test.t5' doesn't exist
+CREATE TABLE t6 (
+id INT PRIMARY KEY,
+INDEX idx (id hnsw_l2_profile) USING EXTENDED(myext.hnsw) WITH (M = 16)
+);
+ERROR HY000: Extended Index feature not yet implemented
+SHOW CREATE TABLE t6;
+ERROR 42S02: Table 'test.t6' doesn't exist
+CREATE TABLE t7 (
+id INT PRIMARY KEY,
+INDEX idx (id myext.hnsw_l2_profile) USING EXTENDED(hnsw)
+);
+ERROR HY000: Extended Index feature not yet implemented
+SHOW CREATE TABLE t7;
+ERROR 42S02: Table 'test.t7' doesn't exist
+CREATE TABLE t8 (
+id INT PRIMARY KEY,
+INDEX idx (id myext.hnsw_l2_profile) USING EXTENDED(myext.hnsw) WITH (M = 16, metric = 'l2')
+);
+ERROR HY000: Extended Index feature not yet implemented
+SHOW CREATE TABLE t8;
+ERROR 42S02: Table 'test.t8' doesn't exist

--- a/mysql-test/suite/villagesql/index/t/alter_table_index.test
+++ b/mysql-test/suite/villagesql/index/t/alter_table_index.test
@@ -1,0 +1,41 @@
+# Test ALTER TABLE ADD INDEX ... USING EXTENDED ... syntax paths
+# A failed ADD INDEX leaves the table and its existing indexes intact.
+
+CREATE TABLE t (id INT PRIMARY KEY, val INT);
+
+# ADD INDEX USING EXTENDED -- unqualified type name
+--error ER_VILLAGESQL_GENERIC_ERROR
+ALTER TABLE t ADD INDEX idx (id) USING EXTENDED(hnsw);
+
+# ADD INDEX USING EXTENDED -- qualified extension.type_name
+--error ER_VILLAGESQL_GENERIC_ERROR
+ALTER TABLE t ADD INDEX idx (id) USING EXTENDED(myext.hnsw);
+
+# ADD INDEX USING EXTENDED + WITH -- numeric and string params
+--error ER_VILLAGESQL_GENERIC_ERROR
+ALTER TABLE t ADD INDEX idx (id) USING EXTENDED(hnsw) WITH (M = 16, metric = 'l2');
+
+# ADD INDEX WITH standalone -- exercises PT_index_with_options path in ALTER TABLE context
+--error ER_VILLAGESQL_GENERIC_ERROR
+ALTER TABLE t ADD INDEX idx (id) WITH (M = 16);
+
+# Column with index profile + USING EXTENDED
+--error ER_VILLAGESQL_GENERIC_ERROR
+ALTER TABLE t ADD INDEX idx (id hnsw_l2_profile) USING EXTENDED(hnsw);
+
+# Column with index profile + qualified type + WITH params
+--error ER_VILLAGESQL_GENERIC_ERROR
+ALTER TABLE t ADD INDEX idx (id hnsw_l2_profile) USING EXTENDED(myext.hnsw) WITH (M = 16, metric = 'l2');
+
+# Column with qualified extension.profile (extension.profile_name syntax)
+--error ER_VILLAGESQL_GENERIC_ERROR
+ALTER TABLE t ADD INDEX idx (id myext.hnsw_l2_profile) USING EXTENDED(hnsw);
+
+# Qualified profile + qualified extension type + WITH params
+--error ER_VILLAGESQL_GENERIC_ERROR
+ALTER TABLE t ADD INDEX idx (id myext.hnsw_l2_profile) USING EXTENDED(myext.hnsw) WITH (M = 16, metric = 'l2');
+
+# Table must be unaffected by the failed ALTER TABLE statements above
+SHOW CREATE TABLE t;
+
+DROP TABLE t;

--- a/mysql-test/suite/villagesql/index/t/alter_table_index.test
+++ b/mysql-test/suite/villagesql/index/t/alter_table_index.test
@@ -1,5 +1,6 @@
 # Test ALTER TABLE ADD INDEX ... USING EXTENDED ... syntax paths
 # A failed ADD INDEX leaves the table and its existing indexes intact.
+# TODO(villagesql-indexing): Remove --error directives and replace with functional tests once custom index execution is implemented.
 
 CREATE TABLE t (id INT PRIMARY KEY, val INT);
 

--- a/mysql-test/suite/villagesql/index/t/create_index.test
+++ b/mysql-test/suite/villagesql/index/t/create_index.test
@@ -1,5 +1,6 @@
 # Test CREATE INDEX ... USING EXTENDED ... syntax paths
 # All cases must parse without error and then fail with "not yet implemented".
+# TODO(villagesql-indexing): Remove --error directives and replace with functional tests once custom index execution is implemented.
 # Covers:
 #   - USING EXTENDED(type_name)             -- unqualified type
 #   - USING EXTENDED(extension.type_name)   -- qualified extension.type

--- a/mysql-test/suite/villagesql/index/t/create_index.test
+++ b/mysql-test/suite/villagesql/index/t/create_index.test
@@ -1,0 +1,63 @@
+# Test CREATE INDEX ... USING EXTENDED ... syntax paths
+# All cases must parse without error and then fail with "not yet implemented".
+# Covers:
+#   - USING EXTENDED(type_name)             -- unqualified type
+#   - USING EXTENDED(extension.type_name)   -- qualified extension.type
+#   - WITH (key = ulong_num)                -- numeric parameter
+#   - WITH (key = 'string')                 -- quoted string parameter
+#   - WITH (key = ident)                    -- unquoted identifier parameter
+#   - WITH (k1 = v1, k2 = v2, ...)         -- multiple parameters
+#   - WITH (...) without USING EXTENDED     -- standalone WITH (PT_index_with_options path)
+#   - (col profile)                         -- unqualified per-column index profile
+#   - (col extension.profile)               -- qualified per-column index profile
+
+CREATE TABLE t (id INT PRIMARY KEY, val INT);
+
+# USING EXTENDED -- unqualified type name
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE INDEX idx ON t (id) USING EXTENDED(hnsw);
+
+# USING EXTENDED -- qualified extension.type_name
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE INDEX idx ON t (id) USING EXTENDED(myext.hnsw);
+
+# USING EXTENDED + WITH -- numeric parameter (ulong_num path)
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE INDEX idx ON t (id) USING EXTENDED(hnsw) WITH (M = 16);
+
+# USING EXTENDED + WITH -- quoted string parameter (TEXT_STRING_sys path)
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE INDEX idx ON t (id) USING EXTENDED(hnsw) WITH (metric = 'l2');
+
+# USING EXTENDED + WITH -- unquoted identifier parameter (ident path)
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE INDEX idx ON t (id) USING EXTENDED(hnsw) WITH (metric = l2);
+
+# USING EXTENDED + WITH -- multiple parameters covering all value kinds
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE INDEX idx ON t (id) USING EXTENDED(myext.hnsw) WITH (M = 16, ef_construction = 200, metric = 'l2', space = cosine);
+
+# WITH standalone without USING EXTENDED -- exercises PT_index_with_options path directly
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE INDEX idx ON t (id) WITH (M = 16);
+
+# Column with index profile (opt_index_profile) + USING EXTENDED
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE INDEX idx ON t (id hnsw_l2_profile) USING EXTENDED(hnsw);
+
+# Column with index profile + qualified extension.type + WITH params
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE INDEX idx ON t (id hnsw_l2_profile) USING EXTENDED(myext.hnsw) WITH (M = 16, metric = 'l2');
+
+# Column with qualified extension.profile (extension.profile_name syntax)
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE INDEX idx ON t (id myext.hnsw_l2_profile) USING EXTENDED(hnsw);
+
+# Qualified profile + qualified extension type + WITH params
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE INDEX idx ON t (id myext.hnsw_l2_profile) USING EXTENDED(myext.hnsw) WITH (M = 16, metric = 'l2');
+
+# Table must be unaffected by all the failed CREATE INDEX statements above
+SHOW CREATE TABLE t;
+
+DROP TABLE t;

--- a/mysql-test/suite/villagesql/index/t/create_table_index.test
+++ b/mysql-test/suite/villagesql/index/t/create_table_index.test
@@ -1,6 +1,7 @@
 # Test CREATE TABLE with inline USING EXTENDED index definitions
 # Inline index options use the same grammar paths as standalone CREATE INDEX.
 # A failed CREATE TABLE leaves no table behind.
+# TODO(villagesql-indexing): Remove --error directives and replace with functional tests once custom index execution is implemented.
 
 # Inline USING EXTENDED -- unqualified type name
 --error ER_VILLAGESQL_GENERIC_ERROR

--- a/mysql-test/suite/villagesql/index/t/create_table_index.test
+++ b/mysql-test/suite/villagesql/index/t/create_table_index.test
@@ -1,0 +1,71 @@
+# Test CREATE TABLE with inline USING EXTENDED index definitions
+# Inline index options use the same grammar paths as standalone CREATE INDEX.
+# A failed CREATE TABLE leaves no table behind.
+
+# Inline USING EXTENDED -- unqualified type name
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE TABLE t1 (id INT PRIMARY KEY, INDEX idx (id) USING EXTENDED(hnsw));
+
+--error ER_NO_SUCH_TABLE
+SHOW CREATE TABLE t1;
+
+# Inline USING EXTENDED -- qualified extension.type_name
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE TABLE t2 (id INT PRIMARY KEY, INDEX idx (id) USING EXTENDED(myext.hnsw));
+
+--error ER_NO_SUCH_TABLE
+SHOW CREATE TABLE t2;
+
+# Inline USING EXTENDED + WITH -- numeric and string params
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE TABLE t3 (
+  id INT PRIMARY KEY,
+  INDEX idx (id) USING EXTENDED(hnsw) WITH (M = 16, metric = 'l2')
+);
+
+--error ER_NO_SUCH_TABLE
+SHOW CREATE TABLE t3;
+
+# Inline WITH standalone -- exercises PT_index_with_options path in CREATE TABLE context
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE TABLE t4 (id INT PRIMARY KEY, INDEX idx (id) WITH (M = 16));
+
+--error ER_NO_SUCH_TABLE
+SHOW CREATE TABLE t4;
+
+# Inline column with index profile + USING EXTENDED
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE TABLE t5 (id INT PRIMARY KEY, INDEX idx (id hnsw_l2_profile) USING EXTENDED(hnsw));
+
+--error ER_NO_SUCH_TABLE
+SHOW CREATE TABLE t5;
+
+# Inline column with index profile + qualified type + WITH params
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE TABLE t6 (
+  id INT PRIMARY KEY,
+  INDEX idx (id hnsw_l2_profile) USING EXTENDED(myext.hnsw) WITH (M = 16)
+);
+
+--error ER_NO_SUCH_TABLE
+SHOW CREATE TABLE t6;
+
+# Inline column with qualified extension.profile
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE TABLE t7 (
+  id INT PRIMARY KEY,
+  INDEX idx (id myext.hnsw_l2_profile) USING EXTENDED(hnsw)
+);
+
+--error ER_NO_SUCH_TABLE
+SHOW CREATE TABLE t7;
+
+# Qualified profile + qualified type + WITH params
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE TABLE t8 (
+  id INT PRIMARY KEY,
+  INDEX idx (id myext.hnsw_l2_profile) USING EXTENDED(myext.hnsw) WITH (M = 16, metric = 'l2')
+);
+
+--error ER_NO_SUCH_TABLE
+SHOW CREATE TABLE t8;

--- a/sql/key_spec.h
+++ b/sql/key_spec.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2015, 2025, Oracle and/or its affiliates.
+   Copyright (c) 2026 VillageSQL Contributors
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -64,6 +65,17 @@ enum fk_match_opt {
 
 enum enum_order : int { ORDER_NOT_RELEVANT = 1, ORDER_ASC, ORDER_DESC };
 
+// One key=value pair from a WITH (...) clause on a custom index.
+// is_string controls JSON encoding: false → bare number, true → quoted string.
+struct IndexWithParam {
+  LEX_CSTRING key{nullptr, 0};
+  bool is_string{false};
+  union {
+    LEX_CSTRING str;  // valid when is_string=true
+    uint64_t num;     // valid when is_string=false
+  } value{};
+};
+
 class KEY_CREATE_INFO {
  public:
   enum ha_key_alg algorithm = HA_KEY_ALG_SE_SPECIFIC;
@@ -72,6 +84,14 @@ class KEY_CREATE_INFO {
     by user.
   */
   bool is_algorithm_explicit = false;
+  // Set when a VillageSQL extension-defined index type is specified via
+  // USING EXTENDED(index_type) or USING EXTENDED(extension.index_type).
+  LEX_CSTRING custom_index_type = {nullptr, 0};
+  LEX_CSTRING custom_index_extension = {nullptr, 0};
+  // Raw parameters from WITH (key=value, ...) clause, to be passed to the
+  // extension's parse function for validation before JSON serialization.
+  // Null when no WITH clause was specified.
+  Mem_root_array<IndexWithParam> *custom_index_params{nullptr};
   ulong block_size = 0;
   LEX_CSTRING parser_name = {NullS, 0};
   LEX_CSTRING comment = {NullS, 0};

--- a/sql/parse_tree_nodes.cc
+++ b/sql/parse_tree_nodes.cc
@@ -27,6 +27,7 @@
 #include <algorithm>
 #include <cstring>
 #include <limits>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -102,6 +103,7 @@
 #include "string_with_len.h"
 #include "strxmov.h"
 #include "template_utils.h"
+#include "villagesql/include/error.h"
 
 static constexpr const size_t MAX_SYS_VAR_LENGTH{32};
 
@@ -699,12 +701,15 @@ PT_key_part_specification::PT_key_part_specification(const POS &pos,
 
 PT_key_part_specification::PT_key_part_specification(
     const POS &pos, const LEX_CSTRING &column_name, enum_order order,
-    int prefix_length)
+    int prefix_length, LEX_CSTRING index_profile_extension,
+    LEX_CSTRING index_profile)
     : super(pos),
       m_expression(nullptr),
       m_order(order),
       m_column_name(column_name),
-      m_prefix_length(prefix_length) {}
+      m_prefix_length(prefix_length),
+      m_index_profile_extension(index_profile_extension),
+      m_index_profile(index_profile) {}
 
 bool PT_key_part_specification::do_contextualize(Parse_context *pc) {
   return super::do_contextualize(pc) || itemize_safe(pc, &m_expression);
@@ -1820,6 +1825,23 @@ bool PT_intersect::do_contextualize(Parse_context *pc [[maybe_unused]]) {
   return contextualize_setop(
       pc, QT_INTERSECT,
       m_is_distinct ? SC_INTERSECT_DISTINCT : SC_INTERSECT_ALL);
+}
+
+bool PT_custom_index_type::do_contextualize(Table_ddl_parse_context *pc) {
+  pc->key_create_info->algorithm = HA_KEY_ALG_SE_SPECIFIC;
+  pc->key_create_info->is_algorithm_explicit = true;
+  pc->key_create_info->custom_index_type = m_name;
+  pc->key_create_info->custom_index_extension = m_extension;
+  // TODO(villagesql-indexing): Execute extended index type.
+  villagesql_error("Extended Index feature not yet implemented", MYF(0));
+  return true;
+}
+
+bool PT_index_with_options::do_contextualize(Table_ddl_parse_context *pc) {
+  pc->key_create_info->custom_index_params = m_params;
+  // TODO(villagesql-indexing): Execute extended index WITH parameters.
+  villagesql_error("Extended Index feature not yet implemented", MYF(0));
+  return true;
 }
 
 static bool setup_index(keytype key_type, const LEX_STRING name,

--- a/sql/parse_tree_nodes.h
+++ b/sql/parse_tree_nodes.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2013, 2025, Oracle and/or its affiliates.
+   Copyright (c) 2026 VillageSQL Contributors
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -2283,7 +2284,9 @@ class PT_key_part_specification : public Parse_tree_node {
            index, or zero if it should index the entire column.
   */
   PT_key_part_specification(const POS &pos, const LEX_CSTRING &column_name,
-                            enum_order order, int prefix_length);
+                            enum_order order, int prefix_length,
+                            LEX_CSTRING index_profile_extension = {nullptr, 0},
+                            LEX_CSTRING index_profile = {nullptr, 0});
 
   /**
     Contextualize this key part specification. This will also call itemize on
@@ -2346,6 +2349,19 @@ class PT_key_part_specification : public Parse_tree_node {
   */
   int get_prefix_length() const { return m_prefix_length; }
 
+  /// @returns true if an explicit index profile was specified for this key
+  /// part.
+  bool has_index_profile() const { return m_index_profile.str != nullptr; }
+
+  /// @returns The optional extension name of the index profile, or empty if
+  /// unqualified.
+  LEX_CSTRING get_index_profile_extension() const {
+    return m_index_profile_extension;
+  }
+
+  /// @returns The index profile name, or an empty LEX_CSTRING if none.
+  LEX_CSTRING get_index_profile() const { return m_index_profile; }
+
  private:
   /**
     The indexed expression in case this is a functional key part. Only valid if
@@ -2365,6 +2381,16 @@ class PT_key_part_specification : public Parse_tree_node {
     is the number of characters.
   */
   int m_prefix_length = 0;
+
+  /// Optional extension qualifier for the index profile (e.g. the "myext"
+  /// in "(col myext.profile)"). Null str when unqualified.
+  LEX_CSTRING m_index_profile_extension{};
+
+  /// Optional index profile name specified in the CREATE INDEX key part.
+  /// Null str when not specified.
+  // TODO(villagesql-indexing): resolve profile to registered IndexProfileDesc
+  // during contextualization.
+  LEX_CSTRING m_index_profile{};
 };
 
 /**
@@ -2431,6 +2457,34 @@ typedef PT_index_option<bool, &KEY_CREATE_INFO::is_visible> PT_index_visibility;
 typedef PT_traceable_index_option<ha_key_alg, &KEY_CREATE_INFO::algorithm,
                                   &KEY_CREATE_INFO::is_algorithm_explicit>
     PT_index_type;
+
+// Parse tree node for a VillageSQL extension-defined index type name.
+// Created when USING EXTENDED(type) or USING EXTENDED(extension.type) is used.
+class PT_custom_index_type final : public PT_base_index_option {
+ public:
+  PT_custom_index_type(const POS &pos, LEX_CSTRING extension, LEX_CSTRING name)
+      : PT_base_index_option(pos), m_extension(extension), m_name(name) {}
+
+  bool do_contextualize(Table_ddl_parse_context *pc) override;
+
+ private:
+  LEX_CSTRING m_extension;
+  LEX_CSTRING m_name;
+};
+
+// Parse tree node for WITH (key=value, ...) on a custom index.
+// Stores the raw parameter list in KEY_CREATE_INFO::custom_index_params for
+// later validation by the extension's parse function and JSON serialization.
+class PT_index_with_options final : public PT_base_index_option {
+ public:
+  PT_index_with_options(const POS &pos, Mem_root_array<IndexWithParam> *params)
+      : PT_base_index_option(pos), m_params(params) {}
+
+  bool do_contextualize(Table_ddl_parse_context *pc) override;
+
+ private:
+  Mem_root_array<IndexWithParam> *m_params;
+};
 
 class PT_create_index_stmt final : public PT_table_ddl_stmt_base {
  public:

--- a/sql/parse_tree_nodes.h
+++ b/sql/parse_tree_nodes.h
@@ -2458,8 +2458,10 @@ typedef PT_traceable_index_option<ha_key_alg, &KEY_CREATE_INFO::algorithm,
                                   &KEY_CREATE_INFO::is_algorithm_explicit>
     PT_index_type;
 
-// Parse tree node for a VillageSQL extension-defined index type name.
-// Created when USING EXTENDED(type) or USING EXTENDED(extension.type) is used.
+// TODO(villagesql-indexing): Move PT_custom_index_type and
+// PT_index_with_options to villagesql/. Parse tree node for a VillageSQL
+// extension-defined index type name. Created when USING EXTENDED(type) or USING
+// EXTENDED(extension.type) is used.
 class PT_custom_index_type final : public PT_base_index_option {
  public:
   PT_custom_index_type(const POS &pos, LEX_CSTRING extension, LEX_CSTRING name)

--- a/sql/parser_yystype.h
+++ b/sql/parser_yystype.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2019, 2025, Oracle and/or its affiliates.
+   Copyright (c) 2026 VillageSQL Contributors
 
   This program is free software; you can redistribute it and/or modify
   it under the terms of the GNU General Public License, version 2.0,
@@ -518,6 +519,12 @@ union MY_SQL_PARSER_STYPE {
   } index_name_and_type;
   PT_base_index_option *index_option;
   Mem_root_array_YY<PT_base_index_option *> index_options;
+  IndexWithParam *index_with_param;
+  Mem_root_array<IndexWithParam> *index_with_params;
+  struct {
+    LEX_CSTRING extension;
+    LEX_CSTRING name;
+  } index_profile_ref;
   Mem_root_array_YY<LEX_STRING> lex_str_list;
   bool visibility;
   PT_with_clause *with_clause;

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -7936,8 +7936,8 @@ opt_index_type_clause:
         ;
 
 index_type_clause:
-          USING index_type                                      { $$= NEW_PTN PT_index_type(@$, $2); }
-        | TYPE_SYM index_type                                   { $$= NEW_PTN PT_index_type(@$, $2); }
+          USING index_type    { $$= NEW_PTN PT_index_type(@$, $2); }
+        | TYPE_SYM index_type { $$= NEW_PTN PT_index_type(@$, $2); }
         | USING EXTENDED_SYM '(' ident ')'                  { $$= NEW_PTN PT_custom_index_type(@$, LEX_CSTRING{}, to_lex_cstring($4)); }
         | USING EXTENDED_SYM '(' ident '.' ident ')'        { $$= NEW_PTN PT_custom_index_type(@$, to_lex_cstring($4), to_lex_cstring($6)); }
         ;

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -1697,6 +1697,8 @@ void warn_on_deprecated_user_defined_collation(
 %type <key_part>
         key_part key_part_with_expression
 
+%type <index_profile_ref> opt_index_profile
+
 %type <date_time_type> date_time_type;
 %type <interval> interval
 
@@ -2078,6 +2080,9 @@ void warn_on_deprecated_user_defined_collation(
           spatial_index_option
           index_type_clause
           opt_index_type_clause
+
+%type <index_with_param> index_with_option
+%type <index_with_params> index_with_option_list
 
 %type <alter_table_algorithm> alter_algorithm_option_value
         alter_algorithm_option
@@ -7833,6 +7838,10 @@ index_options:
 index_option:
           common_index_option { $$= $1; }
         | index_type_clause { $$= $1; }
+        | WITH '(' index_with_option_list ')'
+          {
+            $$= NEW_PTN PT_index_with_options(@$, $3);
+          }
         ;
 
 // These options are common for all index types.
@@ -7853,6 +7862,48 @@ common_index_option:
         | SECONDARY_ENGINE_ATTRIBUTE_SYM opt_equal json_attribute
           {
             $$ = make_index_secondary_engine_attribute(YYMEM_ROOT, $3);
+          }
+        ;
+
+index_with_option_list:
+          index_with_option
+          {
+            $$= NEW_PTN Mem_root_array<IndexWithParam>(YYMEM_ROOT);
+            if (!$$ || $$->push_back(*$1))
+              MYSQL_YYABORT;
+          }
+        | index_with_option_list ',' index_with_option
+          {
+            if ($1->push_back(*$3))
+              MYSQL_YYABORT;
+            $$= $1;
+          }
+        ;
+
+index_with_option:
+          ident EQ ulong_num
+          {
+            $$= NEW_PTN IndexWithParam();
+            if (!$$) MYSQL_YYABORT;
+            $$->key= to_lex_cstring($1);
+            $$->value.num= $3;
+            $$->is_string= false;
+          }
+        | ident EQ TEXT_STRING_sys
+          {
+            $$= NEW_PTN IndexWithParam();
+            if (!$$) MYSQL_YYABORT;
+            $$->key= to_lex_cstring($1);
+            $$->value.str= to_lex_cstring($3);
+            $$->is_string= true;
+          }
+        | ident EQ ident
+          {
+            $$= NEW_PTN IndexWithParam();
+            if (!$$) MYSQL_YYABORT;
+            $$->key= to_lex_cstring($1);
+            $$->value.str= to_lex_cstring($3);
+            $$->is_string= true;
           }
         ;
 
@@ -7885,8 +7936,10 @@ opt_index_type_clause:
         ;
 
 index_type_clause:
-          USING index_type    { $$= NEW_PTN PT_index_type(@$, $2); }
-        | TYPE_SYM index_type { $$= NEW_PTN PT_index_type(@$, $2); }
+          USING index_type                                      { $$= NEW_PTN PT_index_type(@$, $2); }
+        | TYPE_SYM index_type                                   { $$= NEW_PTN PT_index_type(@$, $2); }
+        | USING EXTENDED_SYM '(' ident ')'                  { $$= NEW_PTN PT_custom_index_type(@$, LEX_CSTRING{}, to_lex_cstring($4)); }
+        | USING EXTENDED_SYM '(' ident '.' ident ')'        { $$= NEW_PTN PT_custom_index_type(@$, to_lex_cstring($4), to_lex_cstring($6)); }
         ;
 
 visibility:
@@ -7917,24 +7970,32 @@ key_list:
         ;
 
 key_part:
-          ident opt_ordering_direction
+          ident opt_index_profile opt_ordering_direction
           {
-            $$= NEW_PTN PT_key_part_specification(@$, to_lex_cstring($1), $2, 0);
+            $$= NEW_PTN PT_key_part_specification(@$, to_lex_cstring($1), $3,
+                                                  0, $2.extension, $2.name);
             if ($$ == nullptr)
               MYSQL_YYABORT;
           }
-        | ident '(' NUM ')' opt_ordering_direction
+        | ident '(' NUM ')' opt_index_profile opt_ordering_direction
           {
             int key_part_length= atoi($3.str);
             if (!key_part_length)
             {
               my_error(ER_KEY_PART_0, MYF(0), $1.str);
             }
-            $$= NEW_PTN PT_key_part_specification(@$, to_lex_cstring($1), $5,
-                                                  key_part_length);
+            $$= NEW_PTN PT_key_part_specification(@$, to_lex_cstring($1), $6,
+                                                  key_part_length,
+                                                  $5.extension, $5.name);
             if ($$ == nullptr)
               MYSQL_YYABORT; /* purecov: deadcode */
           }
+        ;
+
+opt_index_profile:
+          %empty              { $$= {NULL_CSTR, NULL_CSTR}; }
+        | ident               { $$= {NULL_CSTR, to_lex_cstring($1)}; }
+        | ident '.' ident     { $$= {to_lex_cstring($1), to_lex_cstring($3)}; }
         ;
 
 key_list_with_expression:


### PR DESCRIPTION
## Description
Add parser support for index profiles, types, and properties in:
- CREATE INDEX
- CREATE TABLE ... INDEX
- ALTER TABLE ... ADD INDEX

Example:
```sql
CREATE INDEX idx ON t (id hnsw_l2)
USING EXTENDED(hnsw)
WITH (M = 16, ef_construction = 200);
```

Fixes #267 