### PR TITLE
Add params_to_string

### DIFF
--- a/villagesql/examples/vsql-tvector/src/tvector.cc
+++ b/villagesql/examples/vsql-tvector/src/tvector.cc
@@ -134,6 +134,16 @@ bool tvector_int_to_params(int64_t value,
   return false;
 }
 
+// Inverse of TVectorParams::parse: render a typed TVectorParams back into the
+// canonical key/value string form. Used by the SDK when the server needs to
+// publish inferred params (e.g., from a constant-string from_string) back in
+// the same shape that parse() consumes.
+void tvector_params_to_strings(const TVectorParams &p,
+                               std::map<std::string, std::string> &out) {
+  out["dimension"] = std::to_string(p.dimension);
+  out["type"] = (p.bytes_per_elem == 8) ? "double" : "float";
+}
+
 // Validate type parameters and compute storage characteristics.
 bool tvector_resolve_params(const std::map<std::string, std::string> &params,
                             vsql::ResolvedTypeParams *result, char *error_msg) {
@@ -424,6 +434,7 @@ constexpr auto TVECTOR = vsql::make_type<kTVectorTypeName>()
                              .persisted_length(-1)
                              .max_decode_buffer_length(16)
                              .params<TVectorParams, &TVectorParams::parse>()
+                             .params_to_strings<&tvector_params_to_strings>()
                              .int_to_params<&tvector_int_to_params>()
                              .resolve_params<&tvector_resolve_params>()
                              .from_string<&tvector_from_string>()

--- a/villagesql/examples/vsql-tvector/src/tvector.cc
+++ b/villagesql/examples/vsql-tvector/src/tvector.cc
@@ -433,8 +433,8 @@ static constexpr const char kTVectorTypeName[] = "TVECTOR";
 constexpr auto TVECTOR = vsql::make_type<kTVectorTypeName>()
                              .persisted_length(-1)
                              .max_decode_buffer_length(16)
-                             .params<TVectorParams, &TVectorParams::parse>()
-                             .params_to_strings<&tvector_params_to_strings>()
+                             .params<TVectorParams, &TVectorParams::parse,
+                                     &tvector_params_to_strings>()
                              .int_to_params<&tvector_int_to_params>()
                              .resolve_params<&tvector_resolve_params>()
                              .from_string<&tvector_from_string>()

--- a/villagesql/sdk/include/villagesql/detail/vef_register.h
+++ b/villagesql/sdk/include/villagesql/detail/vef_register.h
@@ -79,6 +79,27 @@ __attribute__((visibility("hidden"))) vef_func_desc_t *materialize_func_desc(
 namespace villagesql {
 namespace detail {
 
+// has_descriptor<T>: true when T has a .descriptor member (the vsql TypeObject
+// shape produced by vsql::make_type<>().build()). False for the low-level
+// type_builder::TypeDescriptor which stores vef_desc directly.
+template <typename T, typename = void>
+struct has_descriptor : std::false_type {};
+template <typename T>
+struct has_descriptor<T, std::void_t<decltype(std::declval<T>().descriptor)>>
+    : std::true_type {};
+
+// Uniform accessor for the underlying vef_type_desc_t regardless of which
+// shape (TypeObject or TypeDescriptor) the typed-API or low-level extension
+// builder stored in its types_ tuple.
+template <typename T>
+inline const vef_type_desc_t &get_vef_desc(const T &t) {
+  if constexpr (has_descriptor<T>::value) {
+    return t.descriptor.vef_desc;
+  } else {
+    return t.vef_desc;
+  }
+}
+
 // Fills arr[I] with the materialized vef_func_desc_t* for each function.
 template <typename Ext, size_t... Is>
 void vef_fill_func_ptrs(vef_func_desc_t **arr, const Ext &e,
@@ -94,7 +115,7 @@ template <typename Ext, size_t... Is>
 void vef_fill_type_ptrs(vef_type_desc_t **arr, const Ext &e,
                         std::index_sequence<Is...>) {
   ((arr[Is] =
-        const_cast<vef_type_desc_t *>(&e.template type_at<Is>().vef_desc)),
+        const_cast<vef_type_desc_t *>(&get_vef_desc(e.template type_at<Is>()))),
    ...);
 }
 
@@ -141,13 +162,22 @@ void vef_fill_required_capability_reqs(vef_required_capability_t *arr,
   (vef_fill_one_capability_req<Is>(arr, e), ...);
 }
 
-// Calls params_init_fn() for each type that has one.
+// Calls params_init_fn() and params_to_strings_init_fn() for each type that
+// has one. These fields live on the vsql TypeObject only (parameterized types
+// flow through the typed C++ API); low-level type_builder::TypeDescriptor has
+// no init fns. has_descriptor<> gates the access so low-level extensions
+// compile and run with a no-op loop body.
+template <typename T>
+inline void call_type_init_fns(const T &t) {
+  if constexpr (has_descriptor<T>::value) {
+    if (t.params_init_fn) t.params_init_fn();
+    if (t.params_to_strings_init_fn) t.params_to_strings_init_fn();
+  }
+}
+
 template <typename Ext, size_t... Is>
 void vef_init_type_params(const Ext &e, std::index_sequence<Is...>) {
-  ((e.template type_at<Is>().params_init_fn
-        ? e.template type_at<Is>().params_init_fn()
-        : void()),
-   ...);
+  (call_type_init_fns(e.template type_at<Is>()), ...);
 }
 
 // Calls init_name() on any func that has it (auto-named VDFs from the vsql

--- a/villagesql/sdk/include/villagesql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/type_builder.h
@@ -39,28 +39,22 @@ namespace type_builder {
 struct TypeDescriptor {
   vef_type_desc_t vef_desc{};
   vef_type_storage_intf_t storage_intf{};
-  void (*params_init_fn)() = nullptr;
 
   constexpr TypeDescriptor() = default;
 
   constexpr TypeDescriptor(const TypeDescriptor &o)
-      : vef_desc(o.vef_desc),
-        storage_intf(o.storage_intf),
-        params_init_fn(o.params_init_fn) {
+      : vef_desc(o.vef_desc), storage_intf(o.storage_intf) {
     if (storage_intf.version != 0) vef_desc.storage_intf = &storage_intf;
   }
 
   constexpr TypeDescriptor(TypeDescriptor &&o)
-      : vef_desc(o.vef_desc),
-        storage_intf(o.storage_intf),
-        params_init_fn(o.params_init_fn) {
+      : vef_desc(o.vef_desc), storage_intf(o.storage_intf) {
     if (storage_intf.version != 0) vef_desc.storage_intf = &storage_intf;
   }
 
   constexpr TypeDescriptor &operator=(const TypeDescriptor &o) {
     vef_desc = o.vef_desc;
     storage_intf = o.storage_intf;
-    params_init_fn = o.params_init_fn;
     if (storage_intf.version != 0) vef_desc.storage_intf = &storage_intf;
     return *this;
   }

--- a/villagesql/sdk/include/villagesql/vsql/extension_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/extension_builder.h
@@ -98,11 +98,13 @@ struct ExtensionBuilder {
   }
 
   // Accepts a TypeObject (from vsql::make_type().build()) that carries embedded
-  // VDFs alongside the type descriptor, registering both in one call.
+  // VDFs and params-cache init fns alongside the type descriptor, registering
+  // all of them in one call. The whole TypeObject is stored in types_ so that
+  // detail/vef_register.h can reach the init fns at registration time.
   template <typename TypeObj,
             typename = decltype(std::declval<TypeObj>().embedded_funcs)>
   constexpr auto type(const TypeObj &t) const {
-    auto new_types = std::tuple_cat(types_, std::make_tuple(t.descriptor));
+    auto new_types = std::tuple_cat(types_, std::make_tuple(t));
     auto new_funcs = std::tuple_cat(funcs_, t.embedded_funcs);
     return ExtensionBuilder<decltype(new_funcs), decltype(new_types),
                             SysVarTuple, StatusVarTuple,

--- a/villagesql/sdk/include/villagesql/vsql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_builder.h
@@ -267,6 +267,24 @@ using ResolveTypeParamsFunc =
     bool (*)(const std::map<std::string, std::string> &params,
              vsql::ResolvedTypeParams *result, char *error_msg);
 
+// params_to_strings: converts the typed params struct P into its canonical
+// key/value string form (e.g., SVectorParams{6} -> {"dimension":"6"}). This
+// is the inverse direction of the parse callback an extension registers via
+// `.params<P, &Parse>()` on the type builder, whose signature is
+//   P parse(const std::map<std::string,std::string>&)
+// — Parse turns server-supplied strings into a typed P; params_to_strings
+// turns a typed P back into strings the server can read.
+//
+// Used by inference paths (e.g. constant-string from_string pre-execute at
+// fix_fields time) that produce a P and need to publish the equivalent
+// string-form params back to the server.
+//
+// The map keys/values are subject to the same rules as int_to_params: keys
+// are non-empty and free of ',' and '='; values are free of ',' and '='.
+template <typename P>
+using ParamsToStringsFunc = void (*)(const P &,
+                                     std::map<std::string, std::string> &);
+
 // =============================================================================
 // Aggregate Callback Wrappers
 // =============================================================================

--- a/villagesql/sdk/include/villagesql/vsql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/type_builder.h
@@ -171,8 +171,8 @@ inline constexpr TypeOpVdfName<TypeName, Op> kTypeOpVdfName{};
 // Shared builder state passed by value between TypeBuilder specializations.
 //
 // params_init_fn / params_to_strings_init_fn are typed-API-side state set by
-// .params<P, &Parse>() and .params_to_strings<&Fn>() respectively. They are
-// forwarded into the built TypeObject and called once at extension
+// the two- and three-argument forms of .params<P, &Parse[, &ToStrings]>().
+// They are forwarded into the built TypeObject and called once at extension
 // registration to bind the corresponding callbacks into TypeParamsCache<P>.
 // They live here (not on the low-level TypeDescriptor) because parameterized
 // types only flow through the typed C++ API.
@@ -198,8 +198,8 @@ struct TypeObject {
   villagesql::type_builder::TypeDescriptor descriptor;
   EmbeddedFuncsTuple embedded_funcs;
   // Init fns bound to TypeParamsCache<P> at extension registration. Set by
-  // .params<P, &Parse>() / .params_to_strings<&Fn>(); read by the
-  // registration loop in detail/vef_register.h.
+  // the two- and three-argument forms of .params<P, &Parse[, &ToStrings]>();
+  // read by the registration loop in detail/vef_register.h.
   void (*params_init_fn)() = nullptr;
   void (*params_to_strings_init_fn)() = nullptr;
 
@@ -249,14 +249,33 @@ class TypeBuilder {
   // Parameterized type support
   // -------------------------------------------------------------------------
 
-  // Bind the params parse function to TypeParamsCache<P>.
+  // Bind the params parse function to TypeParamsCache<P>, optionally also
+  // binding the inverse params_to_strings function.
   // Must be called before int_to_params() or resolve_params().
-  // P is the params struct type; ParseFunc is a function:
-  //   P fn(const std::map<std::string, std::string>&)
-  template <typename P, auto ParseFunc>
+  //
+  // P is the params struct type. Required signatures:
+  //   ParseFunc:            P  fn(const std::map<std::string,std::string>&)
+  //   ParamsToStringsFunc:  void fn(const P&,
+  //   std::map<std::string,std::string>&)
+  //
+  // ParamsToStringsFunc is the inverse of ParseFunc and is needed by paths
+  // that produce a typed P at runtime (e.g., constant-string from_string
+  // pre-execute at fix_fields time) and need to publish the equivalent
+  // string-form params back to the server. Optional for now while extensions
+  // migrate; will become required.
+  template <typename P, auto ParseFunc, auto ParamsToStringsFunc = nullptr>
   constexpr auto params() const {
     detail::TypeBuilderState s = state_;
     s.params_init_fn = &detail::bind_params_cache<P, ParseFunc>;
+    if constexpr (ParamsToStringsFunc != nullptr) {
+      static_assert(
+          std::is_same_v<decltype(ParamsToStringsFunc),
+                         func_builder::ParamsToStringsFunc<P>>,
+          "params<P, &Parse, &ToStrings>(): third argument must have signature "
+          "void fn(const P&, std::map<std::string,std::string>&)");
+      s.params_to_strings_init_fn =
+          &detail::bind_params_to_strings_cache<P, ParamsToStringsFunc>;
+    }
     s.desc.vef_desc.protocol = VEF_PROTOCOL_2;
     return TypeBuilder<HasFromString, HasToString, HasCompare, true,
                        HasIntToParams, HasResolveParams, EFT, Name>{
@@ -309,34 +328,6 @@ class TypeBuilder {
     return TypeBuilder<HasFromString, HasToString, HasCompare, HasParams,
                        HasIntToParams, true, decltype(new_embedded), Name>{
         s, new_embedded};
-  }
-
-  // params_to_strings: converts a typed P back into canonical key/value
-  // strings — the inverse direction of the parse function registered via
-  // .params<P, &Parse>() above. Required only for parameterized types whose
-  // params need to be inferred at runtime (e.g., constant-string from_string
-  // pre-execute at fix_fields time), so that the inferred P can be expressed
-  // in the string-form the server uses. Not SQL-callable; no VDF name is
-  // generated. Must be called after .params<P, &Parse>().
-  // Function signature:
-  //   void fn(const P&, std::map<std::string,std::string>&)
-  template <auto Func>
-  constexpr auto params_to_strings() const {
-    static_assert(
-        HasParams,
-        "params_to_strings<Func>() requires .params<P, &ParseFn>() first");
-    using P = std::remove_cv_t<std::remove_reference_t<std::tuple_element_t<
-        0, typename func_builder::FuncParamTypes<decltype(Func)>::type>>>;
-    static_assert(
-        std::is_same_v<decltype(Func), func_builder::ParamsToStringsFunc<P>>,
-        "params_to_strings<Func>() requires: "
-        "void fn(const P&, std::map<std::string,std::string>&)");
-    detail::TypeBuilderState s = state_;
-    s.params_to_strings_init_fn =
-        &detail::bind_params_to_strings_cache<P, Func>;
-    return TypeBuilder<HasFromString, HasToString, HasCompare, HasParams,
-                       HasIntToParams, HasResolveParams, EFT, Name>{
-        s, embedded_funcs_};
   }
 
   // -------------------------------------------------------------------------

--- a/villagesql/sdk/include/villagesql/vsql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/type_builder.h
@@ -94,10 +94,18 @@ namespace vsql {
 namespace detail {
 
 // Binds the parse function for parameterized type caches. Stored as a function
-// pointer in TypeDescriptor.params_init_fn and called once during registration.
+// pointer in TypeObject.params_init_fn and called once during registration.
 template <typename P, auto ParseFunc>
 void bind_params_cache() {
   type_params_cache_for<P>().bind(ParseFunc);
+}
+
+// Binds the inverse-of-parse (params_to_strings) function. Stored in
+// TypeObject.params_to_strings_init_fn and called once during registration.
+// P is recovered from the function signature via ParamsToStringsFunc<P>.
+template <typename P, auto ToStringsFunc>
+void bind_params_to_strings_cache() {
+  type_params_cache_for<P>().bind_to_strings(ToStringsFunc);
 }
 
 // =============================================================================
@@ -161,8 +169,17 @@ template <const char *TypeName, TypeOp Op>
 inline constexpr TypeOpVdfName<TypeName, Op> kTypeOpVdfName{};
 
 // Shared builder state passed by value between TypeBuilder specializations.
+//
+// params_init_fn / params_to_strings_init_fn are typed-API-side state set by
+// .params<P, &Parse>() and .params_to_strings<&Fn>() respectively. They are
+// forwarded into the built TypeObject and called once at extension
+// registration to bind the corresponding callbacks into TypeParamsCache<P>.
+// They live here (not on the low-level TypeDescriptor) because parameterized
+// types only flow through the typed C++ API.
 struct TypeBuilderState {
   villagesql::type_builder::TypeDescriptor desc;
+  void (*params_init_fn)() = nullptr;
+  void (*params_to_strings_init_fn)() = nullptr;
 };
 
 }  // namespace detail
@@ -180,6 +197,11 @@ template <typename EmbeddedFuncsTuple = std::tuple<>>
 struct TypeObject {
   villagesql::type_builder::TypeDescriptor descriptor;
   EmbeddedFuncsTuple embedded_funcs;
+  // Init fns bound to TypeParamsCache<P> at extension registration. Set by
+  // .params<P, &Parse>() / .params_to_strings<&Fn>(); read by the
+  // registration loop in detail/vef_register.h.
+  void (*params_init_fn)() = nullptr;
+  void (*params_to_strings_init_fn)() = nullptr;
 
   // Converts to the SQL type name string for use in .returns() and .param().
   constexpr operator const char *() const { return descriptor.vef_desc.name; }
@@ -203,7 +225,9 @@ struct TypeObject {
 //   Name — const char* NTTP from make_type<kName>(); drives selection of the
 //     per-(Name,Op) constexpr VDF name buffers via kTypeOpVdfName<Name,Op>.
 //
-//     NB - there is no HasHash because it is optional.
+//     NB - there is no HasHash because it is optional. params_to_strings is
+//     also optional (for now); it's bound through a separate init-fn slot
+//     rather than tracked via a TypeBuilder template parameter.
 
 template <bool HasFromString = false, bool HasToString = false,
           bool HasCompare = false, bool HasParams = false,
@@ -232,7 +256,7 @@ class TypeBuilder {
   template <typename P, auto ParseFunc>
   constexpr auto params() const {
     detail::TypeBuilderState s = state_;
-    s.desc.params_init_fn = &detail::bind_params_cache<P, ParseFunc>;
+    s.params_init_fn = &detail::bind_params_cache<P, ParseFunc>;
     s.desc.vef_desc.protocol = VEF_PROTOCOL_2;
     return TypeBuilder<HasFromString, HasToString, HasCompare, true,
                        HasIntToParams, HasResolveParams, EFT, Name>{
@@ -285,6 +309,34 @@ class TypeBuilder {
     return TypeBuilder<HasFromString, HasToString, HasCompare, HasParams,
                        HasIntToParams, true, decltype(new_embedded), Name>{
         s, new_embedded};
+  }
+
+  // params_to_strings: converts a typed P back into canonical key/value
+  // strings — the inverse direction of the parse function registered via
+  // .params<P, &Parse>() above. Required only for parameterized types whose
+  // params need to be inferred at runtime (e.g., constant-string from_string
+  // pre-execute at fix_fields time), so that the inferred P can be expressed
+  // in the string-form the server uses. Not SQL-callable; no VDF name is
+  // generated. Must be called after .params<P, &Parse>().
+  // Function signature:
+  //   void fn(const P&, std::map<std::string,std::string>&)
+  template <auto Func>
+  constexpr auto params_to_strings() const {
+    static_assert(
+        HasParams,
+        "params_to_strings<Func>() requires .params<P, &ParseFn>() first");
+    using P = std::remove_cv_t<std::remove_reference_t<std::tuple_element_t<
+        0, typename func_builder::FuncParamTypes<decltype(Func)>::type>>>;
+    static_assert(
+        std::is_same_v<decltype(Func), func_builder::ParamsToStringsFunc<P>>,
+        "params_to_strings<Func>() requires: "
+        "void fn(const P&, std::map<std::string,std::string>&)");
+    detail::TypeBuilderState s = state_;
+    s.params_to_strings_init_fn =
+        &detail::bind_params_to_strings_cache<P, Func>;
+    return TypeBuilder<HasFromString, HasToString, HasCompare, HasParams,
+                       HasIntToParams, HasResolveParams, EFT, Name>{
+        s, embedded_funcs_};
   }
 
   // -------------------------------------------------------------------------
@@ -416,7 +468,8 @@ class TypeBuilder {
     static_assert(!HasResolveParams || HasParams,
                   "vsql::TypeBuilder: params<P, &parse_fn>() is required when "
                   "resolve_params() is used");
-    return TypeObject<EFT>{state_.desc, embedded_funcs_};
+    return TypeObject<EFT>{state_.desc, embedded_funcs_, state_.params_init_fn,
+                           state_.params_to_strings_init_fn};
   }
 
   // Cross-specialization and make_type access.

--- a/villagesql/sdk/include/villagesql/vsql/type_params_cache.h
+++ b/villagesql/sdk/include/villagesql/vsql/type_params_cache.h
@@ -47,14 +47,30 @@ template <typename T>
 class TypeParamsCache {
  public:
   using ParseFn = T (*)(const std::map<std::string, std::string> &);
+  using ToStringsFn = void (*)(const T &, std::map<std::string, std::string> &);
 
   // Binds the parse function used by the no-arg get() overload. Called once
   // during extension initialization (vef_register), before any VDF calls.
   // Not safe to call after registration.
   void bind(ParseFn fn) { parse_fn_ = fn; }
 
+  // Binds the inverse-of-parse function used by inference paths (e.g.
+  // constant-string from_string at fix_fields time). Optional; only required
+  // for parameterized types whose params are inferable at runtime.
+  // Called once during extension initialization, before any VDF calls.
+  void bind_to_strings(ToStringsFn fn) { to_strings_fn_ = fn; }
+
   // Returns true if the parse function has been bound via bind().
   bool is_bound() const { return parse_fn_ != nullptr; }
+
+  // Returns true if a to_strings function has been bound for this type.
+  bool has_to_strings() const { return to_strings_fn_ != nullptr; }
+
+  // Invokes the bound to_strings function. has_to_strings() must be true.
+  void to_strings(const T &p, std::map<std::string, std::string> &out) const {
+    assert(to_strings_fn_ != nullptr);
+    to_strings_fn_(p, out);
+  }
 
   // Returns a reference to the cached T using the bound parse function.
   // bind() must have been called before this overload is used.
@@ -85,6 +101,7 @@ class TypeParamsCache {
 
  private:
   ParseFn parse_fn_ = nullptr;
+  ToStringsFn to_strings_fn_ = nullptr;
   mutable std::shared_mutex mu_;
   // Values are heap-allocated so their addresses remain stable across rehashes.
   // A rehash moves the unordered_map buckets, not the pointed-to T objects,


### PR DESCRIPTION
This is the reverse of the parse function: it takes a struct and makes a string mapping of the params.

While at it, remove params_init_fn from villagesql/type_builder.h.

Add the function for tvector. Once this is in, we will update the external repos and then circle back to make this non-optional.

#449 