### PR TITLE
vef: restore column store wiring

### DIFF
--- a/unittest/gunit/villagesql/validate-t.cc
+++ b/unittest/gunit/villagesql/validate-t.cc
@@ -14,9 +14,9 @@
  * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 
-// Unit tests for validate_extension_registration().
+// Unit tests for parse_extension_registration().
 //
-// These tests exercise the pure validation path — no THD, no VictionaryClient,
+// These tests exercise the pure parsing path — no THD, no VictionaryClient,
 // no .so loading — by constructing vef_registration_t structs directly.
 
 #include <gtest/gtest.h>
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "unittest/gunit/test_utils.h"
+#include "villagesql/sdk/include/villagesql/abi/preview/storage.h"
 #include "villagesql/sdk/include/villagesql/abi/types.h"
 #include "villagesql/veb/validate.h"
 #include "villagesql/veb/veb_file.h"
@@ -115,7 +116,7 @@ TEST_F(ValidateExtensionRegistrationTest, ValidV1TypeAndFunc) {
   reg.funcs = funcs;
 
   std::string error;
-  auto result = villagesql::veb::validate_extension_registration(
+  auto result = villagesql::veb::parse_extension_registration(
       make_ext_reg(&reg, VEF_PROTOCOL_1), "my_ext", "1.0.0", error);
 
   ASSERT_TRUE(result.has_value());
@@ -137,7 +138,7 @@ TEST_F(ValidateExtensionRegistrationTest, EmptyRegistration) {
   reg.deprecated_extension_name = "empty_ext";
 
   std::string error;
-  auto result = villagesql::veb::validate_extension_registration(
+  auto result = villagesql::veb::parse_extension_registration(
       make_ext_reg(&reg, VEF_PROTOCOL_1), "empty_ext", "1.0.0", error);
 
   ASSERT_TRUE(result.has_value());
@@ -148,7 +149,7 @@ TEST_F(ValidateExtensionRegistrationTest, EmptyRegistration) {
 // A null registration pointer (extension registered nothing) is allowed.
 TEST_F(ValidateExtensionRegistrationTest, NullRegistrationPointer) {
   std::string error;
-  auto result = villagesql::veb::validate_extension_registration(
+  auto result = villagesql::veb::parse_extension_registration(
       make_ext_reg(nullptr, VEF_PROTOCOL_1), "my_ext", "1.0.0", error);
 
   ASSERT_TRUE(result.has_value());
@@ -167,7 +168,7 @@ TEST_F(ValidateExtensionRegistrationTest, NullTypeDescriptor) {
   reg.types = types;
 
   std::string error;
-  auto result = villagesql::veb::validate_extension_registration(
+  auto result = villagesql::veb::parse_extension_registration(
       make_ext_reg(&reg, VEF_PROTOCOL_1), "my_ext", "1.0.0", error);
 
   EXPECT_FALSE(result.has_value());
@@ -186,7 +187,7 @@ TEST_F(ValidateExtensionRegistrationTest, ZeroMaxDecodeBufferLength) {
   reg.types = types;
 
   std::string error;
-  auto result = villagesql::veb::validate_extension_registration(
+  auto result = villagesql::veb::parse_extension_registration(
       make_ext_reg(&reg, VEF_PROTOCOL_1), "my_ext", "1.0.0", error);
 
   EXPECT_FALSE(result.has_value());
@@ -205,7 +206,7 @@ TEST_F(ValidateExtensionRegistrationTest, NullFuncDescriptor) {
   reg.funcs = funcs;
 
   std::string error;
-  auto result = villagesql::veb::validate_extension_registration(
+  auto result = villagesql::veb::parse_extension_registration(
       make_ext_reg(&reg, VEF_PROTOCOL_1), "my_ext", "1.0.0", error);
 
   EXPECT_FALSE(result.has_value());
@@ -229,7 +230,7 @@ TEST_F(ValidateExtensionRegistrationTest, ClearWithoutAccumulate) {
   reg.funcs = funcs;
 
   std::string error;
-  auto result = villagesql::veb::validate_extension_registration(
+  auto result = villagesql::veb::parse_extension_registration(
       make_ext_reg(&reg, VEF_PROTOCOL_2), "my_ext", "1.0.0", error);
 
   EXPECT_FALSE(result.has_value());
@@ -255,7 +256,7 @@ TEST_F(ValidateExtensionRegistrationTest, AccumulateWithoutClear) {
   reg.funcs = funcs;
 
   std::string error;
-  auto result = villagesql::veb::validate_extension_registration(
+  auto result = villagesql::veb::parse_extension_registration(
       make_ext_reg(&reg, VEF_PROTOCOL_2), "my_ext", "1.0.0", error);
 
   EXPECT_FALSE(result.has_value());
@@ -280,7 +281,7 @@ TEST_F(ValidateExtensionRegistrationTest,
   reg.funcs = funcs;
 
   std::string error;
-  auto result = villagesql::veb::validate_extension_registration(
+  auto result = villagesql::veb::parse_extension_registration(
       make_ext_reg(&reg, VEF_PROTOCOL_1), "my_ext", "1.0.0", error);
 
   ASSERT_TRUE(result.has_value());
@@ -321,7 +322,7 @@ TEST_F(ValidateExtensionRegistrationTest, V2TypeBadVdfName) {
     reg.types = types;
 
     std::string error;
-    auto result = villagesql::veb::validate_extension_registration(
+    auto result = villagesql::veb::parse_extension_registration(
         make_ext_reg(&reg, VEF_PROTOCOL_2), "my_ext", "1.0.0", error);
 
     EXPECT_FALSE(result.has_value());
@@ -380,13 +381,304 @@ TEST_F(ValidateExtensionRegistrationTest, V2TypeValidVdfNames) {
   reg.funcs = funcs;
 
   std::string error;
-  auto result = villagesql::veb::validate_extension_registration(
+  auto result = villagesql::veb::parse_extension_registration(
       make_ext_reg(&reg, VEF_PROTOCOL_2), "my_ext", "1.0.0", error);
 
   ASSERT_TRUE(result.has_value());
   EXPECT_TRUE(error.empty());
   ASSERT_EQ(result->types.size(), 1u);
   EXPECT_EQ(result->types[0].type_name(), "MYTYPE");
+}
+
+// Stub column storage function pointers — never called during validation.
+static bool stub_storage_create(vef_storage_space_ref_t, vef_storage_trx_ref_t,
+                                uint32_t, vef_storage_arena_t *,
+                                vef_storage_arena_func_t, vef_storage_ctx_t **,
+                                char *, uint32_t) {
+  return false;
+}
+static bool stub_storage_drop(vef_storage_ctx_t *, vef_storage_trx_ref_t,
+                              char *, uint32_t) {
+  return false;
+}
+static bool stub_storage_load(vef_storage_ref_t, vef_storage_arena_t *,
+                              vef_storage_arena_func_t, vef_storage_ctx_t **,
+                              char *, uint32_t) {
+  return false;
+}
+static bool stub_storage_insert(vef_storage_ctx_t *, vef_storage_mtr_ref_t,
+                                vef_storage_trx_ref_t, vef_storage_col_data_t,
+                                vef_storage_col_data_t, vef_storage_col_ref_t *,
+                                char *, uint32_t) {
+  return false;
+}
+static bool stub_storage_select(vef_storage_ctx_t *, vef_storage_mtr_ref_t,
+                                vef_storage_col_ref_t, vef_storage_col_data_t *,
+                                vef_storage_col_data_t *,
+                                vef_storage_trx_ref_t *, bool *, char *,
+                                uint32_t) {
+  return false;
+}
+static bool stub_storage_mark_delete(vef_storage_ctx_t *, vef_storage_mtr_ref_t,
+                                     vef_storage_trx_ref_t,
+                                     vef_storage_col_ref_t, bool, char *,
+                                     uint32_t) {
+  return false;
+}
+static bool stub_storage_purge(vef_storage_ctx_t *, vef_storage_mtr_ref_t,
+                               vef_storage_trx_ref_t, vef_storage_col_ref_t,
+                               char *, uint32_t) {
+  return false;
+}
+
+static vef_type_storage_intf_t make_storage_intf(const char *type_name) {
+  vef_type_storage_intf_t si = {};
+  si.version = VEF_STORAGE_TYPE_INTF_VERSION;
+  si.type_name = type_name;
+  si.create = stub_storage_create;
+  si.drop = stub_storage_drop;
+  si.load = stub_storage_load;
+  si.insert = stub_storage_insert;
+  si.select = stub_storage_select;
+  si.mark_delete = stub_storage_mark_delete;
+  si.purge = stub_storage_purge;
+  return si;
+}
+
+// A v2 extension with a column_store capability wires storage_intf into the
+// matching TypeDescriptor. This is the regression test for the accidental
+// deletion of the wiring block in parse_extension_registration() (commit
+// 736f6a7afca removed it as a side effect of removing
+// validate_sys_var_descriptors in the same diff hunk).
+TEST_F(ValidateExtensionRegistrationTest, ColumnStorageWiredToType) {
+  vef_type_desc_t td = make_v1_type("MYTYPE");
+  vef_type_desc_t *types[] = {&td};
+
+  vef_type_storage_intf_t si = make_storage_intf("MYTYPE");
+  const vef_type_storage_intf_t *storages[] = {&si};
+
+  vef_preview_column_store_ext_desc_t ext_desc = {};
+  ext_desc.version = VEF_COLUMN_STORE_INTF_VERSION;
+  ext_desc.type_storage_count = 1;
+  ext_desc.type_storages = storages;
+
+  vef_required_capability_t cap = {};
+  cap.name = VEF_PREVIEW_COLUMN_STORE_NAME;
+  cap.extension_data = &ext_desc;
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_2;
+  reg.deprecated_extension_name = "my_ext";
+  reg.type_count = 1;
+  reg.types = types;
+  reg.required_capability_count = 1;
+  reg.required_capabilities = &cap;
+
+  std::string error;
+  auto result = villagesql::veb::parse_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_2), "my_ext", "1.0.0", error);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(error.empty());
+  ASSERT_EQ(result->types.size(), 1u);
+  EXPECT_TRUE(result->types[0].storage_intf().has_value());
+}
+
+// Column store wiring is skipped entirely for protocol-1 negotiations even if
+// a column_store capability is present (the field didn't exist in v1).
+TEST_F(ValidateExtensionRegistrationTest,
+       ColumnStorageNotWiredForProtocol1Negotiation) {
+  vef_type_desc_t td = make_v1_type("MYTYPE");
+  vef_type_desc_t *types[] = {&td};
+
+  vef_type_storage_intf_t si = make_storage_intf("MYTYPE");
+  const vef_type_storage_intf_t *storages[] = {&si};
+
+  vef_preview_column_store_ext_desc_t ext_desc = {};
+  ext_desc.version = VEF_COLUMN_STORE_INTF_VERSION;
+  ext_desc.type_storage_count = 1;
+  ext_desc.type_storages = storages;
+
+  vef_required_capability_t cap = {};
+  cap.name = VEF_PREVIEW_COLUMN_STORE_NAME;
+  cap.extension_data = &ext_desc;
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_2;
+  reg.deprecated_extension_name = "my_ext";
+  reg.type_count = 1;
+  reg.types = types;
+  reg.required_capability_count = 1;
+  reg.required_capabilities = &cap;
+
+  std::string error;
+  auto result = villagesql::veb::parse_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_1), "my_ext", "1.0.0", error);
+
+  ASSERT_TRUE(result.has_value());
+  ASSERT_EQ(result->types.size(), 1u);
+  EXPECT_FALSE(result->types[0].storage_intf().has_value());
+}
+
+// Column store capability referencing a type not registered by this extension
+// fails validation.
+TEST_F(ValidateExtensionRegistrationTest, ColumnStorageUnknownTypeFails) {
+  vef_type_desc_t td = make_v1_type("MYTYPE");
+  vef_type_desc_t *types[] = {&td};
+
+  vef_type_storage_intf_t si = make_storage_intf("OTHERTYPE");
+  const vef_type_storage_intf_t *storages[] = {&si};
+
+  vef_preview_column_store_ext_desc_t ext_desc = {};
+  ext_desc.version = VEF_COLUMN_STORE_INTF_VERSION;
+  ext_desc.type_storage_count = 1;
+  ext_desc.type_storages = storages;
+
+  vef_required_capability_t cap = {};
+  cap.name = VEF_PREVIEW_COLUMN_STORE_NAME;
+  cap.extension_data = &ext_desc;
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_2;
+  reg.deprecated_extension_name = "my_ext";
+  reg.type_count = 1;
+  reg.types = types;
+  reg.required_capability_count = 1;
+  reg.required_capabilities = &cap;
+
+  std::string error;
+  auto result = villagesql::veb::parse_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_2), "my_ext", "1.0.0", error);
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_NE(error.find("OTHERTYPE"), std::string::npos);
+}
+
+// Column store capability with incomplete storage functions (missing purge)
+// fails validation.
+TEST_F(ValidateExtensionRegistrationTest, ColumnStorageMissingFunctionFails) {
+  vef_type_desc_t td = make_v1_type("MYTYPE");
+  vef_type_desc_t *types[] = {&td};
+
+  vef_type_storage_intf_t si = make_storage_intf("MYTYPE");
+  si.purge = nullptr;
+  const vef_type_storage_intf_t *storages[] = {&si};
+
+  vef_preview_column_store_ext_desc_t ext_desc = {};
+  ext_desc.version = VEF_COLUMN_STORE_INTF_VERSION;
+  ext_desc.type_storage_count = 1;
+  ext_desc.type_storages = storages;
+
+  vef_required_capability_t cap = {};
+  cap.name = VEF_PREVIEW_COLUMN_STORE_NAME;
+  cap.extension_data = &ext_desc;
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_2;
+  reg.deprecated_extension_name = "my_ext";
+  reg.type_count = 1;
+  reg.types = types;
+  reg.required_capability_count = 1;
+  reg.required_capabilities = &cap;
+
+  std::string error;
+  auto result = villagesql::veb::parse_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_2), "my_ext", "1.0.0", error);
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_NE(error.find("MYTYPE"), std::string::npos);
+}
+
+// A null entry in the type_storages array fails validation.
+TEST_F(ValidateExtensionRegistrationTest, ColumnStorageNullDescriptorFails) {
+  vef_type_desc_t td = make_v1_type("MYTYPE");
+  vef_type_desc_t *types[] = {&td};
+
+  const vef_type_storage_intf_t *storages[] = {nullptr};
+
+  vef_preview_column_store_ext_desc_t ext_desc = {};
+  ext_desc.version = VEF_COLUMN_STORE_INTF_VERSION;
+  ext_desc.type_storage_count = 1;
+  ext_desc.type_storages = storages;
+
+  vef_required_capability_t cap = {};
+  cap.name = VEF_PREVIEW_COLUMN_STORE_NAME;
+  cap.extension_data = &ext_desc;
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_2;
+  reg.deprecated_extension_name = "my_ext";
+  reg.type_count = 1;
+  reg.types = types;
+  reg.required_capability_count = 1;
+  reg.required_capabilities = &cap;
+
+  std::string error;
+  auto result = villagesql::veb::parse_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_2), "my_ext", "1.0.0", error);
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_NE(error.find("NULL"), std::string::npos);
+}
+
+// A column_store capability with a mismatched version field fails validation.
+TEST_F(ValidateExtensionRegistrationTest, ColumnStorageVersionMismatchFails) {
+  vef_type_desc_t td = make_v1_type("MYTYPE");
+  vef_type_desc_t *types[] = {&td};
+
+  vef_type_storage_intf_t si = make_storage_intf("MYTYPE");
+  const vef_type_storage_intf_t *storages[] = {&si};
+
+  vef_preview_column_store_ext_desc_t ext_desc = {};
+  ext_desc.version = VEF_COLUMN_STORE_INTF_VERSION + 99;
+  ext_desc.type_storage_count = 1;
+  ext_desc.type_storages = storages;
+
+  vef_required_capability_t cap = {};
+  cap.name = VEF_PREVIEW_COLUMN_STORE_NAME;
+  cap.extension_data = &ext_desc;
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_2;
+  reg.deprecated_extension_name = "my_ext";
+  reg.type_count = 1;
+  reg.types = types;
+  reg.required_capability_count = 1;
+  reg.required_capabilities = &cap;
+
+  std::string error;
+  auto result = villagesql::veb::parse_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_2), "my_ext", "1.0.0", error);
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_NE(error.find("unsupported version"), std::string::npos);
+}
+
+// Two storage descriptors claiming the same type name fail validation.
+TEST_F(ValidateExtensionRegistrationTest, ColumnStorageDuplicateTypeFails) {
+  vef_type_desc_t td = make_v1_type("MYTYPE");
+  vef_type_desc_t *types[] = {&td};
+
+  vef_type_storage_intf_t si1 = make_storage_intf("MYTYPE");
+  vef_type_storage_intf_t si2 = make_storage_intf("MYTYPE");
+  const vef_type_storage_intf_t *storages[] = {&si1, &si2};
+
+  vef_preview_column_store_ext_desc_t ext_desc = {};
+  ext_desc.version = VEF_COLUMN_STORE_INTF_VERSION;
+  ext_desc.type_storage_count = 2;
+  ext_desc.type_storages = storages;
+
+  vef_required_capability_t cap = {};
+  cap.name = VEF_PREVIEW_COLUMN_STORE_NAME;
+  cap.extension_data = &ext_desc;
+  vef_registration_t reg = {};
+  reg.protocol = VEF_PROTOCOL_2;
+  reg.deprecated_extension_name = "my_ext";
+  reg.type_count = 1;
+  reg.types = types;
+  reg.required_capability_count = 1;
+  reg.required_capabilities = &cap;
+
+  std::string error;
+  auto result = villagesql::veb::parse_extension_registration(
+      make_ext_reg(&reg, VEF_PROTOCOL_2), "my_ext", "1.0.0", error);
+
+  EXPECT_FALSE(result.has_value());
+  EXPECT_NE(error.find("duplicate"), std::string::npos);
 }
 
 // Multiple types and funcs are all validated and returned.
@@ -411,7 +703,7 @@ TEST_F(ValidateExtensionRegistrationTest, MultipleTypesAndFuncs) {
   reg.funcs = funcs;
 
   std::string error;
-  auto result = villagesql::veb::validate_extension_registration(
+  auto result = villagesql::veb::parse_extension_registration(
       make_ext_reg(&reg, VEF_PROTOCOL_1), "my_ext", "2.0.0", error);
 
   ASSERT_TRUE(result.has_value());

--- a/villagesql/veb/register.h
+++ b/villagesql/veb/register.h
@@ -19,7 +19,7 @@
 // register_validated_extension() inserts pre-validated TypeDescriptors and
 // FuncDescriptors into the victionary.  The caller must hold the victionary
 // write lock and supply a ValidatedRegistration produced by
-// validate_extension_registration().
+// parse_extension_registration().
 
 #ifndef VILLAGESQL_VEB_REGISTER_H_
 #define VILLAGESQL_VEB_REGISTER_H_

--- a/villagesql/veb/sql_extension.cc
+++ b/villagesql/veb/sql_extension.cc
@@ -214,14 +214,13 @@ bool Sql_cmd_install_extension::execute(THD *thd) {
 
   std::string reg_error;
   std::optional<villagesql::veb::ValidatedRegistration> validated =
-      villagesql::veb::validate_extension_registration(
+      villagesql::veb::parse_extension_registration(
           registration, extension_name, version, reg_error);
   if (!validated) {
     villagesql_error("Failed to install extension '%s': %s", MYF(0),
                      extension_name.c_str(), reg_error.c_str());
     return end_transaction(thd, true);
   }
-
 
   bool mark_success = true;
   {

--- a/villagesql/veb/validate.cc
+++ b/villagesql/veb/validate.cc
@@ -49,7 +49,7 @@ static Item_result vef_type_to_item_result(const vef_type_t &type) {
   }
 }
 
-std::optional<ValidatedRegistration> validate_extension_registration(
+std::optional<ValidatedRegistration> parse_extension_registration(
     const ExtensionRegistration &ext_reg, const std::string &extension_name,
     const std::string &extension_version, std::string &error_out) {
   ValidatedRegistration result;
@@ -130,6 +130,79 @@ std::optional<ValidatedRegistration> validate_extension_registration(
       result.funcs.push_back(FuncDescriptor(key, extension_version, func_desc,
                                             ext_reg.negotiated_protocol,
                                             return_type));
+    }
+  }
+
+  // Wire column storage implementations to types via the storage capability
+  // extension descriptor. The descriptor lives in the extension_data field of
+  // the vsql::preview::column_store capability entry.
+  if (reg != nullptr && ext_reg.negotiated_protocol >= VEF_PROTOCOL_2 &&
+      reg->required_capability_count > 0) {
+    for (unsigned int i = 0; i < reg->required_capability_count; i++) {
+      const vef_required_capability_t &cap = reg->required_capabilities[i];
+      if (cap.name == nullptr ||
+          strcmp(cap.name, VEF_PREVIEW_COLUMN_STORE_NAME) != 0 ||
+          cap.extension_data == nullptr) {
+        continue;
+      }
+
+      const auto *ext_desc =
+          static_cast<const vef_preview_column_store_ext_desc_t *>(
+              cap.extension_data);
+
+      if (ext_desc->version != VEF_COLUMN_STORE_INTF_VERSION) {
+        error_out = "column_store capability has unsupported version " +
+                    std::to_string(ext_desc->version) + " (expected " +
+                    std::to_string(VEF_COLUMN_STORE_INTF_VERSION) + ")";
+        LogVSQL(ERROR_LEVEL, "Extension '%s': %s", extension_name.c_str(),
+                error_out.c_str());
+        return std::nullopt;
+      }
+
+      for (unsigned int j = 0; j < ext_desc->type_storage_count; j++) {
+        const vef_type_storage_intf_t *sd = ext_desc->type_storages[j];
+        if (sd == nullptr || sd->type_name == nullptr) {
+          error_out = "NULL type storage descriptor at index " +
+                      std::to_string(j) + " in storage capability";
+          LogVSQL(ERROR_LEVEL, "Extension '%s': %s", extension_name.c_str(),
+                  error_out.c_str());
+          return std::nullopt;
+        }
+
+        if (!sd->create || !sd->drop || !sd->load || !sd->insert ||
+            !sd->select || !sd->mark_delete || !sd->purge) {
+          error_out = std::string("type storage for '") + sd->type_name +
+                      "': not all storage functions are registered";
+          LogVSQL(ERROR_LEVEL, "Extension '%s': %s", extension_name.c_str(),
+                  error_out.c_str());
+          return std::nullopt;
+        }
+
+        bool found = false;
+        for (auto &descriptor : result.types) {
+          if (descriptor.type_name() == sd->type_name) {
+            if (descriptor.storage_intf().has_value()) {
+              error_out =
+                  std::string("duplicate storage descriptor for type '") +
+                  sd->type_name + "'";
+              LogVSQL(ERROR_LEVEL, "Extension '%s': %s", extension_name.c_str(),
+                      error_out.c_str());
+              return std::nullopt;
+            }
+            descriptor.set_storage_intf(StorageInterface(*sd));
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          error_out = std::string("type storage refers to unknown type '") +
+                      sd->type_name + "'";
+          LogVSQL(ERROR_LEVEL, "Extension '%s': %s", extension_name.c_str(),
+                  error_out.c_str());
+          return std::nullopt;
+        }
+      }
+      break;
     }
   }
 

--- a/villagesql/veb/validate.h
+++ b/villagesql/veb/validate.h
@@ -14,10 +14,10 @@
  * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 
-// Validates a raw VEF ExtensionRegistration (ABI structs from a loaded .so)
+// Parses a raw VEF ExtensionRegistration (ABI structs from a loaded .so)
 // into a ValidatedRegistration containing typed C++ descriptors.
 //
-// validate_extension_registration() has no side effects and no dependency on
+// parse_extension_registration() has no side effects and no dependency on
 // the victionary or THD, making it independently testable.
 
 #ifndef VILLAGESQL_VEB_VALIDATE_H_
@@ -36,17 +36,18 @@ namespace veb {
 
 struct ExtensionRegistration;
 
-// The result of validating a raw ExtensionRegistration.
-// Contains validated, ready-to-register C++ descriptors for types and funcs.
+// The result of parsing a raw ExtensionRegistration.
+// Contains parsed, ready-to-register C++ descriptors for types and funcs.
 struct ValidatedRegistration {
   std::vector<TypeDescriptor> types;
   std::vector<FuncDescriptor> funcs;
 };
 
-// Validates the raw ABI registration and builds C++ descriptors.
+// Parses the raw ABI registration into C++ descriptors, including wiring
+// column storage interfaces into any types that register them.
 // No THD, no VictionaryClient — purely operates on the ExtensionRegistration.
 // Returns nullopt on error; error_out is set to a descriptive message.
-std::optional<ValidatedRegistration> validate_extension_registration(
+std::optional<ValidatedRegistration> parse_extension_registration(
     const ExtensionRegistration &ext_reg, const std::string &extension_name,
     const std::string &extension_version, std::string &error_out);
 

--- a/villagesql/veb/veb_file.cc
+++ b/villagesql/veb/veb_file.cc
@@ -675,10 +675,10 @@ bool load_installed_extensions(THD *thd) {
 
       std::string reg_error;
       std::optional<ValidatedRegistration> validated =
-          validate_extension_registration(registration, extension_name,
-                                          expected_version, reg_error);
+          parse_extension_registration(registration, extension_name,
+                                       expected_version, reg_error);
       if (!validated) {
-        LogVSQL(ERROR_LEVEL, "Failed to validate extension '%s': %s",
+        LogVSQL(ERROR_LEVEL, "Failed to parse extension '%s': %s",
                 extension_name.c_str(), reg_error.c_str());
         return true;
       }


### PR DESCRIPTION
Commit 736f6a7afca (sys var preview) accidentally deleted the block that wires vef_preview_column_store_ext_desc_t storage descriptors into TypeDescriptors during extension loading. It was swept out in the same diff hunk as the intentional removal of validate_sys_var_descriptors.

Without this code, storage_intf() is never set on any TypeDescriptor, so the ha_innodb.cc guard that blocks indexing on column-storage types never fires — allowing e.g. an SVECTOR primary key to be created silently.

Renames validate_extension_registration -> parse_extension_registration following the 'parse don't validate' principle: the function produces a fully-constructed ValidatedRegistration (including storage wiring), not just a boolean check. The name 'validate' implied read-only checking and obscured that storage wiring is an essential part of producing the result.

Also adds unit tests in validate-t.cc covering the wiring path so this can't regress undetected.
