### PR TITLE
cla: don't fire for org members

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,7 +1,17 @@
+# Verifies contributors have signed the CLA before their PR can be merged.
+#
+# The "CLAAssistant" job is a required status check on main (see repo ruleset).
+# Because it's required, the job must ALWAYS run and report success — we
+# cannot skip the job at the job level, or the required check never reports
+# and merges are blocked. Instead, we run the job unconditionally and use
+# step-level `if:` to choose between a no-op step and the real CLA check.
 name: "CLA Assistant"
 on:
+  # Fires on every comment in the repo. We filter inside the job because the
+  # contributor-assistant action uses comment bodies as signing/recheck signals.
   issue_comment:
     types: [created]
+  # Fires when a PR is opened/updated/closed. This is when we verify CLA status.
   pull_request_target:
     types: [opened, closed, synchronize]
 
@@ -14,15 +24,33 @@ permissions:
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
-    if: >
-      !contains(github.event.pull_request.labels.*.name, 'upstream-merge') &&
-      !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     steps:
+      # No-op step that runs when the PR doesn't need a CLA check:
+      #   - `upstream-merge` label: PRs that bring in vanilla MySQL changes
+      #   - OWNER / MEMBER / COLLABORATOR: people with repo access already
+      #     covered by org-level agreements
+      # When this step runs, the required `CLAAssistant` check reports success
+      # without consulting the CLA signatures.
+      - name: "Skip CLA check (upstream-merge or org member)"
+        if: >
+          contains(github.event.pull_request.labels.*.name, 'upstream-merge') ||
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+        run: echo "CLA check not required for this PR"
+      # Real CLA verification. Runs only when:
+      #   - the PR is NOT exempt (inverse of the skip step above), AND
+      #   - the triggering event is one the action knows how to handle:
+      #       * `pull_request_target`: PR opened/updated/closed — verify status
+      #       * comment containing "recheck": manual re-trigger after signing
+      #       * comment with the exact signing phrase: record a new signature
+      # On a random issue comment with neither phrase, both steps skip and the
+      # job still finishes successfully (no failed step).
       - name: "CLA Assistant"
         if: >
-          (contains(github.event.comment.body, 'recheck') ||
-           contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')) ||
-          github.event_name == 'pull_request_target'
+          !contains(github.event.pull_request.labels.*.name, 'upstream-merge') &&
+          !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
+          ((contains(github.event.comment.body, 'recheck') ||
+            contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')) ||
+           github.event_name == 'pull_request_target')
         uses: contributor-assistant/github-action@v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -14,7 +14,9 @@ permissions:
 jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
-    if: "!contains(github.event.pull_request.labels.*.name, 'upstream-merge')"
+    if: >
+      !contains(github.event.pull_request.labels.*.name, 'upstream-merge') &&
+      !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
     steps:
       - name: "CLA Assistant"
         if: >


### PR DESCRIPTION
## Description

Don't fire the CLA for org members.

(slight caveat: only public org members, so users have to set their org membership to public)