### PR TITLE
Move AreTypesCompatible into TypeContext

### DIFF
--- a/unittest/gunit/villagesql/type_context-t.cc
+++ b/unittest/gunit/villagesql/type_context-t.cc
@@ -290,4 +290,58 @@ TEST_F(TypeContextTest, EmptyParamsSkipsResolveCallback) {
   EXPECT_EQ(ctx.max_decode_buffer_length(), 0);
 }
 
+TEST_F(TypeContextTest, SameKeysAreCompatible) {
+  villagesql::TypeDescriptor desc(
+      villagesql::TypeDescriptorKey("COMPLEX", "test_ext", "1.0.0"),
+      VEF_PROTOCOL_1, 1, 16, 256, villagesql::EncodeFunction(dummy_encode),
+      villagesql::DecodeFunction(dummy_decode),
+      villagesql::CompareFunction(dummy_compare));
+  villagesql::TypeContextKey key("COMPLEX", "test_ext", "1.0.0");
+  villagesql::TypeContext a = make_context(key, &desc);
+  villagesql::TypeContext b = make_context(key, &desc);
+  EXPECT_TRUE(a.is_compatible_with(b));
+  EXPECT_TRUE(b.is_compatible_with(a));
+}
+
+TEST_F(TypeContextTest, DifferentTypeNamesAreNotCompatible) {
+  villagesql::TypeDescriptor desc_a(
+      villagesql::TypeDescriptorKey("COMPLEX", "test_ext", "1.0.0"),
+      VEF_PROTOCOL_1, 1, 16, 256, villagesql::EncodeFunction(dummy_encode),
+      villagesql::DecodeFunction(dummy_decode),
+      villagesql::CompareFunction(dummy_compare));
+  villagesql::TypeDescriptor desc_b(
+      villagesql::TypeDescriptorKey("OTHER", "test_ext", "1.0.0"),
+      VEF_PROTOCOL_1, 1, 16, 256, villagesql::EncodeFunction(dummy_encode),
+      villagesql::DecodeFunction(dummy_decode),
+      villagesql::CompareFunction(dummy_compare));
+  villagesql::TypeContext a = make_context(
+      villagesql::TypeContextKey("COMPLEX", "test_ext", "1.0.0"), &desc_a);
+  villagesql::TypeContext b = make_context(
+      villagesql::TypeContextKey("OTHER", "test_ext", "1.0.0"), &desc_b);
+  EXPECT_FALSE(a.is_compatible_with(b));
+  EXPECT_FALSE(b.is_compatible_with(a));
+}
+
+TEST_F(TypeContextTest, DifferentParametersAreNotCompatible) {
+  static auto rp_ok_fd =
+      make_resolve_params_fd("rp_ok_compat", &resolve_params_ok_vdf);
+
+  villagesql::TypeDescriptor desc(
+      villagesql::TypeDescriptorKey("VVECTOR", "test_ext", "1.0.0"),
+      VEF_PROTOCOL_2, 1, -1, 0, villagesql::EncodeFunction(dummy_encode),
+      villagesql::DecodeFunction(dummy_decode),
+      villagesql::CompareFunction(dummy_compare), std::nullopt, std::nullopt,
+      villagesql::ResolveParamsFunction(&rp_ok_fd));
+  villagesql::TypeContextKey key_3(
+      villagesql::TypeDescriptorKey("VVECTOR", "test_ext", "1.0.0"),
+      villagesql::TypeParameters("dimension=3"));
+  villagesql::TypeContextKey key_4(
+      villagesql::TypeDescriptorKey("VVECTOR", "test_ext", "1.0.0"),
+      villagesql::TypeParameters("dimension=4"));
+  villagesql::TypeContext v3 = make_context(key_3, &desc);
+  villagesql::TypeContext v4 = make_context(key_4, &desc);
+  EXPECT_FALSE(v3.is_compatible_with(v4));
+  EXPECT_FALSE(v4.is_compatible_with(v3));
+}
+
 }  // namespace villagesql_unittest

--- a/villagesql/schema/descriptor/type_context.h
+++ b/villagesql/schema/descriptor/type_context.h
@@ -241,6 +241,12 @@ class TypeContext {
     return descriptor_->is_parameterized() && parameters().empty();
   }
 
+  // Types are compatible if they have the same key (type name, extension,
+  // version, and parameters). This ensures e.g. TVECTOR(3) != TVECTOR(4).
+  bool is_compatible_with(const TypeContext &other) const {
+    return key() == other.key();
+  }
+
   // Convenience accessors for frequently used fields
   const std::string &extension_name() const {
     return descriptor_->extension_name();

--- a/villagesql/sql/metadata_modifier.cc
+++ b/villagesql/sql/metadata_modifier.cc
@@ -342,8 +342,8 @@ bool Metadata_modifier::alter_columns(THD *thd [[maybe_unused]],
         // Custom → custom: types must be compatible.
         Field *old_field = find_field_in_table_sef(table, field.change);
         assert(old_field);
-        if (!AreTypesCompatible(*old_field->get_type_context(),
-                                *field.custom_type_context)) {
+        if (!old_field->get_type_context()->is_compatible_with(
+                *field.custom_type_context)) {
           villagesql_error(
               "Cannot convert between incompatible custom types '%s' and '%s'",
               MYF(0), old_field->get_type_context()->qualified_name().c_str(),

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -499,7 +499,7 @@ bool InjectAndEncodeCustomType(Item *item, const TypeContext &tc) {
   if (item->has_type_context()) {
     // We already got one, you see?
     // Make sure they are compatible!
-    return !AreTypesCompatible(*item->get_type_context(), tc);
+    return !item->get_type_context()->is_compatible_with(tc);
   }
 
   // Set the type context
@@ -557,12 +557,6 @@ std::optional<size_t> TryComputeHash(const TypeContext &tc, const uchar *data,
   return hash_op->invoke(data, len);
 }
 
-bool AreTypesCompatible(const TypeContext &tc1, const TypeContext &tc2) {
-  // Types are compatible if they have the same key (type name, extension,
-  // version, and parameters). This ensures e.g. TVECTOR(3) != TVECTOR(4).
-  return tc1.key() == tc2.key();
-}
-
 bool MaybeValidateUnionTypeCompatibility(Item *accumulator, Item *item) {
   const TypeContext *accumulator_tc = accumulator->get_type_context();
   const TypeContext *item_tc = item->get_type_context();
@@ -587,7 +581,7 @@ bool MaybeValidateUnionTypeCompatibility(Item *accumulator, Item *item) {
                      MYF(0));
     return true;
   } else if (accumulator_tc != nullptr && item_tc != nullptr &&
-             !AreTypesCompatible(*accumulator_tc, *item_tc)) {
+             !accumulator_tc->is_compatible_with(*item_tc)) {
     // Both have custom types but they're incompatible
     villagesql_error(
         "Cannot use UNION with different custom types '%s' and '%s'", MYF(0),
@@ -612,7 +606,7 @@ bool MaybeValidateAndCastCustomTypeComparison(Item &left, Item &right,
 
   // Case 1: Both sides have custom types
   if (lhs_tc != nullptr && rhs_tc != nullptr) {
-    if (!AreTypesCompatible(*lhs_tc, *rhs_tc)) {
+    if (!lhs_tc->is_compatible_with(*rhs_tc)) {
       villagesql_error("Cannot compare types %s and %s in %s", MYF(0),
                        lhs_tc->qualified_name().c_str(),
                        rhs_tc->qualified_name().c_str(), operation_name);
@@ -664,7 +658,7 @@ const TypeContext *GetCompatibleCustomType(const Item &item1,
   auto *tc1 = item1.get_type_context();
   auto *tc2 = item2.get_type_context();
 
-  if (AreTypesCompatible(*tc1, *tc2)) {
+  if (tc1->is_compatible_with(*tc2)) {
     return tc1;  // Compatible - return either one
   }
 
@@ -676,8 +670,8 @@ bool CanStoreInCustomField(const Item *item, const Field *field) {
 
   // If item also has custom type context, check compatibility
   if (item->has_type_context()) {
-    return AreTypesCompatible(*item->get_type_context(),
-                              *field->get_type_context());
+    return item->get_type_context()->is_compatible_with(
+        *field->get_type_context());
   }
 
   // For non-custom items storing into custom fields:
@@ -850,7 +844,7 @@ bool TryCopyCustomTypeField(const Field *from, Field *to) {
   // If target doesn't have a custom type, or custom types do not match,
   // this is an incompatible conversion.
   if (!to->has_type_context() ||
-      !AreTypesCompatible(*from->get_type_context(), *to->get_type_context())) {
+      !from->get_type_context()->is_compatible_with(*to->get_type_context())) {
     StringBuffer<MAX_FIELD_WIDTH> result(from->charset());
     result.length(0U);
     from->val_external_str(&result);
@@ -1001,7 +995,7 @@ static bool AllArgsCompatible(Item_func *func) {
   for (uint i = 1; any_tc && i < func->arg_count; i++) {
     auto *tc = func->get_arg(i)->get_type_context();
     if (!tc) continue;  // not yet custom-typed, skip
-    if (!AreTypesCompatible(*any_tc, *tc)) {
+    if (!any_tc->is_compatible_with(*tc)) {
       villagesql_error("Cannot compare types %s and %s in %s", MYF(0),
                        any_tc->qualified_name().c_str(),
                        tc->qualified_name().c_str(), func->func_name());
@@ -1058,7 +1052,7 @@ static bool CaseArgsCompatible(Item_func *func) {
       villagesql_error(ER_INCOMPARABLE_TYPES, MYF(0), func->func_name());
       return false;
     }
-    if (!AreTypesCompatible(*tc0, *tc1)) {
+    if (!tc0->is_compatible_with(*tc1)) {
       villagesql_error(ER_INCOMPATIBLE_TYPES, MYF(0), tc0->type_name().c_str(),
                        tc1->type_name().c_str());
       return false;

--- a/villagesql/types/util.h
+++ b/villagesql/types/util.h
@@ -246,11 +246,6 @@ int CustomMemCompare(const Item *item, const uchar *data1, size_t len1,
                      const uchar *data2, size_t len2, size_t min_len,
                      bool reverse);
 
-// Check if two TypeContexts represent compatible types for comparison
-// operations Types are compatible if they have the same type name, extension
-// name, and version Returns true if compatible, false if incompatible
-bool AreTypesCompatible(const TypeContext &tc1, const TypeContext &tc2);
-
 // Validate custom type compatibility for UNION operations.
 // Checks if the accumulator (Item_aggregate_type) and incoming item have
 // compatible custom types. Propagates type context to the accumulator as


### PR DESCRIPTION
## Summary

Promote `villagesql::AreTypesCompatible(tc1, tc2)` — which reduces to a single `key()` comparison — to a const member of `TypeContext`:

```cpp
bool TypeContext::is_compatible_with(const TypeContext &other) const {
  return key() == other.key();
}
```

The free function is gone; all 9 call sites updated.

## Context

Splitting this out of #438 per [review feedback](https://github.com/villagesql/villagesql-server/pull/438#discussion_r2547216050). With the predicate as a `TypeContext` member, #438's debug-only asserts in `Field::set_type_context()` / `Item::set_type_context()` can call `custom_type->is_compatible_with(*tc)` directly. The current shape forced a forward declaration of `AreTypesCompatible` in `sql/field.h` because `util.h` (which had the free function) already includes `sql/field.h` — a cycle.

## Changes

- `villagesql/schema/descriptor/type_context.h`: add `is_compatible_with`
- `villagesql/types/util.{h,cc}`: remove free function decl + definition
- `villagesql/types/util.cc`: 8 call sites updated
- `villagesql/sql/metadata_modifier.cc`: 1 call site updated
- `unittest/gunit/villagesql/type_context-t.cc`: 3 new tests (same key, different type name, different parameters)

No behavior change — same predicate, same semantics.

## Test plan

- [x] Debug build (`cmake -DWITH_DEBUG=1`) compiles clean
- [x] `ctest -L villagesql` — 8/8 pass, including the 3 new `IsCompatibleWith*` cases
- [x] CI village MTR + Validate PR