### PR TITLE
Fix docker datadir mismatch

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -43,6 +43,7 @@ RUN mkdir /build && cd /build && \
         -DINSTALL_MYSQLTESTDIR="" \
         -DWITH_ROUTER=OFF \
         -DWITH_NUMA=OFF \
+        -DMYSQL_DATADIR=/var/lib/mysql \
         -DMYSQL_UNIX_ADDR=/var/run/mysqld/mysqld.sock \
         -DMYSQLX_UNIX_ADDR=/var/run/mysqld/mysqlx.sock \
         -DVSQL_PRE_RELEASE_VERSION="$VSQL_PRE_RELEASE_VERSION" \


### PR DESCRIPTION
## Description
The VOLUME declaration in the server Dockerfile says /var/lib/mysql but MySQL is actually writing data to /usr/data/ — confirmed with SELECT @@datadir. Any volume mounted at /var/lib/mysql gets nothing; data disappears when the container stops. 

This fix adds -DMYSQL_DATADIR=/var/lib/mysql to the cmake call in the Dockerfile.

## Related Issue
n/a

## How was this tested?
Verified with cmake configure-only (no full build) against the same flags used in the Dockerfile:                     
   
  Without fix                                                                                                         
  cmake ... -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_CONFIG=mysql_release
  → MYSQL_DATADIR=/usr/data                                                                                             
   
  With fix                                                                                                            
  cmake ... -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_CONFIG=mysql_release -DMYSQL_DATADIR=/var/lib/mysql
  → MYSQL_DATADIR=/var/lib/mysql                                                                                        
   
  Also confirmed the bug on the existing villagesql/server:stable image:                                                
  mysqld --verbose --help | grep datadir
  → datadir   /usr/data/           

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
