### PR TITLE
Add max_persisted_length

### DIFF
--- a/unittest/gunit/villagesql/abi_v2_check-t.cc
+++ b/unittest/gunit/villagesql/abi_v2_check-t.cc
@@ -54,8 +54,9 @@
 //   const char *intrinsic_default_vdf_name;         // +112 (protocol >= 2)
 //   const char *intrinsic_default_str;              // +120 (protocol >= 2)
 //   vef_type_storage_intf_t *storage_intf;          // +128 (protocol >= 2)
+//   int64_t max_persisted_length;                   // +136 (protocol >= 2)
 // ---------------------------------------------------------------------------
-static_assert(sizeof(vef_type_desc_t) == 136,
+static_assert(sizeof(vef_type_desc_t) == 144,
               "ABI v2 break: vef_type_desc_t size changed");
 static_assert(offsetof(vef_type_desc_t, encode_vdf_name) == 64,
               "ABI v2 break: vef_type_desc_t::encode_vdf_name offset changed");
@@ -79,6 +80,9 @@ static_assert(
     "ABI v2 break: vef_type_desc_t::intrinsic_default_str offset changed");
 static_assert(offsetof(vef_type_desc_t, storage_intf) == 128,
               "ABI v2 break: vef_type_desc_t::storage_intf offset changed");
+static_assert(offsetof(vef_type_desc_t, max_persisted_length) == 136,
+              "ABI v2 break: vef_type_desc_t::max_persisted_length offset "
+              "changed");
 
 // ---------------------------------------------------------------------------
 // vef_type_params_t (protocol >= VEF_PROTOCOL_2)

--- a/villagesql/examples/vsql-tvector/src/tvector.cc
+++ b/villagesql/examples/vsql-tvector/src/tvector.cc
@@ -42,6 +42,11 @@
 #include <string>
 #include <string_view>
 
+// Largest dimension a TVECTOR may declare. Enforced in resolve_params and
+// int_to_params; also drives kTVectorMaxPersistedLength below for the
+// constant-string inference path.
+constexpr int64_t kTVectorMaxDimension = 4096;
+
 // Parsed representation of TVECTOR type parameters.
 // The static parse() method is used automatically by make_type_encode,
 // make_type_decode, and make_intrinsic_default when the operation function
@@ -133,10 +138,10 @@ size_t bytes_per_element(const std::map<std::string, std::string> &params) {
 bool tvector_int_to_params(int64_t value,
                            std::map<std::string, std::string> &params,
                            char *error_msg) {
-  if (value <= 0) {
+  if (value <= 0 || value > kTVectorMaxDimension) {
     snprintf(error_msg, VEF_MAX_ERROR_LEN,
-             "TVECTOR dimension must be a positive integer, got %" PRId64,
-             value);
+             "TVECTOR dimension must be in 1..%" PRId64 ", got %" PRId64,
+             kTVectorMaxDimension, value);
     return true;
   }
   params["dimension"] = std::to_string(value);
@@ -160,9 +165,10 @@ bool tvector_resolve_params(const std::map<std::string, std::string> &params,
              "TVECTOR: invalid dimension value '%s'", it->second.c_str());
     return true;
   }
-  if (dimension <= 0) {
+  if (dimension <= 0 || dimension > kTVectorMaxDimension) {
     snprintf(error_msg, VEF_MAX_ERROR_LEN,
-             "TVECTOR: dimension must be a positive integer");
+             "TVECTOR: dimension must be in 1..%" PRId64 ", got %" PRId64,
+             kTVectorMaxDimension, dimension);
     return true;
   }
 
@@ -430,9 +436,17 @@ void tvector_scale(vsql::CustomArgWith<TVectorParams> a, vsql::RealArg scalar,
 
 static constexpr const char kTVectorTypeName[] = "TVECTOR";
 
+// Upper bound on TVECTOR's persisted byte size: kTVectorMaxDimension
+// elements at 8 bytes each (double, the wider of the two supported element
+// types). Used only on the fix_fields-time constant-string inference path;
+// row-time encoding uses the params-resolved persisted_length set by
+// tvector_resolve_params.
+constexpr int64_t kTVectorMaxPersistedLength = kTVectorMaxDimension * 8;
+
 constexpr auto TVECTOR = vsql::make_type<kTVectorTypeName>()
                              .persisted_length(-1)
                              .max_decode_buffer_length(16)
+                             .max_persisted_length(kTVectorMaxPersistedLength)
                              .params<TVectorParams, &TVectorParams::parse,
                                      &TVectorParams::to_strings>()
                              .int_to_params<&tvector_int_to_params>()

--- a/villagesql/examples/vsql-tvector/test/r/tvector_errors.result
+++ b/villagesql/examples/vsql-tvector/test/r/tvector_errors.result
@@ -10,7 +10,7 @@ ERROR 42000: Empty parameter string for type 'vsql_tvector.TVECTOR' near 'TVECTO
 CREATE TABLE t_err (v TVECTOR('invalid'));
 ERROR 42000: Invalid parameter string for type 'vsql_tvector.TVECTOR' near 'TVECTOR('invalid'))' at line 1
 CREATE TABLE t_err (v TVECTOR('dimension=0'));
-ERROR 42000: TVECTOR: dimension must be a positive integer near 'TVECTOR('dimension=0'))' at line 1
+ERROR 42000: TVECTOR: dimension must be in 1..4096, got 0 near 'TVECTOR('dimension=0'))' at line 1
 CREATE TABLE t_err (v TVECTOR('unknown_key=5'));
 ERROR 42000: TVECTOR: dimension must be a positive integer near 'TVECTOR('unknown_key=5'))' at line 1
 SELECT vsql_tvector.tvector_dot_product('[1,2,3]', '[4,5,6]');

--- a/villagesql/sdk/include/villagesql/abi/types.h
+++ b/villagesql/sdk/include/villagesql/abi/types.h
@@ -734,6 +734,22 @@ typedef struct {
   // for the lifetime of the extension. The server reads storage_intf->version
   // to determine which fields are available.
   const vef_type_storage_intf_t *storage_intf;
+
+  // Upper bound on persisted_length across all valid parameterizations of
+  // this type. Required for parameterized types; ignored for non-parameterized
+  // types (where persisted_length already gives the answer). Placed at the
+  // end of the struct so that adding it does not shift earlier offsets,
+  // preserving binary compatibility for v1 extensions.
+  //
+  // Used only on the fix_fields-time constant-string inference path: the
+  // server doesn't yet know the parameters (those are about to be inferred),
+  // so it cannot consult resolve_params to size the encode buffer. It
+  // allocates max_persisted_length bytes, runs from_string with
+  // MaybeParams<P> unknown, then trims the result to actual_len.
+  //
+  // Example: for SVECTOR with max dimension 3072, this is
+  //   sizeof(vef_storage_ref_t) + 3072 * sizeof(float).
+  int64_t max_persisted_length;
 } vef_type_desc_t;
 
 // Config Variables

--- a/villagesql/sdk/include/villagesql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/type_builder.h
@@ -201,6 +201,7 @@ class TypeBuilder {
         intrinsic_default_vdf_name_,
         intrinsic_default_str_,
         storage_intf_.version != 0 ? &desc.storage_intf : nullptr,
+        0,  // max_persisted_length: only set via the typed API
     };
     return desc;
   }

--- a/villagesql/sdk/include/villagesql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/type_builder.h
@@ -201,7 +201,7 @@ class TypeBuilder {
         intrinsic_default_vdf_name_,
         intrinsic_default_str_,
         storage_intf_.version != 0 ? &desc.storage_intf : nullptr,
-        0,  // max_persisted_length: only set via the typed API
+        0,  // max_persisted_length: only set via the v2+ API
     };
     return desc;
   }

--- a/villagesql/sdk/include/villagesql/vsql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/type_builder.h
@@ -44,6 +44,7 @@
 //   static constexpr const char kTVectorTypeName[] = "TVECTOR";
 //
 //   constexpr auto TVECTOR = vsql::make_type<kTVectorTypeName>()
+//       .max_persisted_length(/* upper bound across all valid params */)
 //       .params<TVectorParams, &TVectorParams::parse,
 //               &TVectorParams::to_strings>()
 //       .int_to_params<&my_int_to_params_fn>()
@@ -245,6 +246,24 @@ class TypeBuilder {
 
   constexpr TypeBuilder &max_decode_buffer_length(int64_t len) {
     state_.desc.vef_desc.max_decode_buffer_length = len;
+    return *this;
+  }
+
+  // Upper bound on persisted_length across all valid parameterizations.
+  // Required for parameterized types (parse + to_strings); ignored for
+  // non-parameterized types (persisted_length suffices there).
+  //
+  // Used only on the fix_fields-time constant-string inference path, where
+  // the server has not yet inferred the params and so cannot consult
+  // resolve_params to size the encode buffer. The server allocates this many
+  // bytes, runs from_string with MaybeParams<P> unknown, then trims to
+  // actual_len. After inference, normal row-time calls continue to use the
+  // params-resolved persisted_length as today.
+  //
+  // Optional for now while extensions migrate; will become required for
+  // parameterized types.
+  constexpr TypeBuilder &max_persisted_length(int64_t len) {
+    state_.desc.vef_desc.max_persisted_length = len;
     return *this;
   }
 


### PR DESCRIPTION
This is needed for parameterized types when we encode a value with unknown params.
