### PR TITLE
Use bundled_extensions.txt

### DIFF
--- a/scripts/include_bundled_extensions.sh
+++ b/scripts/include_bundled_extensions.sh
@@ -39,6 +39,16 @@ while IFS= read -r line; do
     BRANCH="${FIELDS[1]:-}"
     REPO_NAME="${SOURCE##*/}"
 
+    # Confirm the extension is bundled
+    BUNDLE=true
+    for FIELD in "${FIELDS[@]:2}"; do
+        [[ "$FIELD" == "bundle=false" || "$FIELD" == "bundle=no" ]] && BUNDLE=false
+    done
+    if [[ "$BUNDLE" == "false" ]]; then
+        log_info "Skipping $REPO_NAME (bundle=false)"
+        continue
+    fi
+
     # Convert all dashes to underscores
     EXT_FILE="${REPO_NAME//-/_}.veb"
     EXT_SRC_VEB="$VEB_SRC_DIR/$EXT_FILE"

--- a/scripts/include_bundled_extensions.sh
+++ b/scripts/include_bundled_extensions.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Copyright (c) 2026 VillageSQL Contributors
+# Build VEB files for bundled VillageSQL extensions.
+#
+# Usage: include_bundled_extensions.sh <dst_dir> <veb_src_dir>
+#
+# <veb_src_dir>: Directory where built .veb files were placed.
+#
+# The extension list is read from villagesql/dev_server/bundled_extensions.txt,
+# located relative to this script's source tree.
+
+set -euo pipefail
+DST_DIR="${1:?Usage: $0 <dst_dir> <veb_src_dir>}"
+VEB_SRC_DIR="${2:?Usage: $0 <dst_dir> <veb_src_dir>}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/vsql_script_utils.sh"
+EXTENSIONS_LIST="$SOURCE_DIR/villagesql/dev_server/bundled_extensions.txt"
+
+if [[ ! -f "$EXTENSIONS_LIST" ]]; then
+    log_error "Extensions list not found: $EXTENSIONS_LIST"
+    exit 1
+fi
+
+if [[ ! -d "$VEB_SRC_DIR" ]]; then
+    log_error "Missing extension source directory: $VEB_SRC_DIR"
+    exit 1
+fi
+
+# Read and parse the list of extensions
+while IFS= read -r line; do
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line// }" ]] && continue
+
+    # Parse "url [branch-or-tag] [key=value ...]" — all fields after url are optional
+    read -ra FIELDS <<< "$line"
+    SOURCE="${FIELDS[0]%/}"
+    BRANCH="${FIELDS[1]:-}"
+    REPO_NAME="${SOURCE##*/}"
+
+    # Convert all dashes to underscores
+    EXT_FILE="${REPO_NAME//-/_}.veb"
+    EXT_SRC_VEB="$VEB_SRC_DIR/$EXT_FILE"
+    if [[ ! -f "$EXT_SRC_VEB" ]]; then
+        log_error "Expected extension $REPO_NAME not found at $EXT_SRC_VEB"
+        exit 1
+    fi
+
+    cp "$EXT_SRC_VEB" "$DST_DIR/$EXT_FILE"
+
+done < "$EXTENSIONS_LIST"

--- a/scripts/make_villagesql_dev_server.sh
+++ b/scripts/make_villagesql_dev_server.sh
@@ -178,8 +178,8 @@ else
     log_info "Step 5: Skipping bundled extensions (set BUILD_BUNDLED_EXTENSIONS=1 to include)"
 fi
 
-# Step 5: Add convenience scripts
-log_step "Step 5: Adding convenience scripts..."
+# Step 6: Add convenience scripts
+log_step "Step 6: Adding convenience scripts..."
 
 # Copy script from source directory
 TEMPLATE_DIR="$SOURCE_DIR/villagesql/dev_server"
@@ -193,8 +193,8 @@ fi
 
 log_info "Convenience scripts added"
 
-# Step 6: Create comprehensive README
-log_step "Step 6: Creating documentation..."
+# Step 7: Create comprehensive README
+log_step "Step 7: Creating documentation..."
 
 # Generate test documentation (always included with stripped MySQL tests)
 TEST_NOTE="**Note:** This package includes the test framework (mysql-test-run.pl, lib/, include/) without any bundled test suites. You can create your own test suites for your extensions."
@@ -220,8 +220,8 @@ Build Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
 Package Type: Development Server
 EOF
 
-# Step 7: Create the final tarball
-log_step "Step 7: Creating final tarball..."
+# Step 8: Create the final tarball
+log_step "Step 8: Creating final tarball..."
 cd "$STAGING_DIR"
 tar czf "$TARBALL_NAME" "$PACKAGE_NAME"
 

--- a/scripts/make_villagesql_dev_server.sh
+++ b/scripts/make_villagesql_dev_server.sh
@@ -165,6 +165,19 @@ if [[ -d "mysql-test" ]]; then
     log_info "mysql-test framework size after cleanup: $MYSQL_TEST_SIZE"
 fi
 
+if [[ "${BUILD_BUNDLED_EXTENSIONS:-0}" == "1" ]]; then
+    log_step "Step 5: Adding bundled extensions..."
+
+    "$SOURCE_DIR/scripts/include_bundled_extensions.sh" \
+            "lib/veb" \
+            "$BUILD_DIR/veb_output_directory"
+
+    log_info "Bundled extensions added to release"
+
+else
+    log_info "Step 6: Skipping bundled extensions (set BUILD_BUNDLED_EXTENSIONS=1 to include)"
+fi
+
 # Step 5: Add convenience scripts
 log_step "Step 5: Adding convenience scripts..."
 

--- a/scripts/make_villagesql_dev_server.sh
+++ b/scripts/make_villagesql_dev_server.sh
@@ -178,7 +178,6 @@ else
     log_info "Step 5: Skipping bundled extensions (set BUILD_BUNDLED_EXTENSIONS=1 to include)"
 fi
 
-# Step 6: Add convenience scripts
 log_step "Step 6: Adding convenience scripts..."
 
 # Copy script from source directory
@@ -193,7 +192,6 @@ fi
 
 log_info "Convenience scripts added"
 
-# Step 7: Create comprehensive README
 log_step "Step 7: Creating documentation..."
 
 # Generate test documentation (always included with stripped MySQL tests)
@@ -220,7 +218,6 @@ Build Date: $(date -u +"%Y-%m-%d %H:%M:%S UTC")
 Package Type: Development Server
 EOF
 
-# Step 8: Create the final tarball
 log_step "Step 8: Creating final tarball..."
 cd "$STAGING_DIR"
 tar czf "$TARBALL_NAME" "$PACKAGE_NAME"

--- a/scripts/make_villagesql_dev_server.sh
+++ b/scripts/make_villagesql_dev_server.sh
@@ -175,7 +175,7 @@ if [[ "${BUILD_BUNDLED_EXTENSIONS:-0}" == "1" ]]; then
     log_info "Bundled extensions added to release"
 
 else
-    log_info "Step 6: Skipping bundled extensions (set BUILD_BUNDLED_EXTENSIONS=1 to include)"
+    log_info "Step 5: Skipping bundled extensions (set BUILD_BUNDLED_EXTENSIONS=1 to include)"
 fi
 
 # Step 5: Add convenience scripts

--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -17,6 +17,8 @@
 # Comments and blank lines are ignored.
 https://github.com/villagesql/vsql-ai main
 https://github.com/villagesql/vsql-crypto main
+https://github.com/villagesql/vsql-cube main abi=dev
 https://github.com/villagesql/vsql-http main
 https://github.com/villagesql/vsql-network-address main
 https://github.com/villagesql/vsql-uuid main
+https://github.com/villagesql/vsql-vector main abi=dev bundle=false

--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -17,8 +17,6 @@
 # Comments and blank lines are ignored.
 https://github.com/villagesql/vsql-ai main
 https://github.com/villagesql/vsql-crypto main
-https://github.com/villagesql/vsql-cube main abi=dev
 https://github.com/villagesql/vsql-http main
 https://github.com/villagesql/vsql-network-address main
 https://github.com/villagesql/vsql-uuid main
-https://github.com/villagesql/vsql-vector main abi=dev bundle=false


### PR DESCRIPTION
During final construction of the release bundle, include the extensions defined to be part of the release dev-server.

These were previously built and tested and only need to be added to the basic package created by CPack.

