### PR TITLE
deny UNINSTALL EXTENSION if indexes exist

### DIFF
--- a/unittest/gunit/villagesql/CMakeLists.txt
+++ b/unittest/gunit/villagesql/CMakeLists.txt
@@ -20,6 +20,7 @@ SET(VILLAGESQL_UNIT_TESTS
   abi_v1_check-t
   abi_v2_check-t
   custom_indexes-t
+  extension_uninstall_checks-t
   semver-t
   type_context-t
   type_descriptor-t
@@ -63,6 +64,7 @@ ENDMACRO()
 ADD_VILLAGESQL_TEST(abi_v1_check-t)
 ADD_VILLAGESQL_TEST(abi_v2_check-t)
 ADD_VILLAGESQL_TEST(custom_indexes-t)
+ADD_VILLAGESQL_TEST(extension_uninstall_checks-t)
 ADD_VILLAGESQL_TEST(semver-t)
 ADD_VILLAGESQL_TEST(type_context-t)
 ADD_VILLAGESQL_TEST(type_descriptor-t)

--- a/unittest/gunit/villagesql/extension_uninstall_checks-t.cc
+++ b/unittest/gunit/villagesql/extension_uninstall_checks-t.cc
@@ -1,0 +1,84 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+// TODO(villagesql-indexing): When CREATE INDEX ... USING EXTENDED is wired
+// end-to-end through VEF, add a functional mysql-test
+// (custom_index_prevents_extension_uninstall.test) that exercises this
+// gating through the SQL surface. Until then, the unit tests below pin the
+// predicate directly.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "unittest/gunit/test_utils.h"
+#include "villagesql/schema/systable/custom_indexes.h"
+#include "villagesql/schema/systable/extensions.h"
+#include "villagesql/schema/systable/helpers.h"
+#include "villagesql/veb/extension_uninstall_checks.h"
+
+namespace villagesql_unittest {
+
+using namespace villagesql;
+
+class ExtensionUninstallChecksTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    villagesql::test_set_lower_case_table_names(0);
+    system_charset_info = &my_charset_utf8mb4_0900_ai_ci;
+  }
+};
+
+TEST_F(ExtensionUninstallChecksTest, CustomIndexPreventsExtensionUninstall) {
+  ExtensionEntry ext(ExtensionKey("vsql_test"), "1.0.0", /*hash=*/{});
+
+  IndexEntry idx(IndexKey("mydb", "t", "idx"), /*id=*/1, "vsql_test", "1.0.0",
+                 "test_idx");
+  std::vector<const IndexEntry *> all_indexes = {&idx};
+
+  EXPECT_TRUE(check_for_indexes_of_extension(ext, all_indexes));
+}
+
+TEST_F(ExtensionUninstallChecksTest,
+       OtherExtensionsIndexDoesNotPreventUninstall) {
+  ExtensionEntry ext(ExtensionKey("vsql_test"), "1.0.0", /*hash=*/{});
+
+  IndexEntry idx(IndexKey("mydb", "t", "idx"), /*id=*/1, "other_ext", "1.0.0",
+                 "test_idx");
+  std::vector<const IndexEntry *> all_indexes = {&idx};
+
+  EXPECT_FALSE(check_for_indexes_of_extension(ext, all_indexes));
+}
+
+TEST_F(ExtensionUninstallChecksTest, VersionMismatchDoesNotPreventUninstall) {
+  ExtensionEntry ext(ExtensionKey("vsql_test"), "2.0.0", /*hash=*/{});
+
+  IndexEntry idx(IndexKey("mydb", "t", "idx"), /*id=*/1, "vsql_test", "1.0.0",
+                 "test_idx");
+  std::vector<const IndexEntry *> all_indexes = {&idx};
+
+  EXPECT_FALSE(check_for_indexes_of_extension(ext, all_indexes));
+}
+
+TEST_F(ExtensionUninstallChecksTest, NoIndexesIsAllowed) {
+  ExtensionEntry ext(ExtensionKey("vsql_test"), "1.0.0", /*hash=*/{});
+  std::vector<const IndexEntry *> all_indexes = {};
+
+  EXPECT_FALSE(check_for_indexes_of_extension(ext, all_indexes));
+}
+
+}  // namespace villagesql_unittest

--- a/villagesql/veb/CMakeLists.txt
+++ b/villagesql/veb/CMakeLists.txt
@@ -14,6 +14,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 SET(VILLAGESQL_VEB_SOURCES
+  extension_uninstall_checks.cc
   register.cc
   sql_extension.cc
   validate.cc

--- a/villagesql/veb/extension_uninstall_checks.cc
+++ b/villagesql/veb/extension_uninstall_checks.cc
@@ -16,13 +16,36 @@
 
 #include "villagesql/veb/extension_uninstall_checks.h"
 
+#include "my_sys.h"
+
+#include "villagesql/include/error.h"
+
 namespace villagesql {
 
 bool check_for_indexes_of_extension(
-    const ExtensionEntry & /*ext_entry*/,
-    const std::vector<const IndexEntry *> & /*all_indexes*/) {
-  // Task 1 stub: returns false unconditionally so the failing unit test
-  // pins the predicate. Replaced with real enumeration in Task 2.
+    const ExtensionEntry &ext_entry,
+    const std::vector<const IndexEntry *> &all_indexes) {
+  const IndexEntry *first = nullptr;
+  int count = 0;
+
+  for (const auto *entry : all_indexes) {
+    if (entry->extension_name == ext_entry.extension_name() &&
+        entry->extension_version == ext_entry.extension_version) {
+      if (count == 0) first = entry;
+      count++;
+    }
+  }
+
+  if (first != nullptr) {
+    villagesql_error(
+        "Cannot drop extension `%s` as %d custom index(es) depend on it, "
+        "e.g. %s.%s.%s uses index type %s",
+        MYF(0), ext_entry.extension_name().c_str(), count,
+        first->db_name().c_str(), first->table_name().c_str(),
+        first->index_name().c_str(), first->index_type_name.c_str());
+    return true;
+  }
+
   return false;
 }
 

--- a/villagesql/veb/extension_uninstall_checks.cc
+++ b/villagesql/veb/extension_uninstall_checks.cc
@@ -1,0 +1,29 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "villagesql/veb/extension_uninstall_checks.h"
+
+namespace villagesql {
+
+bool check_for_indexes_of_extension(
+    const ExtensionEntry & /*ext_entry*/,
+    const std::vector<const IndexEntry *> & /*all_indexes*/) {
+  // Task 1 stub: returns false unconditionally so the failing unit test
+  // pins the predicate. Replaced with real enumeration in Task 2.
+  return false;
+}
+
+}  // namespace villagesql

--- a/villagesql/veb/extension_uninstall_checks.h
+++ b/villagesql/veb/extension_uninstall_checks.h
@@ -1,0 +1,37 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef VILLAGESQL_VEB_EXTENSION_UNINSTALL_CHECKS_H_
+#define VILLAGESQL_VEB_EXTENSION_UNINSTALL_CHECKS_H_
+
+#include <vector>
+
+#include "villagesql/schema/systable/custom_indexes.h"
+#include "villagesql/schema/systable/extensions.h"
+
+namespace villagesql {
+
+// Returns true and emits villagesql_error if any IndexEntry in
+// `all_indexes` belongs to `ext_entry` (matched on extension_name +
+// extension_version). RESTRICT semantics: the caller aborts uninstall when
+// this returns true. No system-table mutations occur.
+bool check_for_indexes_of_extension(
+    const ExtensionEntry &ext_entry,
+    const std::vector<const IndexEntry *> &all_indexes);
+
+}  // namespace villagesql
+
+#endif  // VILLAGESQL_VEB_EXTENSION_UNINSTALL_CHECKS_H_

--- a/villagesql/veb/sql_extension.cc
+++ b/villagesql/veb/sql_extension.cc
@@ -54,6 +54,7 @@
 #include "villagesql/services/status_vars.h"
 #include "villagesql/services/sys_vars.h"
 #include "villagesql/sql/metadata_modifier.h"
+#include "villagesql/veb/extension_uninstall_checks.h"
 #include "villagesql/veb/register.h"
 #include "villagesql/veb/validate.h"
 #include "villagesql/veb/veb_file.h"
@@ -409,6 +410,11 @@ bool remove_extension_from_victionary(
 
   const auto &all_sp_params = victionary.sp_params().get_all_committed();
   if (check_for_sp_params_of_extension(*ext_entry, all_sp_params)) {
+    return true;
+  }
+
+  const auto &all_indexes = victionary.custom_indexes().get_all_committed();
+  if (villagesql::check_for_indexes_of_extension(*ext_entry, all_indexes)) {
     return true;
   }
 


### PR DESCRIPTION
## Description

Adds a RESTRICT-only check in `remove_extension_from_victionary` that blocks `UNINSTALL EXTENSION` when any rows for that extension remain in `villagesql.custom_indexes`. Mirrors the existing `check_for_columns_of_extension` and `check_for_sp_params_of_extension` pattern — same shape, same RESTRICT semantics (no auto-cascade, no `MarkForDeletion` of system-table rows at uninstall).

The gap surfaced while auditing #392. The functional-index-on-custom-column case (what #392 literally asks about) is already blocked today via the column check; what wasn't enumerated was `custom_indexes` itself.

A note on reachability: this gap isn't reachable through SQL today — `CREATE INDEX ... USING EXTENDED(...)` parses but fails before writing any row (see the `--error ER_VILLAGESQL_GENERIC_ERROR` in `mysql-test/suite/villagesql/index/t/create_index.test`). This check exists defensively so it's in place before the CREATE INDEX wiring lands.

## Related Issue

Part of #392. See the audit comment on the issue for the full per-object analysis and the other follow-ups.

## How was this tested?

Four new gtest cases in `unittest/gunit/villagesql/extension_uninstall_checks-t.cc`:
- `CustomIndexPreventsExtensionUninstall` — the positive case
- `OtherExtensionsIndexDoesNotPreventUninstall` — name discriminator
- `VersionMismatchDoesNotPreventUninstall` — version discriminator
- `NoIndexesIsAllowed` — empty-list happy path

TDD shape: the first commit ships a stub returning ` false` so `CustomIndexPreventsExtensionUninstall` fails (proves the predicate is wired through). The second commit replaces the stub with the real enumeration loop and adds the call site in `sql_extension.cc`; all four tests then pass.

Full village suite green:
```
./mysql-test/mysql-test-run.pl --do-suite=village --nounit-tests --parallel=auto
# 563 tests pass, 8 skipped, no failures
```

A functional mysql-test (`custom_index_prevents_extension_uninstall.test`) will be added when `CREATE INDEX ... USING EXTENDED` is end-to-end through VEF. Until then the unit tests pin the predicate — there's a `TODO(villagesql-indexing)` at the top of the test file noting this.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4