### PR TITLE
varlen custom types

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_sp_custom_type_var_local.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_sp_custom_type_var_local.result
@@ -1,0 +1,13 @@
+INSTALL EXTENSION vsql_test_only;
+# Procedure with a single variable-length custom type local
+CREATE PROCEDURE p_varlen_local()
+BEGIN
+DECLARE v vsql_test_only.VARLEN_TEST;
+SELECT 1 AS ok;
+END//
+# CALL exercises sp_rcontext::init_var_table -> make_field
+CALL p_varlen_local();
+ok
+1
+DROP PROCEDURE p_varlen_local;
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/r/extension_varlen_custom_type_encode.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_varlen_custom_type_encode.result
@@ -1,0 +1,27 @@
+INSTALL EXTENSION vsql_test_only;
+# Regular table: INSERT exercises Field TypeEncoder
+CREATE TABLE t_varlen (v vsql_test_only.VARLEN_TEST);
+INSERT INTO t_varlen VALUES ('regular');
+SELECT v FROM t_varlen;
+v
+regular
+DROP TABLE t_varlen;
+# Temporary table: INSERT exercises temporary Field TypeEncoder
+CREATE TEMPORARY TABLE tmp_varlen (v vsql_test_only.VARLEN_TEST);
+INSERT INTO tmp_varlen VALUES ('temporary');
+SELECT v FROM tmp_varlen;
+v
+temporary
+DROP TEMPORARY TABLE tmp_varlen;
+# Stored procedure local: assignment exercises Item/Field encode path
+CREATE PROCEDURE p_varlen_assign()
+BEGIN
+DECLARE v vsql_test_only.VARLEN_TEST;
+SET v = 'procedure';
+SELECT v AS v;
+END//
+CALL p_varlen_assign();
+v
+procedure
+DROP PROCEDURE p_varlen_assign;
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/t/extension_sp_custom_type_var_local.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_sp_custom_type_var_local.test
@@ -1,0 +1,30 @@
+# Regression test for an assertion in make_field (sql/field.cc) that fired
+# when a stored procedure DECLAREs a local variable of a variable-length
+# custom type (persisted_length = -1).
+#
+# CALL on such a procedure triggers sp_rcontext::init_var_table ->
+# create_tmp_table_from_fields -> make_field, where the assertion
+#   f->field_length == create_field.custom_type_context->persisted_length()
+# failed because field_length is derived from max_display_width_in_bytes()
+# while the type's custom_type_context reports persisted_length = -1.
+#
+# Originally observed with the third-party vsql_roaring_bitmap extension's
+# ROARING64 type. Reproduced here with the in-tree vsql_test_only extension's
+# VARLEN_TEST type for regression coverage.
+
+INSTALL EXTENSION vsql_test_only;
+
+--echo # Procedure with a single variable-length custom type local
+delimiter //;
+CREATE PROCEDURE p_varlen_local()
+BEGIN
+  DECLARE v vsql_test_only.VARLEN_TEST;
+  SELECT 1 AS ok;
+END//
+delimiter ;//
+
+--echo # CALL exercises sp_rcontext::init_var_table -> make_field
+CALL p_varlen_local();
+
+DROP PROCEDURE p_varlen_local;
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/t/extension_varlen_custom_type_encode.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_varlen_custom_type_encode.test
@@ -1,0 +1,32 @@
+# Regression coverage for bare variable-length custom types reaching TypeEncoder
+# with persisted_length = -1. These cases must size the encode buffer from a
+# concrete storage cap, not from persisted_length.
+
+INSTALL EXTENSION vsql_test_only;
+
+--echo # Regular table: INSERT exercises Field TypeEncoder
+CREATE TABLE t_varlen (v vsql_test_only.VARLEN_TEST);
+INSERT INTO t_varlen VALUES ('regular');
+SELECT v FROM t_varlen;
+DROP TABLE t_varlen;
+
+--echo # Temporary table: INSERT exercises temporary Field TypeEncoder
+CREATE TEMPORARY TABLE tmp_varlen (v vsql_test_only.VARLEN_TEST);
+INSERT INTO tmp_varlen VALUES ('temporary');
+SELECT v FROM tmp_varlen;
+DROP TEMPORARY TABLE tmp_varlen;
+
+--echo # Stored procedure local: assignment exercises Item/Field encode path
+delimiter //;
+CREATE PROCEDURE p_varlen_assign()
+BEGIN
+  DECLARE v vsql_test_only.VARLEN_TEST;
+  SET v = 'procedure';
+  SELECT v AS v;
+END//
+delimiter ;//
+
+CALL p_varlen_assign();
+DROP PROCEDURE p_varlen_assign;
+
+UNINSTALL EXTENSION vsql_test_only;

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -9633,8 +9633,12 @@ Field *make_field(const Create_field &create_field, TABLE_SHARE *share,
       create_field.m_srid, create_field.is_array);
   if (f && create_field.custom_type_context) {
     f->set_type_context(create_field.custom_type_context);
-    assert(static_cast<int64_t>(f->field_length) ==
-           create_field.custom_type_context->persisted_length());
+    // For variable-length custom types (persisted_length == -1), the
+    // underlying VARCHAR's field_length is the declared storage cap, not
+    // persisted_length.
+    // For fixed-length types, field_length must equal persisted_length.
+    const int64_t pl = create_field.custom_type_context->persisted_length();
+    assert(pl == -1 || static_cast<int64_t>(f->field_length) == pl);
   }
   return f;
 }

--- a/villagesql/test-extensions/vsql-test-only/src/extension.cc
+++ b/villagesql/test-extensions/vsql-test-only/src/extension.cc
@@ -184,11 +184,10 @@ constexpr auto FAULT_BLOB = vsql::make_type<kFaultBlobTypeName>()
 
 // VARLEN_TEST: a minimal variable-length custom type (persisted_length == -1).
 // Stores the input string verbatim and echoes it back on decode. Used as the
-// smallest possible regression case for the make_field assertion that fired
-// when a variable-length custom type is used as a stored procedure local
-// variable.
+// smallest possible regression case for code paths that must treat
+// persisted_length == -1 as "variable length", not as a concrete storage size.
 
-constexpr int64_t kVarlenMaxLength = 65535;
+constexpr int64_t kVarlenMaxLength = 1024;
 
 void varlen_test_encode(std::string_view from, vsql::CustomResult out) {
   auto buf = out.buffer();

--- a/villagesql/test-extensions/vsql-test-only/src/extension.cc
+++ b/villagesql/test-extensions/vsql-test-only/src/extension.cc
@@ -50,6 +50,10 @@
 //
 //                 Any other input is rejected by encode with an assert-style
 //                 error, so tests cannot silently pass unexpected values.
+//
+//   VARLEN_TEST - A variable-length type that stores and decodes the input
+//                 string verbatim. Used for tests that need custom VARCHAR
+//                 storage without extension-specific semantics.
 
 #include <villagesql/vsql.h>
 
@@ -178,6 +182,50 @@ constexpr auto FAULT_BLOB = vsql::make_type<kFaultBlobTypeName>()
                                 .compare<&fault_blob_compare>()
                                 .build();
 
+// VARLEN_TEST: a minimal variable-length custom type (persisted_length == -1).
+// Stores the input string verbatim and echoes it back on decode. Used as the
+// smallest possible regression case for the make_field assertion that fired
+// when a variable-length custom type is used as a stored procedure local
+// variable.
+
+constexpr int64_t kVarlenMaxLength = 65535;
+
+void varlen_test_encode(std::string_view from, vsql::CustomResult out) {
+  auto buf = out.buffer();
+  if (from.size() > buf.size()) return;  // input too long
+  memcpy(buf.data(), from.data(), from.size());
+  out.set_length(static_cast<int64_t>(from.size()));
+}
+
+void varlen_test_decode(vsql::CustomArg in, vsql::StringResult out) {
+  auto data = in.value();
+  auto buf = out.buffer();
+  if (buf.size() < data.size()) return;
+  memcpy(buf.data(), data.data(), data.size());
+  out.set_length(data.size());
+}
+
+int varlen_test_compare(vsql::CustomArg a, vsql::CustomArg b) {
+  auto va = a.value();
+  auto vb = b.value();
+  size_t cmp_len = va.size() < vb.size() ? va.size() : vb.size();
+  int r = memcmp(va.data(), vb.data(), cmp_len);
+  if (r != 0) return r;
+  if (va.size() < vb.size()) return -1;
+  if (va.size() > vb.size()) return 1;
+  return 0;
+}
+
+static constexpr const char kVarlenTestTypeName[] = "VARLEN_TEST";
+
+constexpr auto VARLEN_TEST = vsql::make_type<kVarlenTestTypeName>()
+                                 .persisted_length(-1)
+                                 .max_decode_buffer_length(kVarlenMaxLength)
+                                 .from_string<&varlen_test_encode>()
+                                 .to_string<&varlen_test_decode>()
+                                 .compare<&varlen_test_compare>()
+                                 .build();
+
 using namespace vsql;
 
 VEF_GENERATE_ENTRY_POINTS(
@@ -185,6 +233,9 @@ VEF_GENERATE_ENTRY_POINTS(
         // FAULT_BLOB type: behaviour controlled by
         // "OK"/"DECODE_FAIL"/"ENCODE_FAIL" prefix
         .type(FAULT_BLOB)
+        // VARLEN_TEST: minimal variable-length custom type for regression
+        // testing variable-length code paths.
+        .type(VARLEN_TEST)
         // Test VDF: exercises VEF_RESULT_WARNING vs VEF_RESULT_ERROR
         .func(make_func<&test_result_kind>("test_result_kind")
                   .returns(INT)

--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -88,8 +88,16 @@ class PT_custom_type : public PT_type {
     // persisted_length. For fixed-length types this comes from the descriptor.
     // For variable-length types with parameters, this was computed by
     // resolve_params at TypeContext construction time.
+    //
+    // For variable-length types whose persisted length remains -1, fall back
+    // to the context's max_decode_buffer_length so the underlying VARCHAR
+    // storage has a declared cap. The Field's field_length will reflect this
+    // cap rather than persisted_length == -1.
     if (nullptr == length_spec) {
       int64_t len = type_context->persisted_length();
+      if (len == -1) {
+        len = type_context->max_decode_buffer_length();
+      }
       if (len > 0) {
         snprintf(length_buffer, sizeof(length_buffer), "%" PRId64, len);
         length_spec = length_buffer;
@@ -209,6 +217,8 @@ class PT_custom_type : public PT_type {
                                qname.c_str());
           return nullptr;
         }
+        // Variable-length type without explicit length: the constructor uses
+        // max_decode_buffer_length as the underlying VARCHAR cap.
       }
     }
 

--- a/villagesql/types/type_encoder.cc
+++ b/villagesql/types/type_encoder.cc
@@ -28,9 +28,9 @@
 
 namespace villagesql {
 
-TypeEncoder::TypeEncoder(const TypeContext *tc, MEM_ROOT &mem_root)
-    : mem_root_(&mem_root),
-      buffer_size_(static_cast<size_t>(tc->persisted_length())) {
+TypeEncoder::TypeEncoder(const TypeContext *tc, MEM_ROOT &mem_root,
+                         size_t buffer_size)
+    : mem_root_(&mem_root), buffer_size_(buffer_size) {
   assert(tc != nullptr);
   assert(buffer_size_ > 0);
 

--- a/villagesql/types/type_encoder.h
+++ b/villagesql/types/type_encoder.h
@@ -33,8 +33,8 @@ namespace villagesql {
 // from the owning object's mem_root on first encode and reused for all
 // subsequent encodes within the same lifetime.
 //
-// It pre-allocates a scratch buffer (persisted_length bytes) and a String
-// wrapper once, eliminating per-row allocations during INSERT/UPDATE.
+// It pre-allocates a scratch buffer sized by the caller and a String wrapper
+// once, eliminating per-row allocations during INSERT/UPDATE.
 //
 // For regular-table Fields the buffer is owned by TABLE::mem_root and freed
 // when the TABLE is evicted. For tmp-table Fields it is owned by
@@ -50,7 +50,7 @@ class TypeEncoder {
  public:
   // Construct from mem_root: pre-fills VDF/fn_ state. Does not allocate the
   // encode buffer; call Init() before encode(). mem_root must outlive this.
-  TypeEncoder(const TypeContext *tc, MEM_ROOT &mem_root);
+  TypeEncoder(const TypeContext *tc, MEM_ROOT &mem_root, size_t buffer_size);
 
   // Allocate the encode buffer from mem_root_. Must be called once before
   // encode(). On OOM calls my_error and returns true.
@@ -72,7 +72,7 @@ class TypeEncoder {
  private:
   MEM_ROOT *mem_root_{nullptr};  // owning mem_root, used for overflow growth
   char *buffer_{nullptr};        // pre-allocated from mem_root_
-  size_t buffer_size_{0};        // = tc->persisted_length()
+  size_t buffer_size_{0};
   String result_;                // reused String wrapper pointing into buffer_
 
   // Overflow path: reused when VDF output exceeds buffer_size_ (rare).

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -311,7 +311,15 @@ static TypeEncoder *GetTypeEncoderFor(Field *field) {
     MEM_ROOT &mem_root = (field->table->s->tmp_table == NO_TMP_TABLE)
                              ? field->table->mem_root
                              : field->table->s->mem_root;
-    encoder = new (&mem_root) TypeEncoder(field->get_type_context(), mem_root);
+    const TypeContext *tc = field->get_type_context();
+    const int64_t persisted_length = tc->persisted_length();
+    // For bare variable-length custom types, persisted_length == -1 and the
+    // concrete storage cap lives on the underlying VARCHAR Field.
+    const size_t buffer_size = persisted_length > 0
+                                   ? static_cast<size_t>(persisted_length)
+                                   : field->field_length;
+    assert(buffer_size > 0);
+    encoder = new (&mem_root) TypeEncoder(tc, mem_root, buffer_size);
     if (encoder == nullptr) {
       my_error(ER_OUTOFMEMORY, MYF(ME_FATALERROR), sizeof(TypeEncoder));
       return nullptr;
@@ -330,8 +338,18 @@ static TypeEncoder *GetTypeEncoderFor(Field *field) {
 static TypeEncoder *GetTypeEncoderFor(Item *item) {
   TypeEncoder *encoder = item->get_type_encoder();
   if (encoder == nullptr) {
+    const TypeContext *tc = item->get_type_context();
+    const int64_t persisted_length = tc->persisted_length();
+    const int64_t max_decode_buffer_length = tc->max_decode_buffer_length();
+    assert(persisted_length > 0 || max_decode_buffer_length > 0);
+    // Items have no Field storage cap, so bare variable-length custom types use
+    // the existing max_decode_buffer_length bound as their encode buffer cap.
+    const size_t buffer_size =
+        persisted_length > 0 ? static_cast<size_t>(persisted_length)
+                             : static_cast<size_t>(max_decode_buffer_length);
+    assert(buffer_size > 0);
     encoder = new (current_thd->mem_root)
-        TypeEncoder(item->get_type_context(), *current_thd->mem_root);
+        TypeEncoder(tc, *current_thd->mem_root, buffer_size);
     if (encoder == nullptr) {
       my_error(ER_OUTOFMEMORY, MYF(ME_FATALERROR), sizeof(TypeEncoder));
       return nullptr;
@@ -811,10 +829,10 @@ void CopyCustomToCustomField(const Field *from, Field *to) {
     int2store(to_ptr, static_cast<uint16>(data_len));
   }
 
-  // Ensure data fits in destination field. Compatible TypeContexts share the
-  // same persisted_length (parameters are part of the key), so from and to
-  // have matching field_length, and data_len <= from->field_length holds by
-  // construction.
+  // Ensure data fits in destination field. Compatible TypeContexts have the
+  // same type key (including parameters); for fixed-size types this implies the
+  // same persisted length, and for bare variable-length types both Fields use
+  // the same declared storage cap.
   assert(data_len <= to->field_length);
   // Copy the binary data
   memcpy(to_ptr + to_length_bytes, from_data, data_len);

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -77,9 +77,14 @@ static const char *ER_INCOMPATIBLE_TYPES =
     "Cannot compare values of incompatible types '%s' and '%s'";
 
 // Verify that the Field's storage length matches the TypeContext's
-// persisted_length.
+// persisted_length. Variable-length custom types (persisted_length == -1)
+// piggyback on the underlying VARCHAR storage and have field_length set to a
+// declared cap, so the equality check does not apply to them.
 static bool CheckFieldLengthMatchesType(const Field *field,
                                         const TypeContext *tc) {
+  if (tc->persisted_length() == -1) {
+    return false;
+  }
   if (should_assert_if_false(static_cast<int64_t>(field->field_length) ==
                              tc->persisted_length())) {
     LogVSQL(ERROR_LEVEL,


### PR DESCRIPTION
  Variable-length custom types use persisted_length() == -1 to mean “not fixed-size”. Several paths were incorrectly treating that sentinel as a concrete storage length.

  The original failure showed up with stored procedure locals because they are materialized through:

  sp_rcontext::init_var_table -> create_tmp_table_from_fields -> make_field

  For a variable-length custom type, make_field() was asserting:

  f->field_length == custom_type_context->persisted_length()

  That is wrong. The backing MySQL field is a VARCHAR, so field_length is the declared storage cap, while persisted_length() intentionally remains -1.

  The same conceptual issue also affected encode paths. TypeEncoder sized its scratch buffer from persisted_length(), which turns -1 into an invalid concrete size. For bare variable-length types, encode needs to
  use an existing concrete cap instead.

  The fix:

  assert(pl == -1 || static_cast<int64_t>(f->field_length) == pl);

  CheckFieldLengthMatchesType() also skips the equality check for persisted_length() == -1.

  PT_custom_type now gives bare variable-length custom types an underlying VARCHAR length from TypeContext::max_decode_buffer_length(), so fields have a declared storage cap even when persisted_length() remains -1.

  TypeEncoder no longer derives its buffer size directly from persisted_length(). The caller provides the encode buffer size:

  - Field encode path uses positive persisted_length(), otherwise the field’s declared field_length.
  - Item encode path uses positive persisted_length(), otherwise max_decode_buffer_length().

  For regression coverage, the staged changes add VARLEN_TEST to vsql_test_only, a minimal variable-length custom type, plus tests for:

  - declaring a variable-length custom type as a stored procedure local,
  - inserting into a regular table column,
  - inserting into a temporary table column,
  - assigning/selecting a stored procedure local variable.
