### PR TITLE
TypeContext::is_compatible_with unknown

### DIFF
--- a/unittest/gunit/villagesql/type_context-t.cc
+++ b/unittest/gunit/villagesql/type_context-t.cc
@@ -349,4 +349,55 @@ TEST_F(TypeContextTest, DifferentParametersAreNotCompatible) {
   EXPECT_FALSE(v4.is_compatible_with(v3));
 }
 
+TEST_F(TypeContextTest, UnknownIsCompatibleWithKnownOfSameType) {
+  static auto rp_ok_fd =
+      make_resolve_params_fd("rp_ok_refine", &resolve_params_ok_vdf);
+
+  villagesql::TypeDescriptor desc(
+      villagesql::TypeDescriptorKey("VVECTOR", "test_ext", "1.0.0"),
+      VEF_PROTOCOL_2, 1, -1, 0, /*max_persisted_length=*/0,
+      villagesql::EncodeFunction(dummy_encode),
+      villagesql::DecodeFunction(dummy_decode),
+      villagesql::CompareFunction(dummy_compare), std::nullopt, std::nullopt,
+      villagesql::ResolveParamsFunction(&rp_ok_fd));
+  villagesql::TypeContextKey unknown_key("VVECTOR", "test_ext", "1.0.0");
+  villagesql::TypeContextKey known_key(
+      villagesql::TypeDescriptorKey("VVECTOR", "test_ext", "1.0.0"),
+      villagesql::TypeParameters("dimension=3"));
+  villagesql::TypeContext unknown = make_context(unknown_key, &desc);
+  villagesql::TypeContext known = make_context(known_key, &desc);
+  ASSERT_TRUE(unknown.is_unknown());
+  ASSERT_FALSE(known.is_unknown());
+  EXPECT_TRUE(unknown.is_compatible_with(known));
+  EXPECT_TRUE(known.is_compatible_with(unknown));
+}
+
+TEST_F(TypeContextTest, UnknownIsNotCompatibleWithDifferentType) {
+  static auto rp_ok_fd =
+      make_resolve_params_fd("rp_ok_diff_desc", &resolve_params_ok_vdf);
+
+  villagesql::TypeDescriptor vvector_desc(
+      villagesql::TypeDescriptorKey("VVECTOR", "test_ext", "1.0.0"),
+      VEF_PROTOCOL_2, 1, -1, 0, /*max_persisted_length=*/0,
+      villagesql::EncodeFunction(dummy_encode),
+      villagesql::DecodeFunction(dummy_decode),
+      villagesql::CompareFunction(dummy_compare), std::nullopt, std::nullopt,
+      villagesql::ResolveParamsFunction(&rp_ok_fd));
+  villagesql::TypeDescriptor complex_desc(
+      villagesql::TypeDescriptorKey("COMPLEX", "test_ext", "1.0.0"),
+      VEF_PROTOCOL_1, 1, 16, 256, /*max_persisted_length=*/0,
+      villagesql::EncodeFunction(dummy_encode),
+      villagesql::DecodeFunction(dummy_decode),
+      villagesql::CompareFunction(dummy_compare));
+  villagesql::TypeContext unknown_vvector =
+      make_context(villagesql::TypeContextKey("VVECTOR", "test_ext", "1.0.0"),
+                   &vvector_desc);
+  villagesql::TypeContext complex =
+      make_context(villagesql::TypeContextKey("COMPLEX", "test_ext", "1.0.0"),
+                   &complex_desc);
+  ASSERT_TRUE(unknown_vvector.is_unknown());
+  EXPECT_FALSE(unknown_vvector.is_compatible_with(complex));
+  EXPECT_FALSE(complex.is_compatible_with(unknown_vvector));
+}
+
 }  // namespace villagesql_unittest

--- a/villagesql/schema/descriptor/type_context.h
+++ b/villagesql/schema/descriptor/type_context.h
@@ -241,10 +241,17 @@ class TypeContext {
     return descriptor_->is_parameterized() && parameters().empty();
   }
 
-  // Types are compatible if they have the same key (type name, extension,
-  // version, and parameters). This ensures e.g. TVECTOR(3) != TVECTOR(4).
+  // Types are compatible when they share a descriptor (type name, extension,
+  // version) and either side may be a not-yet-resolved (unknown-params)
+  // variant, or the parameters match. So TVECTOR(3) and TVECTOR(4) are NOT
+  // compatible; TVECTOR with empty params and TVECTOR(3) ARE compatible (the
+  // unknown can refine to the known — e.g. when an inner VDF returns an
+  // unknown TC that the caller then resolves from a sibling argument's
+  // parameters).
   bool is_compatible_with(const TypeContext &other) const {
-    return key() == other.key();
+    if (!(key().descriptor_key() == other.key().descriptor_key())) return false;
+    return is_unknown() || other.is_unknown() ||
+           parameters() == other.parameters();
   }
 
   // Convenience accessors for frequently used fields


### PR DESCRIPTION
## Description

Widen `TypeContext::is_compatible_with`: same descriptor still required, but an unknown-params (parameterized-but-unresolved) variant on either side is now treated as compatible with the resolved form. Two known TCs still need matching parameters.

The strict key-equality predicate from #503 (used by #438's debug assert) was too tight for the resolve path at `villagesql/types/util.cc:1345`, where an Item's TC starts with empty params and gets re-set with the resolved key — same descriptor, different keys, assert fired.

| Existing | New | Result |
|---|---|---|
| `TVECTOR(3)` | `TVECTOR(3)` | ✓ |
| `TVECTOR(3)` | `TVECTOR(4)` | ✗ params disagree |
| `TVECTOR` (empty) | `TVECTOR(3)` | ✓ unknown refines |
| `TVECTOR` | `COMPLEX` | ✗ different descriptor |

## Related Issue

Follow-up to #438 / #503. Unblocks #439, whose tests exercise the resolve path that would otherwise trip the assert in debug builds.

## How was this tested?

- Debug build (`cmake -DWITH_DEBUG=1`) clean
- `ctest -L villagesql` — 8/8 pass
- `type_context-t --gtest_filter='*Compatible*'` — 5/5 pass (3 existing + 2 new: `UnknownIsCompatibleWithKnownOfSameType`, `UnknownIsNotCompatibleWithDifferentType`)

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4