### PR TITLE
Type inference write-back extension side

### DIFF
--- a/unittest/gunit/villagesql/abi_v2_check-t.cc
+++ b/unittest/gunit/villagesql/abi_v2_check-t.cc
@@ -128,5 +128,38 @@ static_assert(sizeof(vef_vdf_result_t) == 72,
 static_assert(offsetof(vef_vdf_result_t, type_params) == 48,
               "ABI v2 break: vef_vdf_result_t::type_params offset changed");
 
+// ---------------------------------------------------------------------------
+// vef_inferred_type_params_t (protocol >= VEF_PROTOCOL_2)
+//   char *buf;             // +0   (8 bytes)
+//   size_t max_buf_len;    // +8   (8 bytes)
+//   size_t actual_len;     // +16  (8 bytes)
+//   bool overflow;         // +24  (1 byte, +7 padding)
+// ---------------------------------------------------------------------------
+static_assert(sizeof(vef_inferred_type_params_t) == 32,
+              "ABI v2 break: vef_inferred_type_params_t size changed");
+static_assert(offsetof(vef_inferred_type_params_t, buf) == 0,
+              "ABI v2 break: vef_inferred_type_params_t::buf offset changed");
+static_assert(
+    offsetof(vef_inferred_type_params_t, max_buf_len) == 8,
+    "ABI v2 break: vef_inferred_type_params_t::max_buf_len offset changed");
+static_assert(
+    offsetof(vef_inferred_type_params_t, actual_len) == 16,
+    "ABI v2 break: vef_inferred_type_params_t::actual_len offset changed");
+static_assert(
+    offsetof(vef_inferred_type_params_t, overflow) == 24,
+    "ABI v2 break: vef_inferred_type_params_t::overflow offset changed");
+
+// ---------------------------------------------------------------------------
+// vef_vdf_args_t (protocol >= VEF_PROTOCOL_2 appends out_type_params)
+//   void *user_data;                                  // +0   (8 bytes)
+//   unsigned int value_count;                         // +8   (4 + 4 pad)
+//   union { values_v1; values; };                     // +16  (8 bytes, ptr)
+//   vef_inferred_type_params_t *out_type_params;      // +24  (8 bytes)
+// ---------------------------------------------------------------------------
+static_assert(sizeof(vef_vdf_args_t) == 32,
+              "ABI v2 break: vef_vdf_args_t size changed");
+static_assert(offsetof(vef_vdf_args_t, out_type_params) == 24,
+              "ABI v2 break: vef_vdf_args_t::out_type_params offset changed");
+
 // Placeholder test so the binary links and runs.
 TEST(AbiV2Check, StaticAssertsPass) {}

--- a/unittest/gunit/villagesql/abi_v2_check-t.cc
+++ b/unittest/gunit/villagesql/abi_v2_check-t.cc
@@ -114,19 +114,25 @@ static_assert(offsetof(vef_invalue_t, type_params) == 24,
               "ABI v2 break: vef_invalue_t::type_params offset changed");
 
 // ---------------------------------------------------------------------------
-// vef_vdf_result_t (protocol >= VEF_PROTOCOL_2 adds type_params in CUSTOM)
-//   vef_return_value_type_t type;             // +0
+// vef_vdf_result_t (protocol >= VEF_PROTOCOL_2 adds type_params in CUSTOM
+// and appends out_type_params)
+//   vef_return_value_type_t type;                     // +0
 //   [4 bytes padding]
-//   size_t actual_len;                        // +8
-//   char *error_msg;                          // +16
-//   union { ... };                            // +24  (48 bytes: CUSTOM has
-//                                             //   bin_buf + max_bin_len +
-//                                             //   alt_bin_buf + type_params)
+//   size_t actual_len;                                // +8
+//   char *error_msg;                                  // +16
+//   union { ... };                                    // +24  (48 bytes:
+//                                                     //   CUSTOM has bin_buf
+//                                                     //   + max_bin_len +
+//                                                     //   alt_bin_buf +
+//                                                     //   type_params)
+//   vef_inferred_type_params_t *out_type_params;      // +72  (8 bytes)
 // ---------------------------------------------------------------------------
-static_assert(sizeof(vef_vdf_result_t) == 72,
+static_assert(sizeof(vef_vdf_result_t) == 80,
               "ABI v2 break: vef_vdf_result_t size changed");
 static_assert(offsetof(vef_vdf_result_t, type_params) == 48,
               "ABI v2 break: vef_vdf_result_t::type_params offset changed");
+static_assert(offsetof(vef_vdf_result_t, out_type_params) == 72,
+              "ABI v2 break: vef_vdf_result_t::out_type_params offset changed");
 
 // ---------------------------------------------------------------------------
 // vef_inferred_type_params_t (protocol >= VEF_PROTOCOL_2)
@@ -149,17 +155,8 @@ static_assert(
     offsetof(vef_inferred_type_params_t, overflow) == 24,
     "ABI v2 break: vef_inferred_type_params_t::overflow offset changed");
 
-// ---------------------------------------------------------------------------
-// vef_vdf_args_t (protocol >= VEF_PROTOCOL_2 appends out_type_params)
-//   void *user_data;                                  // +0   (8 bytes)
-//   unsigned int value_count;                         // +8   (4 + 4 pad)
-//   union { values_v1; values; };                     // +16  (8 bytes, ptr)
-//   vef_inferred_type_params_t *out_type_params;      // +24  (8 bytes)
-// ---------------------------------------------------------------------------
-static_assert(sizeof(vef_vdf_args_t) == 32,
-              "ABI v2 break: vef_vdf_args_t size changed");
-static_assert(offsetof(vef_vdf_args_t, out_type_params) == 24,
-              "ABI v2 break: vef_vdf_args_t::out_type_params offset changed");
+// vef_vdf_args_t has no v2-specific layout additions; its size and field
+// offsets are covered by abi_v1_check-t.cc.
 
 // Placeholder test so the binary links and runs.
 TEST(AbiV2Check, StaticAssertsPass) {}

--- a/villagesql/sdk/include/villagesql/abi/types.h
+++ b/villagesql/sdk/include/villagesql/abi/types.h
@@ -292,6 +292,35 @@ typedef struct {
   const char *const *values;
 } vef_type_params_t;
 
+// Server-supplied output channel for at-parse-time (fix_fields) inference of
+// from_string parameters from a constant string literal. The SDK wrapper
+// writes the canonical "k=v,k=v" form of the inferred params here when the
+// extension's parameterized from_string transitions MaybeParams<P> from
+// unknown to known during the call.
+//
+// Used only on the constant-string inference path. NULL on the normal
+// row-time path; see vef_vdf_args_t::out_type_params.
+//
+// Overflow contract (snprintf-style): the wrapper always sets actual_len to
+// the number of bytes that *would* have been written. If actual_len exceeds
+// max_buf_len, overflow is true and the contents of buf are undefined; the
+// caller should re-invoke with a heap-allocated buffer sized to
+// actual_len + 1 and try again.
+typedef struct {
+  // INPUT: caller-supplied buffer for the canonical "k=v,k=v" params string.
+  char *buf;
+  // INPUT: capacity of buf in bytes.
+  size_t max_buf_len;
+  // OUTPUT: number of bytes that would have been written (no NUL). 0 means
+  // no params were inferred (e.g., the extension's from_string did not call
+  // p.set(), the call errored, or the type does not register
+  // params_to_strings).
+  size_t actual_len;
+  // OUTPUT: true if actual_len > max_buf_len. When true, buf is not safe to
+  // read; the caller should retry with a larger buffer.
+  bool overflow;
+} vef_inferred_type_params_t;
+
 // Input value for VDF function arguments.
 // The `type` field indicates which union member to read.
 // Check `is_null` first - if true, the value is SQL NULL.
@@ -449,6 +478,16 @@ typedef struct {
     // protocol versions.
     vef_invalue_t **values;
   };
+
+  // protocol >= VEF_PROTOCOL_2
+  //
+  // Optional out-channel for constant-string from_string inference at
+  // fix_fields time. NULL on the normal row-time path. When non-NULL AND the
+  // extension's parameterized from_string transitions MaybeParams<P> from
+  // unknown to known, the SDK wrapper writes the inferred params as a
+  // canonical "k=v,k=v" string via the type's registered params_to_strings
+  // callback. See vef_inferred_type_params_t for the overflow contract.
+  vef_inferred_type_params_t *out_type_params;
 } vef_vdf_args_t;
 
 typedef struct {

--- a/villagesql/sdk/include/villagesql/abi/types.h
+++ b/villagesql/sdk/include/villagesql/abi/types.h
@@ -299,7 +299,7 @@ typedef struct {
 // unknown to known during the call.
 //
 // Used only on the constant-string inference path. NULL on the normal
-// row-time path; see vef_vdf_args_t::out_type_params.
+// row-time path; see vef_vdf_result_t::out_type_params.
 //
 // Overflow contract (snprintf-style): the wrapper always sets actual_len to
 // the number of bytes that *would* have been written. If actual_len exceeds
@@ -439,6 +439,16 @@ typedef struct {
     // For INT return type
     long long int_value;
   };
+
+  // protocol >= VEF_PROTOCOL_2
+  //
+  // Optional out-channel for constant-string from_string inference at
+  // fix_fields time. NULL on the normal row-time path. When non-NULL AND the
+  // extension's parameterized from_string transitions MaybeParams<P> from
+  // unknown to known, the SDK wrapper writes the inferred params as a
+  // canonical "k=v,k=v" string via the type's registered params_to_strings
+  // callback. See vef_inferred_type_params_t for the overflow contract.
+  vef_inferred_type_params_t *out_type_params;
 } vef_vdf_result_t;
 
 // =============================================================================
@@ -478,16 +488,6 @@ typedef struct {
     // protocol versions.
     vef_invalue_t **values;
   };
-
-  // protocol >= VEF_PROTOCOL_2
-  //
-  // Optional out-channel for constant-string from_string inference at
-  // fix_fields time. NULL on the normal row-time path. When non-NULL AND the
-  // extension's parameterized from_string transitions MaybeParams<P> from
-  // unknown to known, the SDK wrapper writes the inferred params as a
-  // canonical "k=v,k=v" string via the type's registered params_to_strings
-  // callback. See vef_inferred_type_params_t for the overflow contract.
-  vef_inferred_type_params_t *out_type_params;
 } vef_vdf_args_t;
 
 typedef struct {

--- a/villagesql/sdk/include/villagesql/vsql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_builder.h
@@ -510,13 +510,14 @@ struct TypeEncodeWithCacheVdfWrapper {
     // Inference-path write-back: when the server invoked us with no input
     // type_params (signalling "please infer"), the wrapper publishes the
     // canonical "k=v,k=v" form of the resulting MaybeParams<P> back to the
-    // server via args->out_type_params. All four guards must hold:
-    //   1. server opted in by setting args->out_type_params
+    // server via result->out_type_params. All four guards must hold:
+    //   1. server opted in by setting result->out_type_params
     //   2. encode succeeded (no warning/error)
     //   3. we were on the inference path (input type_params was empty)
     //   4. the extension actually inferred params and registered to_strings
-    if (args->out_type_params != nullptr && result->type == VEF_RESULT_VALUE &&
-        !input_params_known && maybe_params.is_known() &&
+    if (result->out_type_params != nullptr &&
+        result->type == VEF_RESULT_VALUE && !input_params_known &&
+        maybe_params.is_known() &&
         type_params_cache_for<P>().has_to_strings()) {
       std::map<std::string, std::string> m;
       type_params_cache_for<P>().to_strings(maybe_params.value(), m);
@@ -525,8 +526,8 @@ struct TypeEncodeWithCacheVdfWrapper {
       // its leading comma if not first) won't fit, stop writing but keep
       // iterating to accumulate `needed` for the snprintf-style overflow
       // signal. Caller retries with a larger buffer.
-      char *const buf_begin = args->out_type_params->buf;
-      const size_t cap = args->out_type_params->max_buf_len;
+      char *const buf_begin = result->out_type_params->buf;
+      const size_t cap = result->out_type_params->max_buf_len;
       char *p = buf_begin;
       size_t needed = 0;
       bool ok = true;
@@ -546,8 +547,8 @@ struct TypeEncodeWithCacheVdfWrapper {
         needed += pair_size;
         first = false;
       }
-      args->out_type_params->actual_len = needed;
-      args->out_type_params->overflow = !ok;
+      result->out_type_params->actual_len = needed;
+      result->out_type_params->overflow = !ok;
     }
   }
 };

--- a/villagesql/sdk/include/villagesql/vsql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_builder.h
@@ -499,12 +499,56 @@ struct TypeEncodeWithCacheVdfWrapper {
     // wrapper construction below will then leave MaybeParams<P> in the unknown
     // state.
     MaybeParams<P> maybe_params;
-    if (result->type_params.count > 0) {
+    const bool input_params_known = result->type_params.count > 0;
+    if (input_params_known) {
       maybe_params =
           MaybeParams<P>(type_params_cache_for<P>().get(result->type_params));
     }
     set_default_encode_failure(result, arg);
     Func(maybe_params, {arg.str_value, arg.str_len}, CustomResult(result));
+
+    // Inference-path write-back: when the server invoked us with no input
+    // type_params (signalling "please infer"), the wrapper publishes the
+    // canonical "k=v,k=v" form of the resulting MaybeParams<P> back to the
+    // server via args->out_type_params. All four guards must hold:
+    //   1. server opted in by setting args->out_type_params
+    //   2. encode succeeded (no warning/error)
+    //   3. we were on the inference path (input type_params was empty)
+    //   4. the extension actually inferred params and registered to_strings
+    if (args->out_type_params != nullptr && result->type == VEF_RESULT_VALUE &&
+        !input_params_known && maybe_params.is_known() &&
+        type_params_cache_for<P>().has_to_strings()) {
+      std::map<std::string, std::string> m;
+      type_params_cache_for<P>().to_strings(maybe_params.value(), m);
+
+      // Single-pass greedy write into the caller's buffer. If a pair (with
+      // its leading comma if not first) won't fit, stop writing but keep
+      // iterating to accumulate `needed` for the snprintf-style overflow
+      // signal. Caller retries with a larger buffer.
+      char *const buf_begin = args->out_type_params->buf;
+      const size_t cap = args->out_type_params->max_buf_len;
+      char *p = buf_begin;
+      size_t needed = 0;
+      bool ok = true;
+      bool first = true;
+      for (const auto &[k, v] : m) {
+        const size_t pair_size = (first ? 0u : 1u) + k.size() + 1u + v.size();
+        if (ok && static_cast<size_t>(p - buf_begin) + pair_size <= cap) {
+          if (!first) *p++ = ',';
+          std::memcpy(p, k.data(), k.size());
+          p += k.size();
+          *p++ = '=';
+          std::memcpy(p, v.data(), v.size());
+          p += v.size();
+        } else {
+          ok = false;
+        }
+        needed += pair_size;
+        first = false;
+      }
+      args->out_type_params->actual_len = needed;
+      args->out_type_params->overflow = !ok;
+    }
   }
 };
 


### PR DESCRIPTION
When params are unknown, prepare the return of them to the server side, checking for a large enough buffer size.

This is not fully plumbed as the server side needs to change as well.

#449

