### PR TITLE
regression tests for UNINSTALL

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/functional_index_on_custom_column_prevents_extension_uninstall.result
+++ b/mysql-test/suite/villagesql/extension/r/functional_index_on_custom_column_prevents_extension_uninstall.result
@@ -1,0 +1,13 @@
+CREATE TABLE t (id INT PRIMARY KEY, c COMPLEX,
+INDEX idx_func ((vsql_complex.complex_real(c))));
+INSERT INTO t VALUES (1, '(1,2)');
+# Blocked while the COMPLEX column exists (custom_columns persistent dep).
+UNINSTALL EXTENSION vsql_complex;
+ERROR HY000: Cannot drop extension `vsql_complex` as 1 column(s) depend on it, e.g. test.t.c has type COMPLEX
+# Persistent: still blocked after the table cache is flushed.
+FLUSH TABLES;
+UNINSTALL EXTENSION vsql_complex;
+ERROR HY000: Cannot drop extension `vsql_complex` as 1 column(s) depend on it, e.g. test.t.c has type COMPLEX
+# Dropping the table clears the dependency; uninstall now succeeds.
+DROP TABLE t;
+UNINSTALL EXTENSION vsql_complex;

--- a/mysql-test/suite/villagesql/extension/r/generated_column_with_vdf_errors_after_extension_uninstall.result
+++ b/mysql-test/suite/villagesql/extension/r/generated_column_with_vdf_errors_after_extension_uninstall.result
@@ -1,0 +1,18 @@
+CREATE TABLE t (id INT PRIMARY KEY, v INT,
+gen DOUBLE AS (v + vsql_complex.complex_real('(1,2)')) STORED);
+INSERT INTO t (id, v) VALUES (1, 10);
+SELECT * FROM t;
+id	v	gen
+1	10	11
+# While the table is open, use_count blocks UNINSTALL.
+UNINSTALL EXTENSION vsql_complex;
+ERROR HY000: Cannot uninstall extension 'vsql_complex': VDF 'complex_real' is currently in use
+# Cold-cache UNINSTALL succeeds: no custom column to pin the extension.
+FLUSH TABLES;
+UNINSTALL EXTENSION vsql_complex;
+# Reads and writes on the table now error like a missing UDF.
+SELECT * FROM t;
+ERROR 42000: FUNCTION vsql_complex.complex_real does not exist
+INSERT INTO t (id, v) VALUES (2, 20);
+ERROR 42000: FUNCTION vsql_complex.complex_real does not exist
+DROP TABLE t;

--- a/mysql-test/suite/villagesql/extension/r/view_with_vdf_errors_after_extension_uninstall.result
+++ b/mysql-test/suite/villagesql/extension/r/view_with_vdf_errors_after_extension_uninstall.result
@@ -1,0 +1,11 @@
+CREATE VIEW v AS SELECT vsql_complex.complex_real('(1,2)') AS r;
+SELECT * FROM v;
+r
+1
+# Cold-cache UNINSTALL succeeds: view's in-memory ref is gone.
+FLUSH TABLES;
+UNINSTALL EXTENSION vsql_complex;
+# View body still references the now-removed VDF; SELECT errors at runtime.
+SELECT * FROM v;
+ERROR HY000: View 'test.v' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
+DROP VIEW v;

--- a/mysql-test/suite/villagesql/extension/r/view_with_vdf_errors_after_extension_uninstall.result
+++ b/mysql-test/suite/villagesql/extension/r/view_with_vdf_errors_after_extension_uninstall.result
@@ -2,8 +2,7 @@ CREATE VIEW v AS SELECT vsql_complex.complex_real('(1,2)') AS r;
 SELECT * FROM v;
 r
 1
-# Cold-cache UNINSTALL succeeds: view's in-memory ref is gone.
-FLUSH TABLES;
+# Nothing holds the VDF after the SELECT completes; UNINSTALL succeeds.
 UNINSTALL EXTENSION vsql_complex;
 # View body still references the now-removed VDF; SELECT errors at runtime.
 SELECT * FROM v;

--- a/mysql-test/suite/villagesql/extension/t/functional_index_on_custom_column_prevents_extension_uninstall.test
+++ b/mysql-test/suite/villagesql/extension/t/functional_index_on_custom_column_prevents_extension_uninstall.test
@@ -1,7 +1,6 @@
 # Functional index over a custom-typed column carries a custom_columns
 # dependency on the underlying column. UNINSTALL EXTENSION must be blocked
 # while such a column exists, in both open-cache and cold-cache states.
-# Regression test for the #392 audit's literal ask.
 
 --source include/villagesql/install_complex_extension.inc
 

--- a/mysql-test/suite/villagesql/extension/t/functional_index_on_custom_column_prevents_extension_uninstall.test
+++ b/mysql-test/suite/villagesql/extension/t/functional_index_on_custom_column_prevents_extension_uninstall.test
@@ -1,0 +1,23 @@
+# Functional index over a custom-typed column carries a custom_columns
+# dependency on the underlying column. UNINSTALL EXTENSION must be blocked
+# while such a column exists, in both open-cache and cold-cache states.
+# Regression test for the #392 audit's literal ask.
+
+--source include/villagesql/install_complex_extension.inc
+
+CREATE TABLE t (id INT PRIMARY KEY, c COMPLEX,
+                INDEX idx_func ((vsql_complex.complex_real(c))));
+INSERT INTO t VALUES (1, '(1,2)');
+
+--echo # Blocked while the COMPLEX column exists (custom_columns persistent dep).
+--error ER_VILLAGESQL_GENERIC_ERROR
+UNINSTALL EXTENSION vsql_complex;
+
+--echo # Persistent: still blocked after the table cache is flushed.
+FLUSH TABLES;
+--error ER_VILLAGESQL_GENERIC_ERROR
+UNINSTALL EXTENSION vsql_complex;
+
+--echo # Dropping the table clears the dependency; uninstall now succeeds.
+DROP TABLE t;
+UNINSTALL EXTENSION vsql_complex;

--- a/mysql-test/suite/villagesql/extension/t/generated_column_with_vdf_errors_after_extension_uninstall.test
+++ b/mysql-test/suite/villagesql/extension/t/generated_column_with_vdf_errors_after_extension_uninstall.test
@@ -1,0 +1,31 @@
+# A generated column whose expression calls a VDF over only built-in inputs
+# carries no custom_columns row, so nothing persistent pins the extension at
+# uninstall time. While the table is open, the in-memory use_count check
+# blocks UNINSTALL; once the table cache is flushed, UNINSTALL succeeds.
+# Subsequent reads/writes on the table then error with the same code MySQL
+# returns for any missing function: ER_SP_DOES_NOT_EXIST (1305). This pins
+# that runtime behavior so future changes don't silently downgrade the error.
+
+--source include/villagesql/install_complex_extension.inc
+
+CREATE TABLE t (id INT PRIMARY KEY, v INT,
+                gen DOUBLE AS (v + vsql_complex.complex_real('(1,2)')) STORED);
+INSERT INTO t (id, v) VALUES (1, 10);
+SELECT * FROM t;
+
+--echo # While the table is open, use_count blocks UNINSTALL.
+--error ER_VILLAGESQL_GENERIC_ERROR
+UNINSTALL EXTENSION vsql_complex;
+
+--echo # Cold-cache UNINSTALL succeeds: no custom column to pin the extension.
+FLUSH TABLES;
+UNINSTALL EXTENSION vsql_complex;
+
+--echo # Reads and writes on the table now error like a missing UDF.
+--error ER_SP_DOES_NOT_EXIST
+SELECT * FROM t;
+
+--error ER_SP_DOES_NOT_EXIST
+INSERT INTO t (id, v) VALUES (2, 20);
+
+DROP TABLE t;

--- a/mysql-test/suite/villagesql/extension/t/view_with_vdf_errors_after_extension_uninstall.test
+++ b/mysql-test/suite/villagesql/extension/t/view_with_vdf_errors_after_extension_uninstall.test
@@ -1,0 +1,21 @@
+# A view body that references a VDF over only-built-in inputs has no
+# persistent dependency in custom_columns. After FLUSH TABLES drops the
+# view's in-memory use_count, UNINSTALL EXTENSION succeeds. The view body
+# then carries a dangling VDF reference, which surfaces as ER_VIEW_INVALID
+# at SELECT time -- the same shape as a view that references a now-removed
+# stored function. Pins the at-query error path the #392 discussion settled on.
+
+--source include/villagesql/install_complex_extension.inc
+
+CREATE VIEW v AS SELECT vsql_complex.complex_real('(1,2)') AS r;
+SELECT * FROM v;
+
+--echo # Cold-cache UNINSTALL succeeds: view's in-memory ref is gone.
+FLUSH TABLES;
+UNINSTALL EXTENSION vsql_complex;
+
+--echo # View body still references the now-removed VDF; SELECT errors at runtime.
+--error ER_VIEW_INVALID
+SELECT * FROM v;
+
+DROP VIEW v;

--- a/mysql-test/suite/villagesql/extension/t/view_with_vdf_errors_after_extension_uninstall.test
+++ b/mysql-test/suite/villagesql/extension/t/view_with_vdf_errors_after_extension_uninstall.test
@@ -3,7 +3,7 @@
 # view's in-memory use_count, UNINSTALL EXTENSION succeeds. The view body
 # then carries a dangling VDF reference, which surfaces as ER_VIEW_INVALID
 # at SELECT time -- the same shape as a view that references a now-removed
-# stored function. Pins the at-query error path the #392 discussion settled on.
+# stored function.
 
 --source include/villagesql/install_complex_extension.inc
 

--- a/mysql-test/suite/villagesql/extension/t/view_with_vdf_errors_after_extension_uninstall.test
+++ b/mysql-test/suite/villagesql/extension/t/view_with_vdf_errors_after_extension_uninstall.test
@@ -1,17 +1,16 @@
 # A view body that references a VDF over only-built-in inputs has no
-# persistent dependency in custom_columns. After FLUSH TABLES drops the
-# view's in-memory use_count, UNINSTALL EXTENSION succeeds. The view body
-# then carries a dangling VDF reference, which surfaces as ER_VIEW_INVALID
-# at SELECT time -- the same shape as a view that references a now-removed
-# stored function.
+# persistent dependency in custom_columns. The SELECT releases its use_count
+# on the VDF when it completes, so nothing pins the extension and UNINSTALL
+# EXTENSION succeeds. The view body then carries a dangling VDF reference,
+# which surfaces as ER_VIEW_INVALID at SELECT time -- the same shape as a
+# view that references a now-removed stored function.
 
 --source include/villagesql/install_complex_extension.inc
 
 CREATE VIEW v AS SELECT vsql_complex.complex_real('(1,2)') AS r;
 SELECT * FROM v;
 
---echo # Cold-cache UNINSTALL succeeds: view's in-memory ref is gone.
-FLUSH TABLES;
+--echo # Nothing holds the VDF after the SELECT completes; UNINSTALL succeeds.
 UNINSTALL EXTENSION vsql_complex;
 
 --echo # View body still references the now-removed VDF; SELECT errors at runtime.


### PR DESCRIPTION
## Description

Two regression tests pinning behavior surfaced by the #392 audit:

- `functional_index_on_custom_column_prevents_extension_uninstall.test` — UNINSTALL is blocked while a functional index over a `COMPLEX` column exists, in both open-cache and cold-cache states. This is the issue's literal ask.
- `view_with_vdf_errors_after_extension_uninstall.test` — a view body referencing a VDF over only-built-in inputs has no persistent dependency, so cold-cache UNINSTALL succeeds; querying the view then errors with `ER_VIEW_INVALID` at SELECT time, matching the UDF-shaped behavior the audit thread settled on.

## Related Issue

Part of #392.

## How was this tested?

```
./mysql-test/mysql-test-run.pl --suite=villagesql/extension \
  functional_index_on_custom_column_prevents_extension_uninstall \
  view_with_vdf_errors_after_extension_uninstall
```

Both tests pass.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4