### PR TITLE
UNINSTALL EXTENSION foo VERSION

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_uninstall_version.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_uninstall_version.result
@@ -1,0 +1,24 @@
+# Install vsql_simple
+INSTALL EXTENSION vsql_simple;
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+EXTENSION_NAME	EXTENSION_VERSION
+vsql_simple	0.0.1
+# UNINSTALL with wrong VERSION must fail and leave the extension in place
+UNINSTALL EXTENSION vsql_simple VERSION '9.9.9';
+ERROR HY000: Cannot uninstall extension 'vsql_simple': installed version is '0.0.1' but VERSION '9.9.9' was specified
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+EXTENSION_NAME	EXTENSION_VERSION
+vsql_simple	0.0.1
+# UNINSTALL with matching VERSION succeeds
+UNINSTALL EXTENSION vsql_simple VERSION '0.0.1';
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+EXTENSION_NAME	EXTENSION_VERSION
+# UNINSTALL with VERSION when not installed fails as before
+UNINSTALL EXTENSION vsql_simple VERSION '0.0.1';
+ERROR HY000: Extension 'vsql_simple' is not installed
+# Reinstall, then UNINSTALL without VERSION still works (backward compat)
+INSTALL EXTENSION vsql_simple;
+UNINSTALL EXTENSION vsql_simple;
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+EXTENSION_NAME	EXTENSION_VERSION
+include/rpl/deprecated/show_binlog_events.inc

--- a/mysql-test/suite/villagesql/extension/t/extension_uninstall_version.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_uninstall_version.test
@@ -1,0 +1,29 @@
+# Test UNINSTALL EXTENSION ... VERSION 'x.y.z' version-match clause.
+# When VERSION is specified, uninstall must match the installed version or
+# fail. When omitted, uninstall behaves as before.
+
+--source include/villagesql/binlog_check_begin.inc
+
+--echo # Install vsql_simple
+INSTALL EXTENSION vsql_simple;
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+
+--echo # UNINSTALL with wrong VERSION must fail and leave the extension in place
+--error ER_VILLAGESQL_GENERIC_ERROR
+UNINSTALL EXTENSION vsql_simple VERSION '9.9.9';
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+
+--echo # UNINSTALL with matching VERSION succeeds
+UNINSTALL EXTENSION vsql_simple VERSION '0.0.1';
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+
+--echo # UNINSTALL with VERSION when not installed fails as before
+--error ER_VILLAGESQL_GENERIC_ERROR
+UNINSTALL EXTENSION vsql_simple VERSION '0.0.1';
+
+--echo # Reinstall, then UNINSTALL without VERSION still works (backward compat)
+INSTALL EXTENSION vsql_simple;
+UNINSTALL EXTENSION vsql_simple;
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+
+--source include/villagesql/binlog_check_end.inc

--- a/sql/lex.h
+++ b/sql/lex.h
@@ -783,6 +783,7 @@ static const SYMBOL symbols[] = {
     {SYM("VARCHARACTER", VARCHAR_SYM)},
     {SYM("VARIABLES", VARIABLES)},
     {SYM("VARYING", VARYING)},
+    {SYM("VERSION", VERSION_SYM)},
     {SYM("WAIT", WAIT_SYM)},
     {SYM("WARNINGS", WARNINGS)},
     {SYM("WEEK", WEEK_SYM)},

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -1460,6 +1460,8 @@ void warn_on_deprecated_user_defined_collation(
 // TODO(villagesql-rebase): Check if token number needs updating during MySQL rebase
 %token<lexer.keyword> EXTENSION_SYM              1215  /* VILLAGESQL */
 %token                DOUBLE_COLON               1216  /* VILLAGESQL OPERATOR */
+// TODO(villagesql-rebase): Check if token number needs updating during MySQL rebase
+%token<lexer.keyword> VERSION_SYM                1217  /* VILLAGESQL */
 
 /*
   NOTE! When adding new non-standard keywords, make sure they are added to the
@@ -1552,6 +1554,7 @@ void warn_on_deprecated_user_defined_collation(
         opt_channel
         opt_explain_for_schema
         opt_compression_algorithm
+        opt_extension_version
 
 %type <lex_str_list> TEXT_STRING_sys_list
 
@@ -10716,6 +10719,11 @@ function_call_keyword:
           {
             $$= NEW_PTN Item_func_user(@$);
           }
+        // TODO(villagesql-rebase): VERSION() as keyword-function, check placement during MySQL rebase
+        | VERSION_SYM '(' ')'
+          {
+            $$= NEW_PTN Item_func_version(@$);
+          }
         | YEAR_SYM '(' expr ')'
           {
             $$= NEW_PTN Item_func_year(@$, $3);
@@ -15825,6 +15833,7 @@ ident_keywords_unambiguous:
         | VALUE_SYM
         | VARIABLES
         | VCPU_SYM
+        | VERSION_SYM
         | VIEW_SYM
         | VISIBLE_SYM
         | WAIT_SYM
@@ -18295,11 +18304,12 @@ uninstall:
             lex->m_sql_cmd= new (YYMEM_ROOT) Sql_cmd_uninstall_plugin(to_lex_cstring($3));
           }
        // TODO(villagesql-rebase): UNINSTALL EXTENSION grammar rule, check placement during MySQL rebase
-       | UNINSTALL_SYM EXTENSION_SYM IDENT_sys
+       | UNINSTALL_SYM EXTENSION_SYM IDENT_sys opt_extension_version
           {
             LEX *lex= Lex;
             lex->sql_command= SQLCOM_UNINSTALL_EXTENSION;
-            lex->m_sql_cmd= new (YYMEM_ROOT) Sql_cmd_uninstall_extension(to_lex_cstring($3));
+            lex->m_sql_cmd= new (YYMEM_ROOT)
+                Sql_cmd_uninstall_extension(to_lex_cstring($3), $4);
           }
        | UNINSTALL_SYM COMPONENT_SYM TEXT_STRING_sys_list
           {
@@ -18307,6 +18317,12 @@ uninstall:
             lex->sql_command= SQLCOM_UNINSTALL_COMPONENT;
             lex->m_sql_cmd= new (YYMEM_ROOT) Sql_cmd_uninstall_component($3);
           }
+        ;
+
+// TODO(villagesql-rebase): UNINSTALL EXTENSION VERSION clause, check placement during MySQL rebase
+opt_extension_version:
+          %empty { $$ = {}; }
+        | VERSION_SYM TEXT_STRING_sys { $$ = to_lex_cstring($2); }
         ;
 
 TEXT_STRING_sys_list:

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -1460,7 +1460,6 @@ void warn_on_deprecated_user_defined_collation(
 // TODO(villagesql-rebase): Check if token number needs updating during MySQL rebase
 %token<lexer.keyword> EXTENSION_SYM              1215  /* VILLAGESQL */
 %token                DOUBLE_COLON               1216  /* VILLAGESQL OPERATOR */
-// TODO(villagesql-rebase): Check if token number needs updating during MySQL rebase
 %token<lexer.keyword> VERSION_SYM                1217  /* VILLAGESQL */
 
 /*
@@ -18319,7 +18318,6 @@ uninstall:
           }
         ;
 
-// TODO(villagesql-rebase): UNINSTALL EXTENSION VERSION clause, check placement during MySQL rebase
 opt_extension_version:
           %empty { $$ = {}; }
         | VERSION_SYM TEXT_STRING_sys { $$ = to_lex_cstring($2); }

--- a/villagesql/veb/sql_extension.cc
+++ b/villagesql/veb/sql_extension.cc
@@ -410,8 +410,8 @@ bool remove_extension_from_victionary(
     villagesql_error(
         "Cannot uninstall extension '%s': installed version is '%s' but "
         "VERSION '%s' was specified",
-        MYF(0), extension_name.c_str(),
-        ext_entry->extension_version.c_str(), expected_version.c_str());
+        MYF(0), extension_name.c_str(), ext_entry->extension_version.c_str(),
+        expected_version.c_str());
     return true;
   }
 

--- a/villagesql/veb/sql_extension.cc
+++ b/villagesql/veb/sql_extension.cc
@@ -386,8 +386,13 @@ bool check_for_sp_params_of_extension(
 
 // If the transaction commits, then `to_unregister` is used to unregister the
 // .so file.
+//
+// If `expected_version` is non-empty, the installed extension's version must
+// match exactly or uninstall is rejected. Callers pass an empty string when no
+// VERSION clause was specified, preserving pre-#345 behavior.
 bool remove_extension_from_victionary(
     THD *thd, VictionaryClient &victionary, const std::string &extension_name,
+    const std::string &expected_version,
     std::optional<veb::ExtensionRegistration> &to_unregister) {
   auto write_lock = victionary.get_write_lock();
 
@@ -397,6 +402,16 @@ bool remove_extension_from_victionary(
     villagesql_error("Extension '%s' is not installed", MYF(0),
                      extension_name.c_str());
 
+    return true;
+  }
+
+  if (!expected_version.empty() &&
+      ext_entry->extension_version != expected_version) {
+    villagesql_error(
+        "Cannot uninstall extension '%s': installed version is '%s' but "
+        "VERSION '%s' was specified",
+        MYF(0), extension_name.c_str(),
+        ext_entry->extension_version.c_str(), expected_version.c_str());
     return true;
   }
 
@@ -514,6 +529,8 @@ bool Sql_cmd_uninstall_extension::execute(THD *thd) {
     return true;
 
   std::string extension_name(m_name.str, m_name.length);
+  std::string expected_version =
+      m_version.str ? to_string(m_version) : std::string();
 
   // Acquire X MDL lock with statement duration on the normalized extension
   // name to synchronize with following operations. All such operations must
@@ -559,7 +576,7 @@ bool Sql_cmd_uninstall_extension::execute(THD *thd) {
   std::optional<villagesql::veb::ExtensionRegistration> to_unregister;
   // Phase 1: Do all lookups and mark operations while holding lock
   if (villagesql::remove_extension_from_victionary(
-          thd, victionary, extension_name, to_unregister)) {
+          thd, victionary, extension_name, expected_version, to_unregister)) {
     return end_transaction(thd, true);
   }
 

--- a/villagesql/veb/sql_extension.cc
+++ b/villagesql/veb/sql_extension.cc
@@ -389,7 +389,8 @@ bool check_for_sp_params_of_extension(
 //
 // If `expected_version` is non-empty, the installed extension's version must
 // match exactly or uninstall is rejected. Callers pass an empty string when no
-// VERSION clause was specified, preserving pre-#345 behavior.
+// VERSION clause was specified, falling back to whichever version is currently
+// installed.
 bool remove_extension_from_victionary(
     THD *thd, VictionaryClient &victionary, const std::string &extension_name,
     const std::string &expected_version,

--- a/villagesql/veb/sql_extension.h
+++ b/villagesql/veb/sql_extension.h
@@ -51,8 +51,13 @@ class Sql_cmd_install_extension : public Sql_cmd {
 // This class implements the UNINSTALL EXTENSION statement.
 class Sql_cmd_uninstall_extension : public Sql_cmd {
  public:
-  explicit Sql_cmd_uninstall_extension(const LEX_CSTRING &name)
-      : m_name(name) {}
+  // @param name     Extension name to uninstall.
+  // @param version  Expected installed version (m_version.str == nullptr if no
+  //                 VERSION clause was specified). When set, uninstall fails
+  //                 unless the installed version matches exactly.
+  Sql_cmd_uninstall_extension(const LEX_CSTRING &name,
+                              const LEX_CSTRING &version)
+      : m_name(name), m_version(version) {}
 
   enum_sql_command sql_command_code() const override {
     return SQLCOM_UNINSTALL_EXTENSION;
@@ -65,6 +70,7 @@ class Sql_cmd_uninstall_extension : public Sql_cmd {
 
  private:
   LEX_CSTRING m_name;
+  LEX_CSTRING m_version;
 };
 
 #endif  // VILLAGESQL_VEB_SQL_EXTENSION_H_


### PR DESCRIPTION
## Description

Lets callers assert the installed version on uninstall:

```sql
UNINSTALL EXTENSION foo VERSION '0.0.1';
```

Fails loudly if the installed version doesn't match; leaves the extension in place. Omitting the clause preserves prior behavior.

`VERSION_SYM` is added as an unreserved keyword. Since that would otherwise shadow the built-in `VERSION()` scalar (bootstrap SQL uses it), I added an explicit `VERSION_SYM '(' ')'` rule to `function_call_keyword` — same pattern MySQL uses for `DATABASE()`, `USER()`.

Symmetric `INSTALL EXTENSION ... VERSION` is filed as follow-up #501.

## Related Issue

Fixes #345

## How was this tested?

New test `extension_uninstall_version.test` covers wrong version (error), matching version (success), not-installed-with-VERSION (existing error), and naked uninstall (backward compat). All pass.

Ran the broader villagesql suite — only `vsql-keyring.keyring_no_component` fails, and it reproduces on `main` unchanged, so it's a pre-existing flake.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4