### PR TITLE
VEF: pretty up Capabilities

### DIFF
--- a/villagesql/sdk/include/villagesql/detail/cap_receive.h
+++ b/villagesql/sdk/include/villagesql/detail/cap_receive.h
@@ -1,0 +1,76 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+#ifndef VILLAGESQL_DETAIL_CAP_RECEIVE_H
+#define VILLAGESQL_DETAIL_CAP_RECEIVE_H
+
+#include <cstdio>
+
+#include <villagesql/abi/types.h>
+#include <villagesql/vsql/capability_traits.h>
+
+namespace vsql::detail {
+
+// Glue between the wire format's single-arg receive signature and the
+// extension's wrapper object.
+//
+// The wire format carries `bool (*receive)(vef_capability_receive_arg_t*)` —
+// no per-call user_data — so the receive callback needs another way to
+// know which wrapper instance to store into. CapReceiveSlot<Capability>
+// provides that: a per-type static `instance` is set at registration
+// time (in vef_register_impl, which runs at .so load and is NOT
+// constexpr), and `receive` reads it.
+//
+// One Capability per extension is fine because each extension's .so
+// has its own static storage. Within an extension, register at most
+// one instance per Capability type.
+template <typename Capability>
+struct CapReceiveSlot {
+  // Set at registration time to point at the extension's wrapper.
+  // Read by `receive` to locate the abi-pointer slot via the trait.
+  static Capability *instance;
+
+  // Captureless — convertible to a plain function pointer for the
+  // wire format. Performs a version check before storing the vtable.
+  static bool receive(vef_capability_receive_arg_t *arg) noexcept {
+    Capability *p = instance;
+    if (p == nullptr) {
+      // Should not happen if registration ran correctly.
+      snprintf(arg->error_buf, arg->error_buf_len,
+               "capability slot not initialized");
+      return false;
+    }
+    using Traits = CapabilityTraits<Capability>;
+    using AbiType = typename Traits::AbiType;
+    auto *v = static_cast<const AbiType *>(arg->vtable);
+    if (v->version != Traits::kAbiVersion) {
+      snprintf(arg->error_buf, arg->error_buf_len,
+               "version mismatch: server=%u, compiled=%u",
+               static_cast<unsigned>(v->version),
+               static_cast<unsigned>(Traits::kAbiVersion));
+      return false;
+    }
+    void *dest = Traits::vtable_destination(p);
+    *static_cast<const AbiType **>(dest) = v;
+    return true;
+  }
+};
+
+template <typename Capability>
+Capability *CapReceiveSlot<Capability>::instance = nullptr;
+
+}  // namespace vsql::detail
+
+#endif  // VILLAGESQL_DETAIL_CAP_RECEIVE_H

--- a/villagesql/sdk/include/villagesql/detail/vef_register.h
+++ b/villagesql/sdk/include/villagesql/detail/vef_register.h
@@ -26,7 +26,10 @@
 #include <utility>
 
 #include <villagesql/abi/types.h>
+#include <villagesql/detail/cap_receive.h>
+#include <villagesql/detail/capability_hash.h>
 #include <villagesql/sdk_version.h>
+#include <villagesql/vsql/capability_traits.h>
 
 namespace vsql {
 
@@ -113,12 +116,31 @@ void vef_fill_status_var_ptrs(vef_status_var_desc_t **arr, const Ext &e,
    ...);
 }
 
-// Fills arr[I] with a copy of each vef_required_capability_t.
+// For each Capability* the builder accumulated, publish it into
+// CapReceiveSlot<Capability>::instance (so the captureless receive
+// callback can find its target) and fill arr[I] with the wire entry.
+template <size_t I, typename Ext>
+void vef_fill_one_capability_req(vef_required_capability_t *arr,
+                                 const Ext &e) {
+  auto *cap_ptr = e.template required_capability_at<I>();
+  using Capability =
+      std::remove_cv_t<std::remove_pointer_t<decltype(cap_ptr)>>;
+  using Traits = ::vsql::detail::CapabilityTraits<Capability>;
+
+  ::vsql::detail::CapReceiveSlot<Capability>::instance = cap_ptr;
+
+  arr[I].name = Traits::kName;
+  arr[I].receive = &::vsql::detail::CapReceiveSlot<Capability>::receive;
+  arr[I].abi_type_hash =
+      villagesql::detail::abi_type_hash<typename Traits::AbiType>();
+  arr[I].min_version = Traits::kAbiVersion;
+}
+
 template <typename Ext, size_t... Is>
 void vef_fill_required_capability_reqs(vef_required_capability_t *arr,
                                        const Ext &e,
                                        std::index_sequence<Is...>) {
-  ((arr[Is] = e.template required_capability_at<Is>()), ...);
+  (vef_fill_one_capability_req<Is>(arr, e), ...);
 }
 
 // Calls params_init_fn() for each type that has one.

--- a/villagesql/sdk/include/villagesql/detail/vef_register.h
+++ b/villagesql/sdk/include/villagesql/detail/vef_register.h
@@ -120,11 +120,9 @@ void vef_fill_status_var_ptrs(vef_status_var_desc_t **arr, const Ext &e,
 // CapReceiveSlot<Capability>::instance (so the captureless receive
 // callback can find its target) and fill arr[I] with the wire entry.
 template <size_t I, typename Ext>
-void vef_fill_one_capability_req(vef_required_capability_t *arr,
-                                 const Ext &e) {
+void vef_fill_one_capability_req(vef_required_capability_t *arr, const Ext &e) {
   auto *cap_ptr = e.template required_capability_at<I>();
-  using Capability =
-      std::remove_cv_t<std::remove_pointer_t<decltype(cap_ptr)>>;
+  using Capability = std::remove_cv_t<std::remove_pointer_t<decltype(cap_ptr)>>;
   using Traits = ::vsql::detail::CapabilityTraits<Capability>;
 
   ::vsql::detail::CapReceiveSlot<Capability>::instance = cap_ptr;

--- a/villagesql/sdk/include/villagesql/preview/keyring.h
+++ b/villagesql/sdk/include/villagesql/preview/keyring.h
@@ -23,9 +23,9 @@
 
 namespace vsql::preview_keyring {
 
-// Declare a Keyring by value in your extension and pass its address to
+// Declare a KeyringCapability by value in your extension and pass it to
 // .with(). VEF populates `abi` during registration.
-class Keyring {
+class KeyringCapability {
  public:
   enum class Status {
     OK = VEF_KEYRING_OK,

--- a/villagesql/sdk/include/villagesql/preview/keyring.h
+++ b/villagesql/sdk/include/villagesql/preview/keyring.h
@@ -8,7 +8,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
+// GNU General Public License, version 2.0, for more details.
 //
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
@@ -18,92 +18,47 @@
 
 #include <string>
 #include <string_view>
-#include <type_traits>
 
 #include <villagesql/abi/preview/keyring.h>
-#include <villagesql/detail/capability_hash.h>
-#include <villagesql/vsql/extension_builder.h>
 
-namespace vsql::preview::keyring {
+namespace vsql::preview_keyring {
 
-// C++ wrapper around vef_preview_keyring_t.
-//
-// Usage:
-//   static auto g_keyring = vsql::preview::keyring::make_capability();
-//
-//   // In extension code:
-//   auto result = g_keyring.read("my-key", "", value);
-//
-// Register with:
-//   make_extension().with<preview_keyring<g_keyring>>()
-class Capability {
+// Declare a Keyring by value in your extension and pass its address to
+// .with(). VEF populates `abi` during registration.
+class Keyring {
  public:
-  static constexpr const char *kName = VEF_PREVIEW_KEYRING_NAME;
-  static constexpr uint32_t kAbiVersion = VEF_PREVIEW_KEYRING_ABI_VERSION;
+  enum class Status {
+    OK = VEF_KEYRING_OK,
+    NOT_FOUND = VEF_KEYRING_NOT_FOUND,
+    UNAVAILABLE = VEF_KEYRING_UNAVAILABLE,
+    ERROR = VEF_KEYRING_ERROR,
+  };
 
-  // Read a secret from the MySQL keyring component into value.
-  //   auth_id may be empty to read internal keys.
-  //   Returns VEF_KEYRING_OK on success, VEF_KEYRING_NOT_FOUND if the key does
-  //   not exist, VEF_KEYRING_UNAVAILABLE if no keyring component is installed,
-  //   or VEF_KEYRING_ERROR on other failures.
-  vef_keyring_result_t read(std::string_view data_id, std::string_view auth_id,
-                            std::string &value) const {
-    if (!available()) return VEF_KEYRING_UNAVAILABLE;
-    value.resize(4096);
-    size_t out_len = 0;
-    vef_keyring_result_t result =
-        abi_->read(data_id.data(), auth_id.empty() ? nullptr : auth_id.data(),
-                   reinterpret_cast<unsigned char *>(value.data()),
-                   value.size(), &out_len);
-    if (result == VEF_KEYRING_OK) value.resize(out_len);
-    return result;
-  }
+  // Outcome of a read(). On Status::OK, value contains the secret.
+  // On any other Status, value is empty.
+  struct ReadResult {
+    Status status;
+    std::string value;
+  };
 
-  // Write a secret to the MySQL keyring component.
-  //   auth_id may be empty to store as an internal key.
-  //   Returns VEF_KEYRING_OK on success, VEF_KEYRING_UNAVAILABLE if no keyring
-  //   component is installed, or VEF_KEYRING_ERROR on other failures.
-  vef_keyring_result_t write(std::string_view data_id, std::string_view auth_id,
-                             std::string_view data) const {
-    if (!available()) return VEF_KEYRING_UNAVAILABLE;
-    return abi_->write(
-        data_id.data(), auth_id.empty() ? nullptr : auth_id.data(),
-        reinterpret_cast<const unsigned char *>(data.data()), data.size());
-  }
+  // Read a secret from the keyring. auth_id defaults to empty (internal
+  // keys, not accessible via SQL).
+  [[nodiscard]] ReadResult read(std::string_view data_id,
+                                std::string_view auth_id = {}) const;
 
-  bool available() const { return version() > 0; }
+  // Write a secret to the keyring. auth_id may be empty to store as an
+  // internal key.
+  [[nodiscard]] Status write(std::string_view data_id, std::string_view auth_id,
+                             std::string_view data) const;
 
-  // Returns the server-side capability ABI version, or 0 if unavailable.
-  // Compare against VEF_PREVIEW_KEYRING_ABI_VERSION to check what the current
-  // SDK was compiled against.
-  uint32_t version() const { return abi_ != nullptr ? abi_->version : 0; }
-
-  // Public so that cap_receive() can store the server vtable pointer here.
-  // Do not access directly — use read(), write(), and available() instead.
-  const vef_preview_keyring_t *abi_ = nullptr;
+  // VEF writes this during registration. Public for the registration
+  // glue; do not access from extension code.
+  const vef_preview_keyring_t *abi = nullptr;
 };
 
-inline Capability make_capability() { return Capability{}; }
+}  // namespace vsql::preview_keyring
 
-}  // namespace vsql::preview::keyring
-
-namespace vsql::preview {
-
-// Traits type for registering the keyring capability via
-// .with<preview_keyring<cap>>. Only available when this header is included.
-template <auto &cap>
-struct preview_keyring {
-  template <typename Inner>
-  static constexpr auto bind(Inner builder) {
-    using Cap = keyring::Capability;
-    return builder.required_capability(
-        {Cap::kName, &::vsql::cap_receive<Cap, &cap>,
-         ::villagesql::detail::abi_type_hash<
-             std::remove_cv_t<std::remove_pointer_t<decltype(cap.abi_)>>>(),
-         Cap::kAbiVersion});
-  }
-};
-
-}  // namespace vsql::preview
+#include <villagesql/preview/keyring_impl.h>
+#include <villagesql/preview/keyring_register.h>
 
 #endif  // VILLAGESQL_PREVIEW_KEYRING_H

--- a/villagesql/sdk/include/villagesql/preview/keyring_impl.h
+++ b/villagesql/sdk/include/villagesql/preview/keyring_impl.h
@@ -21,8 +21,8 @@
 
 namespace vsql::preview_keyring {
 
-inline Keyring::ReadResult Keyring::read(std::string_view data_id,
-                                         std::string_view auth_id) const {
+inline KeyringCapability::ReadResult KeyringCapability::read(
+    std::string_view data_id, std::string_view auth_id) const {
   std::string value;
   value.resize(4096);
   size_t out_len = 0;
@@ -36,9 +36,9 @@ inline Keyring::ReadResult Keyring::read(std::string_view data_id,
   return {static_cast<Status>(result), {}};
 }
 
-inline Keyring::Status Keyring::write(std::string_view data_id,
-                                      std::string_view auth_id,
-                                      std::string_view data) const {
+inline KeyringCapability::Status KeyringCapability::write(
+    std::string_view data_id, std::string_view auth_id,
+    std::string_view data) const {
   return static_cast<Status>(abi->write(
       data_id.data(), auth_id.empty() ? nullptr : auth_id.data(),
       reinterpret_cast<const unsigned char *>(data.data()), data.size()));

--- a/villagesql/sdk/include/villagesql/preview/keyring_impl.h
+++ b/villagesql/sdk/include/villagesql/preview/keyring_impl.h
@@ -1,0 +1,49 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+#ifndef VILLAGESQL_PREVIEW_KEYRING_IMPL_H
+#define VILLAGESQL_PREVIEW_KEYRING_IMPL_H
+
+#include <villagesql/abi/preview/keyring.h>
+#include <villagesql/preview/keyring.h>
+
+namespace vsql::preview_keyring {
+
+inline Keyring::ReadResult Keyring::read(std::string_view data_id,
+                                         std::string_view auth_id) const {
+  std::string value;
+  value.resize(4096);
+  size_t out_len = 0;
+  vef_keyring_result_t result = abi->read(
+      data_id.data(), auth_id.empty() ? nullptr : auth_id.data(),
+      reinterpret_cast<unsigned char *>(value.data()), value.size(), &out_len);
+  if (result == VEF_KEYRING_OK) {
+    value.resize(out_len);
+    return {Status::OK, std::move(value)};
+  }
+  return {static_cast<Status>(result), {}};
+}
+
+inline Keyring::Status Keyring::write(std::string_view data_id,
+                                      std::string_view auth_id,
+                                      std::string_view data) const {
+  return static_cast<Status>(abi->write(
+      data_id.data(), auth_id.empty() ? nullptr : auth_id.data(),
+      reinterpret_cast<const unsigned char *>(data.data()), data.size()));
+}
+
+}  // namespace vsql::preview_keyring
+
+#endif  // VILLAGESQL_PREVIEW_KEYRING_IMPL_H

--- a/villagesql/sdk/include/villagesql/preview/keyring_register.h
+++ b/villagesql/sdk/include/villagesql/preview/keyring_register.h
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+#ifndef VILLAGESQL_PREVIEW_KEYRING_REGISTER_H
+#define VILLAGESQL_PREVIEW_KEYRING_REGISTER_H
+
+#include <villagesql/abi/preview/keyring.h>
+#include <villagesql/preview/keyring.h>
+#include <villagesql/vsql/capability_traits.h>
+
+namespace vsql::detail {
+
+template <>
+struct CapabilityTraits<::vsql::preview_keyring::Keyring> {
+  static constexpr const char *kName = VEF_PREVIEW_KEYRING_NAME;
+  static constexpr uint32_t kAbiVersion = VEF_PREVIEW_KEYRING_ABI_VERSION;
+  using AbiType = vef_preview_keyring_t;
+
+  static constexpr void *vtable_destination(
+      ::vsql::preview_keyring::Keyring *p) noexcept {
+    return static_cast<void *>(&p->abi);
+  }
+};
+
+}  // namespace vsql::detail
+
+#endif  // VILLAGESQL_PREVIEW_KEYRING_REGISTER_H

--- a/villagesql/sdk/include/villagesql/preview/keyring_register.h
+++ b/villagesql/sdk/include/villagesql/preview/keyring_register.h
@@ -23,13 +23,13 @@
 namespace vsql::detail {
 
 template <>
-struct CapabilityTraits<::vsql::preview_keyring::Keyring> {
+struct CapabilityTraits<::vsql::preview_keyring::KeyringCapability> {
   static constexpr const char *kName = VEF_PREVIEW_KEYRING_NAME;
   static constexpr uint32_t kAbiVersion = VEF_PREVIEW_KEYRING_ABI_VERSION;
   using AbiType = vef_preview_keyring_t;
 
   static constexpr void *vtable_destination(
-      ::vsql::preview_keyring::Keyring *p) noexcept {
+      ::vsql::preview_keyring::KeyringCapability *p) noexcept {
     return static_cast<void *>(&p->abi);
   }
 };

--- a/villagesql/sdk/include/villagesql/preview/ping.h
+++ b/villagesql/sdk/include/villagesql/preview/ping.h
@@ -20,9 +20,9 @@
 
 namespace vsql::preview_ping {
 
-// Declare a Ping by value in your extension and pass its address to
+// Declare a PingCapability by value in your extension and pass it to
 // .with(). VEF populates `abi` during registration.
-class Ping {
+class PingCapability {
  public:
   long long ping() const;
 

--- a/villagesql/sdk/include/villagesql/preview/ping_impl.h
+++ b/villagesql/sdk/include/villagesql/preview/ping_impl.h
@@ -13,27 +13,18 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
-#ifndef VILLAGESQL_PREVIEW_PING_H
-#define VILLAGESQL_PREVIEW_PING_H
+#ifndef VILLAGESQL_PREVIEW_PING_IMPL_H
+#define VILLAGESQL_PREVIEW_PING_IMPL_H
 
 #include <villagesql/abi/preview/ping.h>
+#include <villagesql/preview/ping.h>
 
 namespace vsql::preview_ping {
 
-// Declare a Ping by value in your extension and pass its address to
-// .with(). VEF populates `abi` during registration.
-class Ping {
- public:
-  long long ping() const;
-
-  // VEF writes this during registration. Public for the registration
-  // glue; do not access from extension code.
-  const vef_preview_ping_t *abi = nullptr;
-};
+inline long long Ping::ping() const {
+  return static_cast<long long>(abi->ping());
+}
 
 }  // namespace vsql::preview_ping
 
-#include <villagesql/preview/ping_impl.h>
-#include <villagesql/preview/ping_register.h>
-
-#endif  // VILLAGESQL_PREVIEW_PING_H
+#endif  // VILLAGESQL_PREVIEW_PING_IMPL_H

--- a/villagesql/sdk/include/villagesql/preview/ping_impl.h
+++ b/villagesql/sdk/include/villagesql/preview/ping_impl.h
@@ -21,7 +21,7 @@
 
 namespace vsql::preview_ping {
 
-inline long long Ping::ping() const {
+inline long long PingCapability::ping() const {
   return static_cast<long long>(abi->ping());
 }
 

--- a/villagesql/sdk/include/villagesql/preview/ping_register.h
+++ b/villagesql/sdk/include/villagesql/preview/ping_register.h
@@ -23,13 +23,13 @@
 namespace vsql::detail {
 
 template <>
-struct CapabilityTraits<::vsql::preview_ping::Ping> {
+struct CapabilityTraits<::vsql::preview_ping::PingCapability> {
   static constexpr const char *kName = VEF_PREVIEW_PING_NAME;
   static constexpr uint32_t kAbiVersion = VEF_PREVIEW_PING_ABI_VERSION;
   using AbiType = vef_preview_ping_t;
 
   static constexpr void *vtable_destination(
-      ::vsql::preview_ping::Ping *p) noexcept {
+      ::vsql::preview_ping::PingCapability *p) noexcept {
     return static_cast<void *>(&p->abi);
   }
 };

--- a/villagesql/sdk/include/villagesql/preview/ping_register.h
+++ b/villagesql/sdk/include/villagesql/preview/ping_register.h
@@ -13,27 +13,27 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
-#ifndef VILLAGESQL_PREVIEW_PING_H
-#define VILLAGESQL_PREVIEW_PING_H
+#ifndef VILLAGESQL_PREVIEW_PING_REGISTER_H
+#define VILLAGESQL_PREVIEW_PING_REGISTER_H
 
 #include <villagesql/abi/preview/ping.h>
+#include <villagesql/preview/ping.h>
+#include <villagesql/vsql/capability_traits.h>
 
-namespace vsql::preview_ping {
+namespace vsql::detail {
 
-// Declare a Ping by value in your extension and pass its address to
-// .with(). VEF populates `abi` during registration.
-class Ping {
- public:
-  long long ping() const;
+template <>
+struct CapabilityTraits<::vsql::preview_ping::Ping> {
+  static constexpr const char *kName = VEF_PREVIEW_PING_NAME;
+  static constexpr uint32_t kAbiVersion = VEF_PREVIEW_PING_ABI_VERSION;
+  using AbiType = vef_preview_ping_t;
 
-  // VEF writes this during registration. Public for the registration
-  // glue; do not access from extension code.
-  const vef_preview_ping_t *abi = nullptr;
+  static constexpr void *vtable_destination(
+      ::vsql::preview_ping::Ping *p) noexcept {
+    return static_cast<void *>(&p->abi);
+  }
 };
 
-}  // namespace vsql::preview_ping
+}  // namespace vsql::detail
 
-#include <villagesql/preview/ping_impl.h>
-#include <villagesql/preview/ping_register.h>
-
-#endif  // VILLAGESQL_PREVIEW_PING_H
+#endif  // VILLAGESQL_PREVIEW_PING_REGISTER_H

--- a/villagesql/sdk/include/villagesql/vsql/capability_traits.h
+++ b/villagesql/sdk/include/villagesql/vsql/capability_traits.h
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+#ifndef VILLAGESQL_VSQL_CAPABILITY_TRAITS_H
+#define VILLAGESQL_VSQL_CAPABILITY_TRAITS_H
+
+namespace vsql::detail {
+
+// Primary template for capability traits. Each capability provides a
+// specialization that defines:
+//   static constexpr const char* kName;
+//       The capability name the server looks up.
+//   static constexpr uint32_t kAbiVersion;
+//       The ABI version this extension was compiled against. Used as
+//       min_version in the wire entry and for the exact-match check in
+//       CapReceiveSlot::receive.
+//   using AbiType = ...;
+//       The C ABI struct type (e.g. vef_preview_ping_t). Used to
+//       compute villagesql::detail::abi_type_hash<AbiType>() for the
+//       wire format's mismatch check.
+//   static constexpr void* vtable_destination(Capability* p);
+//       The address inside *p where the server should write the
+//       capability's vtable pointer at registration time.
+//
+// .with(Capability&) on ExtensionBuilder reads these from the
+// specialization keyed by the user's wrapper type.
+template <typename Capability>
+struct CapabilityTraits;
+
+}  // namespace vsql::detail
+
+#endif  // VILLAGESQL_VSQL_CAPABILITY_TRAITS_H

--- a/villagesql/sdk/include/villagesql/vsql/extension_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/extension_builder.h
@@ -17,11 +17,11 @@
 #define VILLAGESQL_VSQL_EXTENSION_BUILDER_H
 
 #include <cstddef>
-#include <cstdio>
 #include <tuple>
 #include <utility>
 
-#include <villagesql/detail/capability_hash.h>
+#include <villagesql/detail/cap_receive.h>
+#include <villagesql/vsql/capability_traits.h>
 
 #include <villagesql/detail/vef_register.h>
 #include <villagesql/vsql/status_var_builder.h>
@@ -33,33 +33,6 @@ namespace vsql {
 // make_func, INT, STRING, etc. without additional using-declarations at the
 // call site.
 using namespace func_builder;
-
-// cap_receive<Cap, cap_ptr> is the default extension-side receive function.
-// Called by the server's capability compat function with the server's vtable
-// pointer. Stores the vtable into cap_ptr->abi_ and returns true only if the
-// server's capability version exactly matches Cap::kAbiVersion.
-//
-// Exact match is intentionally strict: it ensures the extension is always
-// running against the same ABI version it was compiled against. If you need
-// to accept a different server version (e.g. degrade gracefully when the
-// server is newer), supply a custom receive function in the capability's
-// bind() instead of using cap_receive.
-//
-// cap_ptr must have static storage duration so its address is a valid non-type
-// template argument.
-template <typename Cap, Cap *cap_ptr>
-bool cap_receive(vef_capability_receive_arg_t *arg) {
-  auto *v = static_cast<decltype(cap_ptr->abi_)>(arg->vtable);
-  if (v->version != Cap::kAbiVersion) {
-    snprintf(arg->error_buf, arg->error_buf_len,
-             "version mismatch: server=%u, compiled=%u",
-             static_cast<unsigned>(v->version),
-             static_cast<unsigned>(Cap::kAbiVersion));
-    return false;
-  }
-  cap_ptr->abi_ = v;
-  return true;
-}
 
 // ExtensionBuilder is the vsql-API extension builder. It is a standalone type
 // (not a wrapper around villagesql::extension_builder::ExtensionBuilder) so it
@@ -171,28 +144,19 @@ struct ExtensionBuilder {
   // vef_register_impl() runs should wrap ExtensionBuilder and override this.
   void init() const {}
 
-  // Low-level method for use by capability bind() functions only.
-  // Prefer .with<Traits>() at call sites.
-  constexpr auto required_capability(
-      const vef_required_capability_t &req) const {
+  // Capability registration. The user's wrapper is captured into the
+  // builder's tuple as a typed Capability*. At registration time
+  // vef_register_impl publishes the pointer into
+  // CapReceiveSlot<Capability> and emits a wire entry whose receive
+  // callback is the slot's captureless `receive` function.
+  template <typename Capability>
+  constexpr auto with(Capability &cap) const {
     auto new_caps =
-        std::tuple_cat(required_capabilities_, std::make_tuple(req));
+        std::tuple_cat(required_capabilities_, std::make_tuple(&cap));
     return ExtensionBuilder<FuncTuple, TypeTuple, SysVarTuple, StatusVarTuple,
                             decltype(new_caps)>{
         funcs_,       types_,   sys_vars_,
         status_vars_, new_caps, require_atleast_min(VEF_PROTOCOL_2)};
-  }
-
-  // Generic builder extension point for capabilities. Traits is defined in
-  // its own header — only available when that header is included.
-  template <typename Traits>
-  constexpr auto with() const {
-    return Traits::bind(*this);
-  }
-
-  template <typename Traits, typename Config>
-  constexpr auto with(Config config) const {
-    return Traits::bind(*this, config);
   }
 
   // For testing only — forces the extension to require protocol p regardless

--- a/villagesql/test-extensions/vsql-keyring-reader/src/extension.cc
+++ b/villagesql/test-extensions/vsql-keyring-reader/src/extension.cc
@@ -29,9 +29,9 @@
 #include <villagesql/vsql.h>
 
 using namespace vsql;
-using Keyring = vsql::preview_keyring::Keyring;
+using KeyringCapability = vsql::preview_keyring::KeyringCapability;
 
-static Keyring g_keyring;
+static KeyringCapability g_keyring;
 
 // keyring_read(data_id, auth_id) - reads a secret from the keyring.
 // Returns the secret as a string, or NULL if not found.
@@ -44,11 +44,11 @@ void keyring_read(StringArg data_id, StringArg auth_id, StringResult out) {
 
   const auto [status, value] =
       g_keyring.read(data_id.value(), auth_id.is_null() ? "" : auth_id.value());
-  if (status == Keyring::Status::UNAVAILABLE) {
+  if (status == KeyringCapability::Status::UNAVAILABLE) {
     out.error("No keyring component is installed");
     return;
   }
-  if (status != Keyring::Status::OK) {
+  if (status != KeyringCapability::Status::OK) {
     out.set_null();
     return;
   }
@@ -69,13 +69,13 @@ void keyring_store(StringArg data_id, StringArg auth_id, StringArg value,
     return;
   }
 
-  Keyring::Status status = g_keyring.write(
+  KeyringCapability::Status status = g_keyring.write(
       data_id.value(), auth_id.is_null() ? "" : auth_id.value(), value.value());
-  if (status == Keyring::Status::UNAVAILABLE) {
+  if (status == KeyringCapability::Status::UNAVAILABLE) {
     out.error("No keyring component is installed");
     return;
   }
-  out.set(status == Keyring::Status::OK ? 0 : 1);
+  out.set(status == KeyringCapability::Status::OK ? 0 : 1);
 }
 
 VEF_GENERATE_ENTRY_POINTS(make_extension()

--- a/villagesql/test-extensions/vsql-keyring-reader/src/extension.cc
+++ b/villagesql/test-extensions/vsql-keyring-reader/src/extension.cc
@@ -29,9 +29,9 @@
 #include <villagesql/vsql.h>
 
 using namespace vsql;
-using vsql::preview::preview_keyring;
+using Keyring = vsql::preview_keyring::Keyring;
 
-static auto g_keyring = vsql::preview::keyring::make_capability();
+static Keyring g_keyring;
 
 // keyring_read(data_id, auth_id) - reads a secret from the keyring.
 // Returns the secret as a string, or NULL if not found.
@@ -42,14 +42,13 @@ void keyring_read(StringArg data_id, StringArg auth_id, StringResult out) {
     return;
   }
 
-  std::string value;
-  vef_keyring_result_t kr = g_keyring.read(
-      data_id.value(), auth_id.is_null() ? "" : auth_id.value(), value);
-  if (kr == VEF_KEYRING_UNAVAILABLE) {
+  const auto [status, value] =
+      g_keyring.read(data_id.value(), auth_id.is_null() ? "" : auth_id.value());
+  if (status == Keyring::Status::UNAVAILABLE) {
     out.error("No keyring component is installed");
     return;
   }
-  if (kr != VEF_KEYRING_OK) {
+  if (status != Keyring::Status::OK) {
     out.set_null();
     return;
   }
@@ -70,13 +69,13 @@ void keyring_store(StringArg data_id, StringArg auth_id, StringArg value,
     return;
   }
 
-  vef_keyring_result_t kr = g_keyring.write(
+  Keyring::Status status = g_keyring.write(
       data_id.value(), auth_id.is_null() ? "" : auth_id.value(), value.value());
-  if (kr == VEF_KEYRING_UNAVAILABLE) {
+  if (status == Keyring::Status::UNAVAILABLE) {
     out.error("No keyring component is installed");
     return;
   }
-  out.set(kr == VEF_KEYRING_OK ? 0 : 1);
+  out.set(status == Keyring::Status::OK ? 0 : 1);
 }
 
 VEF_GENERATE_ENTRY_POINTS(make_extension()
@@ -91,4 +90,4 @@ VEF_GENERATE_ENTRY_POINTS(make_extension()
                                         .param(STRING)
                                         .param(STRING)
                                         .build())
-                              .with<preview_keyring<g_keyring>>())
+                              .with(g_keyring))

--- a/villagesql/test-extensions/vsql-preview-ping-no-cap-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-preview-ping-no-cap-test/src/extension.cc
@@ -13,8 +13,8 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-// vsql_preview_ping_no_cap_test extension: verifies that omitting .with<>
-// for a capability causes it to be unavailable (abi_ stays null), and that
+// vsql_preview_ping_no_cap_test extension: verifies that omitting .with()
+// for a capability causes it to be unavailable (abi stays null), and that
 // the extension degrades gracefully rather than crashing.
 //
 // VDFs provided:
@@ -26,20 +26,20 @@
 
 using namespace vsql;
 
-// g_ping is never registered via .with<preview_ping<g_ping>>(), so
-// abi_ stays null and available() returns false.
-static auto g_ping = vsql::preview::ping::make_capability();
+// g_ping is never registered via .with(g_ping), so
+// abi stays null.
+static vsql::preview_ping::Ping g_ping;
 
 static void ping_available_impl(IntResult out) {
-  out.set(g_ping.available() ? 1 : 0);
+  out.set(g_ping.abi != nullptr ? 1 : 0);
 }
 
 static void ping_value_impl(IntResult out) {
-  if (!g_ping.available()) {
+  if (g_ping.abi == nullptr) {
     out.set_null();
     return;
   }
-  out.set(static_cast<long long>(g_ping.ping()));
+  out.set(g_ping.ping());
 }
 
 VEF_GENERATE_ENTRY_POINTS(

--- a/villagesql/test-extensions/vsql-preview-ping-no-cap-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-preview-ping-no-cap-test/src/extension.cc
@@ -28,7 +28,7 @@ using namespace vsql;
 
 // g_ping is never registered via .with(g_ping), so
 // abi stays null.
-static vsql::preview_ping::Ping g_ping;
+static vsql::preview_ping::PingCapability g_ping;
 
 static void ping_available_impl(IntResult out) {
   out.set(g_ping.abi != nullptr ? 1 : 0);

--- a/villagesql/test-extensions/vsql-preview-ping-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-preview-ping-test/src/extension.cc
@@ -13,33 +13,22 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-// vsql_preview_ping_test extension: exercises the preview capability
-// registration system using the "vsql::ping" capability.
+// vsql_preview_ping_test extension: exercises the (consolidated)
+// preview capability system using the "vsql::ping" capability.
 //
 // Provides a single VDF vsql_preview_ping_test.ping() that calls the
-// server-provided ping capability and returns its counter value. This
-// verifies end-to-end that the capability system is wired up correctly.
-//
-// VDFs provided:
-//   ping() -> INT   Calls the server ping capability and returns the counter.
+// server-provided ping capability and returns its counter value.
 
 #include <villagesql/preview/ping.h>
 #include <villagesql/vsql.h>
 
 using namespace vsql;
-using vsql::preview::preview_ping;
 
-static auto g_ping = vsql::preview::ping::make_capability();
+static vsql::preview_ping::Ping g_ping;
 
-static void ping_impl(IntResult out) {
-  if (!g_ping.available()) {
-    out.set_null();
-    return;
-  }
-  out.set(static_cast<long long>(g_ping.ping()));
-}
+static void ping_impl(IntResult out) { out.set(g_ping.ping()); }
 
 VEF_GENERATE_ENTRY_POINTS(
     make_extension()
         .func(make_func<&ping_impl>("ping").returns(INT).build())
-        .with<preview_ping<g_ping>>())
+        .with(g_ping))

--- a/villagesql/test-extensions/vsql-preview-ping-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-preview-ping-test/src/extension.cc
@@ -24,7 +24,7 @@
 
 using namespace vsql;
 
-static vsql::preview_ping::Ping g_ping;
+static vsql::preview_ping::PingCapability g_ping;
 
 static void ping_impl(IntResult out) { out.set(g_ping.ping()); }
 

--- a/villagesql/test-extensions/vsql-preview-ping-v2-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-preview-ping-v2-test/src/extension.cc
@@ -17,46 +17,54 @@
 // only provides ping ABI v1.
 //
 // Uses a local ping_abi_v2.h instead of the SDK's ping header so that it can
-// declare min_version=2 without waiting for the real ping v2 to exist. The
+// declare kAbiVersion=2 without waiting for the real ping v2 to exist. The
 // server's preview_ping_compat checks min_version against its vtable version
 // field (1) and rejects the extension with "capability version too old".
-//
-// VDFs provided (never reachable — extension always fails to load):
-//   ping_v2_value() -> INT   Returns the ping counter.
-//   pong_value()    -> INT   Returns the pong counter (requires server v2).
 
 #include "ping_abi_v2.h"
 
 #include <cstdint>
-#include <type_traits>
 
-#include <villagesql/detail/capability_hash.h>
 #include <villagesql/vsql.h>
+#include <villagesql/vsql/capability_traits.h>
 
 using namespace vsql;
 
 struct PingV2Capability {
+  const vef_preview_ping_v2_t *abi = nullptr;
+};
+
+namespace vsql::detail {
+
+template <>
+struct CapabilityTraits<PingV2Capability> {
   static constexpr const char *kName = VEF_PREVIEW_PING_NAME;
   static constexpr uint32_t kAbiVersion = VEF_PREVIEW_PING_V2_ABI_VERSION;
-  const vef_preview_ping_v2_t *abi_ = nullptr;
+  using AbiType = vef_preview_ping_v2_t;
+
+  static constexpr void *vtable_destination(PingV2Capability *p) noexcept {
+    return static_cast<void *>(&p->abi);
+  }
 };
+
+}  // namespace vsql::detail
 
 static PingV2Capability g_ping{};
 
 static void ping_v2_value_impl(IntResult out) {
-  if (g_ping.abi_ == nullptr) {
+  if (g_ping.abi == nullptr) {
     out.set_null();
     return;
   }
-  out.set(static_cast<long long>(g_ping.abi_->ping()));
+  out.set(static_cast<long long>(g_ping.abi->ping()));
 }
 
 static void pong_value_impl(IntResult out) {
-  if (g_ping.abi_ == nullptr || g_ping.abi_->version < 2) {
+  if (g_ping.abi == nullptr || g_ping.abi->version < 2) {
     out.set_null();
     return;
   }
-  out.set(static_cast<long long>(g_ping.abi_->pong()));
+  out.set(static_cast<long long>(g_ping.abi->pong()));
 }
 
 VEF_GENERATE_ENTRY_POINTS(
@@ -65,9 +73,4 @@ VEF_GENERATE_ENTRY_POINTS(
                   .returns(INT)
                   .build())
         .func(make_func<&pong_value_impl>("pong_value").returns(INT).build())
-        .required_capability(
-            {PingV2Capability::kName,
-             &::vsql::cap_receive<PingV2Capability, &g_ping>,
-             villagesql::detail::abi_type_hash<std::remove_cv_t<
-                 std::remove_pointer_t<decltype(g_ping.abi_)>>>(),
-             PingV2Capability::kAbiVersion}))
+        .with(g_ping))

--- a/villagesql/test-extensions/vsql-preview-unknown-cap-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-preview-unknown-cap-test/src/extension.cc
@@ -17,47 +17,39 @@
 // system when a requested capability is not registered on the server.
 //
 // Requests a capability named "vsql::nonexistent" which the server will never
-// populate. The cap_available() VDF returns whether the capability was
-// populated — it should always return 0.
-//
-// VDFs provided:
-//   cap_available() -> INT   Returns 1 if the unknown cap was populated, else
-//   0.
+// register. INSTALL EXTENSION fails with a "required capability not
+// registered" error before any user-visible code runs, so the extension
+// exposes no VDFs.
 
-#include <cstdint>
-
-#include <villagesql/detail/capability_hash.h>
 #include <villagesql/vsql.h>
 
 using namespace vsql;
 
-// Minimal ABI struct for the nonexistent capability.
-// version must be first, as required by all capability vtables.
-// The server will never populate this, so abi_ stays null after registration.
+// Made-up abi struct + capability name that the server never registers.
 struct NonexistentAbi {
   uint32_t version;
   void (*fn)();
 };
 
-struct UnknownCapability {
-  static constexpr const char *kName = "vsql::nonexistent";
-  static constexpr uint32_t kAbiVersion = 1;
-  const NonexistentAbi *abi_ = nullptr;
+struct NonexistentCap {
+  const NonexistentAbi *abi = nullptr;
 };
 
-static UnknownCapability g_cap{};
+namespace vsql::detail {
 
-static void cap_available_impl(IntResult out) {
-  out.set(g_cap.abi_ != nullptr && g_cap.abi_->fn != nullptr ? 1 : 0);
-}
+template <>
+struct CapabilityTraits<NonexistentCap> {
+  static constexpr const char *kName = "vsql::nonexistent";
+  static constexpr uint32_t kAbiVersion = 1;
+  using AbiType = NonexistentAbi;
 
-VEF_GENERATE_ENTRY_POINTS(
-    make_extension()
-        .func(make_func<&cap_available_impl>("cap_available")
-                  .returns(INT)
-                  .build())
-        .required_capability(
-            {UnknownCapability::kName,
-             &::vsql::cap_receive<UnknownCapability, &g_cap>,
-             villagesql::detail::abi_type_hash<NonexistentAbi>(),
-             UnknownCapability::kAbiVersion}))
+  static constexpr void *vtable_destination(NonexistentCap *p) noexcept {
+    return static_cast<void *>(&p->abi);
+  }
+};
+
+}  // namespace vsql::detail
+
+static NonexistentCap g_nonexistent;
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().with(g_nonexistent))


### PR DESCRIPTION
Change how we do Capabilities. Big 2 goals:

foo.h: can have just declaration that's relevant to consumers
  (hide impl in foo-impl.h)
.with(&f) instead of .with<preview_foo<f>>()

Other things that come along with this:
* change from a receive() func to writing into a pointer
* remove checking capability hash
* make ping and keyring capabilities have a higher-level C++ API instead of reexporting ABI types
* redo nonexistent capability test: now the extension will just fail to load
