### PR TITLE
sdk: typed prerun/postrun

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_simple_type_usage.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_simple_type_usage.result
@@ -79,7 +79,7 @@ ERROR HY000: Cannot initialize function 'ba_concat': wrong number of arguments (
 SELECT vsql_simple.ba_concat_all(t.data) AS one
 FROM test_bytearray t WHERE t.id = 1;
 one
-hello
+hello   
 SELECT vsql_simple.ba_concat_all(t1.data, t2.data, t3.data) AS three
 FROM test_bytearray t1, test_bytearray t2, test_bytearray t3
 WHERE t1.id = 1 AND t2.id = 2 AND t3.id = 3;

--- a/mysql-test/suite/villagesql/extension/r/extension_simple_type_usage.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_simple_type_usage.result
@@ -79,7 +79,7 @@ ERROR HY000: Cannot initialize function 'ba_concat': wrong number of arguments (
 SELECT vsql_simple.ba_concat_all(t.data) AS one
 FROM test_bytearray t WHERE t.id = 1;
 one
-hello   
+hello
 SELECT vsql_simple.ba_concat_all(t1.data, t2.data, t3.data) AS three
 FROM test_bytearray t1, test_bytearray t2, test_bytearray t3
 WHERE t1.id = 1 AND t2.id = 2 AND t3.id = 3;
@@ -108,6 +108,12 @@ SELECT vsql_simple.ba_concat_all(t1.data, 'abc') AS with_str
 FROM test_bytearray t1 WHERE t1.id = 1;
 with_str
 NULL
+# Test ba_call_index (exercises typed prerun/postrun + state-passing VDF)
+SELECT vsql_simple.ba_call_index() as idx FROM test_bytearray ORDER BY id;
+idx
+1
+2
+3
 # Clean up
 DROP TABLE test_bytearray;
 # Uninstall the extension

--- a/mysql-test/suite/villagesql/extension/r/extension_vdf_state_writeback.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_vdf_state_writeback.result
@@ -1,0 +1,23 @@
+# restart: --veb-dir=MYSQLTEST_VARDIR/veb
+Creating extension test_state_writeback using SDK...
+Created test_state_writeback.veb
+INSTALL EXTENSION test_state_writeback;
+CREATE TABLE seq (id INT PRIMARY KEY, s VARCHAR(8));
+INSERT INTO seq VALUES (1, 'a'), (2, 'b'), (3, 'c');
+# By-value: every row reads user_data == nullptr (the prerun value),
+# emits NULL, then leaks its malloc'd buffer when the assignment
+# back into the local `void* user_data` parameter is dropped.
+SELECT id, s, test_state_writeback.previous_byval(s) AS prev FROM seq ORDER BY id;
+id	s	prev
+1	a	NULL
+2	b	NULL
+3	c	NULL
+# By-reference: assignment in the VDF body writes args->user_data
+# so the next row sees the cached pointer. Expected: NULL, 'a', 'b'.
+SELECT id, s, test_state_writeback.previous_byref(s) AS prev FROM seq ORDER BY id;
+id	s	prev
+1	a	NULL
+2	b	a
+3	c	b
+DROP TABLE seq;
+UNINSTALL EXTENSION test_state_writeback;

--- a/mysql-test/suite/villagesql/extension/r/extension_vdf_state_writeback.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_vdf_state_writeback.result
@@ -2,22 +2,24 @@
 Creating extension test_state_writeback using SDK...
 Created test_state_writeback.veb
 INSTALL EXTENSION test_state_writeback;
-CREATE TABLE seq (id INT PRIMARY KEY, s VARCHAR(8));
-INSERT INTO seq VALUES (1, 'a'), (2, 'b'), (3, 'c');
-# By-value: every row reads user_data == nullptr (the prerun value),
-# emits NULL, then leaks its malloc'd buffer when the assignment
-# back into the local `void* user_data` parameter is dropped.
-SELECT id, s, test_state_writeback.previous_byval(s) AS prev FROM seq ORDER BY id;
+CREATE TABLE seq (id INT PRIMARY KEY, s VARCHAR(16));
+INSERT INTO seq VALUES
+(1, 'a'),
+(2, 'bb'),
+(3, 'ccc'),
+(4, 'dd'),
+(5, 'ee'),
+(6, 'ffffffff');
+# First row prev is NULL; later rows reflect prior s.
+# Rows 4-5 reuse the same buffer (shorter than capacity);
+# row 6 reallocs because 'ffffffff' doesn't fit.
+SELECT id, s, test_state_writeback.previous(s) AS prev FROM seq ORDER BY id;
 id	s	prev
 1	a	NULL
-2	b	NULL
-3	c	NULL
-# By-reference: assignment in the VDF body writes args->user_data
-# so the next row sees the cached pointer. Expected: NULL, 'a', 'b'.
-SELECT id, s, test_state_writeback.previous_byref(s) AS prev FROM seq ORDER BY id;
-id	s	prev
-1	a	NULL
-2	b	a
-3	c	b
+2	bb	a
+3	ccc	bb
+4	dd	ccc
+5	ee	dd
+6	ffffffff	ee
 DROP TABLE seq;
 UNINSTALL EXTENSION test_state_writeback;

--- a/mysql-test/suite/villagesql/extension/t/extension_simple_type_usage.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_simple_type_usage.test
@@ -79,6 +79,9 @@ FROM test_bytearray t1 WHERE t1.id = 1;
 SELECT vsql_simple.ba_concat_all(t1.data, 'abc') AS with_str
 FROM test_bytearray t1 WHERE t1.id = 1;
 
+--echo # Test ba_call_index (exercises typed prerun/postrun + state-passing VDF)
+SELECT vsql_simple.ba_call_index() as idx FROM test_bytearray ORDER BY id;
+
 --echo # Clean up
 DROP TABLE test_bytearray;
 

--- a/mysql-test/suite/villagesql/extension/t/extension_vdf_state_writeback.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_vdf_state_writeback.test
@@ -1,19 +1,10 @@
-# Compares two VDF shapes that manage per-statement scratch via the typed
-# prerun/postrun + user_data slot (#551):
+# previous(s) returns the s passed to the previous row (or NULL on the
+# first row). Implemented via the typed prerun/postrun + `void*&` user_data
+# slot (WrapperVoidStarRefState) introduced in #551.
 #
-#   previous_byval(s)  -> first parameter `void* user_data`
-#                         passes the slot value as a copy. Assignment
-#                         inside the body is local. Demonstrates the
-#                         writeback gap on the existing wrapper.
-#
-#   previous_byref(s)  -> first parameter `void*& user_data`
-#                         binds args->user_data by reference (routes
-#                         through WrapperVoidStarState). Assignment in
-#                         the body survives across rows and postrun
-#                         frees the final allocation.
-#
-# Both VDFs are meant to compute the "lag" of `s`: the previous row's
-# value, or NULL on the first row.
+# The VDF mallocs storage on first need, reuses it when subsequent strings
+# fit, and reallocates when a longer string arrives. Postrun frees the
+# final buffer.
 
 # Setup VEB directory for testing
 --let $veb_dir = $MYSQLTEST_VARDIR/veb
@@ -29,17 +20,19 @@
 
 INSTALL EXTENSION test_state_writeback;
 
-CREATE TABLE seq (id INT PRIMARY KEY, s VARCHAR(8));
-INSERT INTO seq VALUES (1, 'a'), (2, 'b'), (3, 'c');
+CREATE TABLE seq (id INT PRIMARY KEY, s VARCHAR(16));
+INSERT INTO seq VALUES
+  (1, 'a'),
+  (2, 'bb'),
+  (3, 'ccc'),
+  (4, 'dd'),
+  (5, 'ee'),
+  (6, 'ffffffff');
 
---echo # By-value: every row reads user_data == nullptr (the prerun value),
---echo # emits NULL, then leaks its malloc'd buffer when the assignment
---echo # back into the local `void* user_data` parameter is dropped.
-SELECT id, s, test_state_writeback.previous_byval(s) AS prev FROM seq ORDER BY id;
-
---echo # By-reference: assignment in the VDF body writes args->user_data
---echo # so the next row sees the cached pointer. Expected: NULL, 'a', 'b'.
-SELECT id, s, test_state_writeback.previous_byref(s) AS prev FROM seq ORDER BY id;
+--echo # First row prev is NULL; later rows reflect prior s.
+--echo # Rows 4-5 reuse the same buffer (shorter than capacity);
+--echo # row 6 reallocs because 'ffffffff' doesn't fit.
+SELECT id, s, test_state_writeback.previous(s) AS prev FROM seq ORDER BY id;
 
 DROP TABLE seq;
 UNINSTALL EXTENSION test_state_writeback;

--- a/mysql-test/suite/villagesql/extension/t/extension_vdf_state_writeback.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_vdf_state_writeback.test
@@ -1,0 +1,45 @@
+# Compares two VDF shapes that manage per-statement scratch via the typed
+# prerun/postrun + user_data slot (#551):
+#
+#   previous_byval(s)  -> first parameter `void* user_data`
+#                         passes the slot value as a copy. Assignment
+#                         inside the body is local. Demonstrates the
+#                         writeback gap on the existing wrapper.
+#
+#   previous_byref(s)  -> first parameter `void*& user_data`
+#                         binds args->user_data by reference (routes
+#                         through WrapperVoidStarState). Assignment in
+#                         the body survives across rows and postrun
+#                         frees the final allocation.
+#
+# Both VDFs are meant to compute the "lag" of `s`: the previous row's
+# value, or NULL on the first row.
+
+# Setup VEB directory for testing
+--let $veb_dir = $MYSQLTEST_VARDIR/veb
+--exec mkdir -p $veb_dir
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--let $restart_parameters = restart: --veb-dir=$veb_dir
+--source include/restart_mysqld.inc
+
+--let $extension_name = test_state_writeback
+--let $extension_version = 1.0.0
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/state_writeback_vdf.cc
+--source include/villagesql/create_extension_sdk.inc
+
+INSTALL EXTENSION test_state_writeback;
+
+CREATE TABLE seq (id INT PRIMARY KEY, s VARCHAR(8));
+INSERT INTO seq VALUES (1, 'a'), (2, 'b'), (3, 'c');
+
+--echo # By-value: every row reads user_data == nullptr (the prerun value),
+--echo # emits NULL, then leaks its malloc'd buffer when the assignment
+--echo # back into the local `void* user_data` parameter is dropped.
+SELECT id, s, test_state_writeback.previous_byval(s) AS prev FROM seq ORDER BY id;
+
+--echo # By-reference: assignment in the VDF body writes args->user_data
+--echo # so the next row sees the cached pointer. Expected: NULL, 'a', 'b'.
+SELECT id, s, test_state_writeback.previous_byref(s) AS prev FROM seq ORDER BY id;
+
+DROP TABLE seq;
+UNINSTALL EXTENSION test_state_writeback;

--- a/mysql-test/suite/villagesql/std_data/state_writeback_vdf.cc
+++ b/mysql-test/suite/villagesql/std_data/state_writeback_vdf.cc
@@ -1,0 +1,99 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Test-only extension demonstrating the difference between the by-value
+// (`void*`) and by-reference (`void*&`) user_data wrappers introduced by
+// the typed prerun/postrun API (PR #551).
+//
+// Both VDFs implement the same "lag" function: previous(s) returns the
+// s passed on the prior row, or NULL on the first row. Storage is a
+// malloc'd buffer holding [size_t length][bytes].
+//
+//   previous_byval(s):  declares `void* user_data` — pointer is copied
+//                       in, assignment inside the body is local.
+//                       Expected: NULL on every row, buffers leaked.
+//
+//   previous_byref(s):  declares `void*& user_data` — routes through
+//                       WrapperVoidStarState so assignments survive
+//                       across rows and postrun frees the final buffer.
+//                       Expected: NULL, then the prior s.
+
+#include <villagesql/vsql.h>
+
+#include <cstdlib>
+#include <cstring>
+
+using namespace vsql;
+
+static void common_prerun(PrerunArgs, PrerunResult out) {
+  out.set_user_data(nullptr);
+}
+
+static void common_postrun(PostrunArgs args) { std::free(args.user_data()); }
+
+// Helper: pop the stored previous string out (or set null), then malloc
+// a new buffer holding `s` and return it. Returns the pointer the caller
+// should stash into the user_data slot.
+static void *emit_prev_and_stash(void *prev, StringArg s, StringResult out) {
+  if (prev == nullptr) {
+    out.set_null();
+  } else {
+    size_t len;
+    std::memcpy(&len, prev, sizeof(len));
+    const char *bytes = static_cast<const char *>(prev) + sizeof(len);
+    out.set(std::string_view(bytes, len));
+    std::free(prev);
+  }
+  if (s.is_null()) return nullptr;
+  auto sv = s.value();
+  size_t k = sizeof(size_t);
+  void *p = std::malloc(k + sv.size());
+  size_t len = sv.size();
+  std::memcpy(p, &len, k);
+  std::memcpy(static_cast<char *>(p) + k, sv.data(), sv.size());
+  return p;
+}
+
+// By-value: user_data is passed as a copy. Assignment is local. Every
+// row sees nullptr (the prerun value); the malloc'd buffer is leaked.
+void previous_byval(void *user_data, StringArg s, StringResult out) {
+  user_data = emit_prev_and_stash(user_data, s, out);
+  (void)user_data;  // assignment is local; writeback does not persist
+}
+
+// By-reference: user_data is passed as `void*&` and binds to the slot
+// directly. The body's assignment updates args->user_data, so subsequent
+// rows read the cached pointer and postrun frees the final allocation.
+void previous_byref(void *&user_data, StringArg s, StringResult out) {
+  user_data = emit_prev_and_stash(user_data, s, out);
+}
+
+VEF_GENERATE_ENTRY_POINTS(
+    make_extension()
+        .func(make_func<&previous_byval>("previous_byval")
+                  .returns(STRING)
+                  .param(STRING)
+                  .buffer_size(1024)
+                  .prerun<&common_prerun>()
+                  .postrun<&common_postrun>()
+                  .build())
+        .func(make_func<&previous_byref>("previous_byref")
+                  .returns(STRING)
+                  .param(STRING)
+                  .buffer_size(1024)
+                  .prerun<&common_prerun>()
+                  .postrun<&common_postrun>()
+                  .build()))

--- a/mysql-test/suite/villagesql/std_data/state_writeback_vdf.cc
+++ b/mysql-test/suite/villagesql/std_data/state_writeback_vdf.cc
@@ -14,22 +14,15 @@
  * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 
-// Test-only extension demonstrating the difference between the by-value
-// (`void*`) and by-reference (`void*&`) user_data wrappers introduced by
-// the typed prerun/postrun API (PR #551).
+// Test-only extension demonstrating the typed prerun/postrun + `void*&`
+// user_data slot (WrapperVoidStarRefState) from PR #551.
 //
-// Both VDFs implement the same "lag" function: previous(s) returns the
-// s passed on the prior row, or NULL on the first row. Storage is a
-// malloc'd buffer holding [size_t length][bytes].
-//
-//   previous_byval(s):  declares `void* user_data` — pointer is copied
-//                       in, assignment inside the body is local.
-//                       Expected: NULL on every row, buffers leaked.
-//
-//   previous_byref(s):  declares `void*& user_data` — routes through
-//                       WrapperVoidStarState so assignments survive
-//                       across rows and postrun frees the final buffer.
-//                       Expected: NULL, then the prior s.
+// previous(s) returns the s passed to the previous row, or NULL on the
+// first row. Storage is a malloc'd buffer laid out as:
+//   [size_t capacity][size_t length][capacity bytes of payload]
+// capacity is the payload bytes currently available; length is how many
+// of those are in use. When a longer string arrives we free the buffer
+// and malloc a new one; shorter strings reuse the existing allocation.
 
 #include <villagesql/vsql.h>
 
@@ -38,62 +31,53 @@
 
 using namespace vsql;
 
-static void common_prerun(PrerunArgs, PrerunResult out) {
+struct Hdr {
+  size_t capacity;
+  size_t length;
+};
+
+static void previous_prerun(PrerunArgs, PrerunResult out) {
   out.set_user_data(nullptr);
 }
 
-static void common_postrun(PostrunArgs args) { std::free(args.user_data()); }
-
-// Helper: pop the stored previous string out (or set null), then malloc
-// a new buffer holding `s` and return it. Returns the pointer the caller
-// should stash into the user_data slot.
-static void *emit_prev_and_stash(void *prev, StringArg s, StringResult out) {
-  if (prev == nullptr) {
-    out.set_null();
+void previous_vdf(void *&user_data, StringArg s, StringResult out) {
+  // Emit the previous value, if any.
+  if (user_data != nullptr) {
+    auto *hdr = static_cast<Hdr *>(user_data);
+    const char *bytes = reinterpret_cast<const char *>(hdr) + sizeof(Hdr);
+    out.set(std::string_view(bytes, hdr->length));
   } else {
-    size_t len;
-    std::memcpy(&len, prev, sizeof(len));
-    const char *bytes = static_cast<const char *>(prev) + sizeof(len);
-    out.set(std::string_view(bytes, len));
-    std::free(prev);
+    out.set_null();
   }
-  if (s.is_null()) return nullptr;
+
+  // Stash the current row's value for the next call. A NULL input clears
+  // the slot (and frees any buffer we were carrying).
+  if (s.is_null()) {
+    std::free(user_data);
+    user_data = nullptr;
+    return;
+  }
+
   auto sv = s.value();
-  size_t k = sizeof(size_t);
-  void *p = std::malloc(k + sv.size());
-  size_t len = sv.size();
-  std::memcpy(p, &len, k);
-  std::memcpy(static_cast<char *>(p) + k, sv.data(), sv.size());
-  return p;
+  size_t needed = sv.size();
+  auto *hdr = static_cast<Hdr *>(user_data);
+  if (hdr == nullptr || hdr->capacity < needed) {
+    std::free(user_data);
+    hdr = static_cast<Hdr *>(std::malloc(sizeof(Hdr) + needed));
+    hdr->capacity = needed;
+  }
+  hdr->length = needed;
+  std::memcpy(reinterpret_cast<char *>(hdr) + sizeof(Hdr), sv.data(), needed);
+  user_data = hdr;
 }
 
-// By-value: user_data is passed as a copy. Assignment is local. Every
-// row sees nullptr (the prerun value); the malloc'd buffer is leaked.
-void previous_byval(void *user_data, StringArg s, StringResult out) {
-  user_data = emit_prev_and_stash(user_data, s, out);
-  (void)user_data;  // assignment is local; writeback does not persist
-}
-
-// By-reference: user_data is passed as `void*&` and binds to the slot
-// directly. The body's assignment updates args->user_data, so subsequent
-// rows read the cached pointer and postrun frees the final allocation.
-void previous_byref(void *&user_data, StringArg s, StringResult out) {
-  user_data = emit_prev_and_stash(user_data, s, out);
-}
+static void previous_postrun(PostrunArgs args) { std::free(args.user_data()); }
 
 VEF_GENERATE_ENTRY_POINTS(
-    make_extension()
-        .func(make_func<&previous_byval>("previous_byval")
-                  .returns(STRING)
-                  .param(STRING)
-                  .buffer_size(1024)
-                  .prerun<&common_prerun>()
-                  .postrun<&common_postrun>()
-                  .build())
-        .func(make_func<&previous_byref>("previous_byref")
-                  .returns(STRING)
-                  .param(STRING)
-                  .buffer_size(1024)
-                  .prerun<&common_prerun>()
-                  .postrun<&common_postrun>()
-                  .build()))
+    make_extension().func(make_func<&previous_vdf>("previous")
+                              .returns(STRING)
+                              .param(STRING)
+                              .buffer_size(1024)
+                              .prerun<&previous_prerun>()
+                              .postrun<&previous_postrun>()
+                              .build()))

--- a/villagesql/examples/vsql-simple/src/extension.cc
+++ b/villagesql/examples/vsql-simple/src/extension.cc
@@ -112,6 +112,28 @@ void odd_chars(CustomArg in, CustomResult out) {
   out.set_length(kBytearrayLen);
 }
 
+// BA_CALL_INDEX: return the 1-based index of this call within the current
+// statement. Demonstrates the typed prerun/postrun + State& pattern: prerun
+// allocates a counter, each row reads-and-increments via the VDF's State&
+// first parameter, and postrun frees.
+
+struct CallCounter {
+  long long n = 0;
+};
+
+void ba_call_index_prerun(PrerunArgs, PrerunResult out) {
+  out.set_user_data(new CallCounter{});
+}
+
+void ba_call_index(CallCounter &state, IntResult out) {
+  state.n++;
+  out.set(state.n);
+}
+
+void ba_call_index_postrun(PostrunArgs args) {
+  args.delete_state<CallCounter>();
+}
+
 // BA_CONCAT: concatenate two bytearrays (returns STRING with 16 bytes)
 void ba_concat(CustomArg a, CustomArg b, StringResult out) {
   if (a.is_null() || b.is_null()) {
@@ -204,6 +226,12 @@ VEF_GENERATE_ENTRY_POINTS(
                   .returns(STRING)
                   .param(BYTEARRAY)
                   .param(BYTEARRAY)
+                  .build())
+        .func(make_func<&ba_call_index>("ba_call_index")
+                  .returns(INT)
+                  .param()
+                  .prerun<&ba_call_index_prerun>()
+                  .postrun<&ba_call_index_postrun>()
                   .build())
         .func(make_func<&ba_len>("ba_len").returns(INT).param().build())
         .func(make_func<&ba_concat_all>("ba_concat_all")

--- a/villagesql/examples/vsql-simple/src/extension.cc
+++ b/villagesql/examples/vsql-simple/src/extension.cc
@@ -158,24 +158,20 @@ void ba_len(IntResult out) { out.set(static_cast<long long>(kBytearrayLen)); }
 // Prerun: validate that all arguments are BYTEARRAY (or NULL literals,
 // which appear as VEF_TYPE_STRING in the prerun arg-type array) and ask
 // the server to allocate arg_count * kBytearrayLen bytes of result buffer.
-void ba_concat_all_prerun(vef_context_t *, vef_prerun_args_t *args,
-                          vef_prerun_result_t *result) {
-  if (args->arg_count == 0) {
-    result->type = VEF_RESULT_ERROR;
-    snprintf(result->error_msg, VEF_MAX_ERROR_LEN,
-             "ba_concat_all requires at least one argument");
+void ba_concat_all_prerun(vsql::PrerunArgs args, vsql::PrerunResult out) {
+  if (args.size() == 0) {
+    out.error("ba_concat_all requires at least one argument");
     return;
   }
-  for (unsigned int i = 0; i < args->arg_count; i++) {
-    vef_type_id id = args->arg_types[i].id;
-    if (id != VEF_TYPE_CUSTOM && id != VEF_TYPE_STRING) {
-      result->type = VEF_RESULT_ERROR;
-      snprintf(result->error_msg, VEF_MAX_ERROR_LEN,
-               "ba_concat_all: argument %u must be BYTEARRAY", i);
+  for (size_t i = 0; i < args.size(); i++) {
+    auto t = args.type_at(i);
+    if (!t.is_custom() && !t.is_str()) {
+      out.error("ba_concat_all: argument " + std::to_string(i) +
+                " must be BYTEARRAY");
       return;
     }
   }
-  result->result_buffer_size = args->arg_count * kBytearrayLen;
+  out.request_buffer_size(args.size() * kBytearrayLen);
 }
 
 void ba_concat_all(VarArgs args, StringResult out) {

--- a/villagesql/sdk/include/villagesql/detail/func_builder.h
+++ b/villagesql/sdk/include/villagesql/detail/func_builder.h
@@ -529,8 +529,50 @@ struct WrapperTypedState {
 //
 // Param tuple shape: <void*, TypedArg..., ResultWrapper>. Same indexing as
 // WrapperTypedState.
+//
+// Read-only with respect to the user_data slot: any assignment inside the
+// VDF body is local because the pointer is copied. Use WrapperVoidStarRefState
+// (declare `void*&`) if the body needs to update the slot.
 template <auto Func, size_t NumParams>
-struct WrapperVoidState {
+struct WrapperVoidStarState {
+  static void invoke(vef_context_t *ctx, vef_vdf_args_t *args,
+                     vef_vdf_result_t *result) {
+    invoke_impl(ctx, args, result, std::make_index_sequence<NumParams>{});
+  }
+
+ private:
+  template <size_t... Is>
+  static void invoke_impl(vef_context_t *ctx, vef_vdf_args_t *args,
+                          vef_vdf_result_t *result,
+                          std::index_sequence<Is...>) {
+    using Params = typename FuncParamTypes<decltype(Func)>::type;
+    std::array<vef_invalue_t, NumParams> vals{
+        get_invalue(ctx, args, static_cast<unsigned int>(Is))...};
+    Func(args->user_data,
+         make_arg<std::tuple_element_t<1 + Is, Params>>(&vals[Is])...,
+         make_result<std::tuple_element_t<1 + NumParams, Params>>(result));
+  }
+
+  template <typename T>
+  static T make_arg(vef_invalue_t *v) {
+    return T(v);
+  }
+  template <typename T>
+  static T make_result(vef_vdf_result_t *r) {
+    return T(r);
+  }
+};
+
+// Wrapper for VDFs whose first parameter is `void*&` — like
+// WrapperVoidStarState but binds args->user_data by reference so the VDF body
+// can write back into the slot. Use this when the body needs to lazily allocate
+// scratch space (or otherwise update the pointer) and have the new pointer
+// survive across rows and reach postrun for cleanup.
+//
+// Param tuple shape: <void*&, TypedArg..., ResultWrapper>. Same indexing as
+// WrapperVoidStarState.
+template <auto Func, size_t NumParams>
+struct WrapperVoidStarRefState {
   static void invoke(vef_context_t *ctx, vef_vdf_args_t *args,
                      vef_vdf_result_t *result) {
     invoke_impl(ctx, args, result, std::make_index_sequence<NumParams>{});

--- a/villagesql/sdk/include/villagesql/detail/func_builder.h
+++ b/villagesql/sdk/include/villagesql/detail/func_builder.h
@@ -33,6 +33,7 @@
 
 #include <villagesql/abi/types.h>
 #include <villagesql/vsql/func_types.h>
+#include <villagesql/vsql/pre_post_run.h>
 #include <villagesql/vsql/type_params.h>
 #include <villagesql/vsql/var_args.h>
 
@@ -378,6 +379,47 @@ struct AggResultWithOutputWrapper {
   }
 };
 
+// Wrappers that convert a typed user prerun/postrun (void(PrerunArgs,
+// PrerunResult) / void(PostrunArgs)) into the raw vef_*_func_t ABI shape.
+// Used by FuncBuilder::prerun/postrun when the user's hook is typed.
+
+template <auto Hook>
+void typed_prerun_wrapper(vef_context_t *, vef_prerun_args_t *args,
+                          vef_prerun_result_t *result) {
+  Hook(PrerunArgs(args), PrerunResult(result));
+}
+
+template <auto Hook>
+void typed_postrun_wrapper(vef_context_t *, vef_postrun_args_t *args,
+                           vef_postrun_result_t *) {
+  Hook(PostrunArgs(args));
+}
+
+// Predicates used by FuncBuilder::prerun/postrun to decide which wrapper
+// (if any) to install. Each is true exactly when the hook's signature
+// matches the typed shape for its slot.
+
+template <auto Hook>
+constexpr bool is_typed_prerun() {
+  using Params = typename FuncParamTypes<decltype(Hook)>::type;
+  if constexpr (std::tuple_size_v<Params> != 2) {
+    return false;
+  } else {
+    return std::is_same_v<std::tuple_element_t<0, Params>, PrerunArgs> &&
+           std::is_same_v<std::tuple_element_t<1, Params>, PrerunResult>;
+  }
+}
+
+template <auto Hook>
+constexpr bool is_typed_postrun() {
+  using Params = typename FuncParamTypes<decltype(Hook)>::type;
+  if constexpr (std::tuple_size_v<Params> != 1) {
+    return false;
+  } else {
+    return std::is_same_v<std::tuple_element_t<0, Params>, PostrunArgs>;
+  }
+}
+
 // Generates a vef_vdf_func_t that unpacks vef_vdf_args_t and adapts each
 // argument and result to the declared typed wrapper parameter of Func.
 //
@@ -440,6 +482,80 @@ struct VarArgsWrapper {
   static void invoke(vef_context_t * /*ctx*/, vef_vdf_args_t *args,
                      vef_vdf_result_t *result) {
     Func(::vsql::VarArgs(args), ResultParam(result));
+  }
+};
+
+// Wrapper for VDFs whose first parameter is `State&` — typed per-statement
+// state allocated in prerun via PrerunResult::emplace_state<State>. The
+// wrapper dereferences args->user_data as State* and forwards a reference.
+//
+// Param tuple shape: <State&, TypedArg..., ResultWrapper>. NumParams is the
+// SQL argument count (not counting state or result), so typed args live at
+// indices [1, NumParams].
+template <auto Func, typename State, size_t NumParams>
+struct WrapperTypedState {
+  static void invoke(vef_context_t *ctx, vef_vdf_args_t *args,
+                     vef_vdf_result_t *result) {
+    invoke_impl(ctx, args, result, std::make_index_sequence<NumParams>{});
+  }
+
+ private:
+  template <size_t... Is>
+  static void invoke_impl(vef_context_t *ctx, vef_vdf_args_t *args,
+                          vef_vdf_result_t *result,
+                          std::index_sequence<Is...>) {
+    using Params = typename FuncParamTypes<decltype(Func)>::type;
+    State &state = *static_cast<State *>(args->user_data);
+    std::array<vef_invalue_t, NumParams> vals{
+        get_invalue(ctx, args, static_cast<unsigned int>(Is))...};
+    Func(state, make_arg<std::tuple_element_t<1 + Is, Params>>(&vals[Is])...,
+         make_result<std::tuple_element_t<1 + NumParams, Params>>(result));
+  }
+
+  template <typename T>
+  static T make_arg(vef_invalue_t *v) {
+    return T(v);
+  }
+  template <typename T>
+  static T make_result(vef_vdf_result_t *r) {
+    return T(r);
+  }
+};
+
+// Wrapper for VDFs whose first parameter is `void*` — raw escape hatch for
+// extensions that manage state with custom allocators, polymorphic state,
+// or anything that doesn't fit emplace_state<T>. The wrapper forwards
+// args->user_data straight through.
+//
+// Param tuple shape: <void*, TypedArg..., ResultWrapper>. Same indexing as
+// WrapperTypedState.
+template <auto Func, size_t NumParams>
+struct WrapperVoidState {
+  static void invoke(vef_context_t *ctx, vef_vdf_args_t *args,
+                     vef_vdf_result_t *result) {
+    invoke_impl(ctx, args, result, std::make_index_sequence<NumParams>{});
+  }
+
+ private:
+  template <size_t... Is>
+  static void invoke_impl(vef_context_t *ctx, vef_vdf_args_t *args,
+                          vef_vdf_result_t *result,
+                          std::index_sequence<Is...>) {
+    using Params = typename FuncParamTypes<decltype(Func)>::type;
+    std::array<vef_invalue_t, NumParams> vals{
+        get_invalue(ctx, args, static_cast<unsigned int>(Is))...};
+    Func(args->user_data,
+         make_arg<std::tuple_element_t<1 + Is, Params>>(&vals[Is])...,
+         make_result<std::tuple_element_t<1 + NumParams, Params>>(result));
+  }
+
+  template <typename T>
+  static T make_arg(vef_invalue_t *v) {
+    return T(v);
+  }
+  template <typename T>
+  static T make_result(vef_vdf_result_t *r) {
+    return T(r);
   }
 };
 

--- a/villagesql/sdk/include/villagesql/vsql.h
+++ b/villagesql/sdk/include/villagesql/vsql.h
@@ -60,7 +60,9 @@
 //           .build()))
 //
 // For aggregate VDFs (SQL SUM, COUNT, etc.), see make_aggregate_func in
-// vsql/func_builder.h. For full documentation see the individual headers below.
+// vsql/func_builder.h. For per-statement lifecycle hooks (prerun/postrun),
+// see vsql/pre_post_run.h. For full documentation see the individual
+// headers below.
 
 // Typed function and type-operation builders (rejects raw ABI signatures).
 #include <villagesql/vsql/func_builder.h>

--- a/villagesql/sdk/include/villagesql/vsql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_builder.h
@@ -318,7 +318,11 @@ class FuncBuilder {
       // state-style VDFs. Today these run only for stateless shapes.
       using First = std::tuple_element_t<0, AllParams>;
       if constexpr (std::is_same_v<First, void *>) {
-        meta.f = &detail::WrapperVoidState<Func, NumParams>::invoke;
+        meta.f = &detail::WrapperVoidStarState<Func, NumParams>::invoke;
+      } else if constexpr (std::is_same_v<First, void *&>) {
+        // `void*&` routes to WrapperVoidStarRefState so assignments inside the
+        // VDF write back to args->user_data and survive across rows.
+        meta.f = &detail::WrapperVoidStarRefState<Func, NumParams>::invoke;
       } else {
         // Both `State&` and `const State&` route to WrapperTypedState; the
         // implicit conversion from `State&` to `const State&` happens at

--- a/villagesql/sdk/include/villagesql/vsql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_builder.h
@@ -39,6 +39,7 @@
 #include <type_traits>
 
 #include <villagesql/vsql/func_types.h>
+#include <villagesql/vsql/pre_post_run.h>
 #include <villagesql/vsql/type_params.h>
 
 // Storage characteristics resolved from type parameters.
@@ -139,9 +140,12 @@ template <typename P>
 using ParamsToStringsFunc = void (*)(const P &,
                                      std::map<std::string, std::string> &);
 
-// =============================================================================
 // FuncBuilder
-// =============================================================================
+//
+// HasPrerun is set to true by .prerun<>(). build() requires it when Func's
+// signature reads state from user_data (void(State&,...) / void(void*,...)),
+// so that registering a state-style VDF without a prerun is a compile error
+// rather than a runtime null dereference.
 
 // Selects between fixed-arity and varargs builders. A builder starts in
 // kUnset; .param(TYPE) (or .param() zero-arity) transitions to kFixed,
@@ -149,23 +153,25 @@ using ParamsToStringsFunc = void (*)(const P &,
 // enforced by static_assert.
 enum class ParamMode { kUnset, kFixed, kVarargs };
 
-template <auto Func, size_t NumParams, ParamMode Mode = ParamMode::kUnset>
+template <auto Func, size_t NumParams, ParamMode Mode = ParamMode::kUnset,
+          bool HasPrerun = false>
 class FuncBuilder {
  public:
-  constexpr FuncBuilder<Func, NumParams, Mode> &returns(const char *t) {
+  constexpr FuncBuilder<Func, NumParams, Mode, HasPrerun> &returns(
+      const char *t) {
     return_type_ = t;
     return *this;
   }
 
   // Add a typed parameter. Once called, no further .varargs() is allowed.
-  constexpr FuncBuilder<Func, NumParams + 1, ParamMode::kFixed> param(
-      const char *t) const {
+  constexpr FuncBuilder<Func, NumParams + 1, ParamMode::kFixed, HasPrerun>
+  param(const char *t) const {
     static_assert(Mode != ParamMode::kVarargs,
                   ".param(TYPE) and .varargs() are mutually exclusive");
     static_assert(Mode != ParamMode::kFixed || NumParams > 0,
                   ".param(TYPE) and .param() (zero-arity) are mutually "
                   "exclusive");
-    FuncBuilder<Func, NumParams + 1, ParamMode::kFixed> next;
+    FuncBuilder<Func, NumParams + 1, ParamMode::kFixed, HasPrerun> next;
     next.name_ = name_;
     next.return_type_ = return_type_;
     next.buffer_size_ = buffer_size_;
@@ -182,14 +188,14 @@ class FuncBuilder {
   // Explicitly declare zero-arity. Useful for functions that read only
   // session state or return a constant. Mutually exclusive with .param(TYPE)
   // and .varargs().
-  constexpr FuncBuilder<Func, 0, ParamMode::kFixed> param() const {
+  constexpr FuncBuilder<Func, 0, ParamMode::kFixed, HasPrerun> param() const {
     static_assert(NumParams == 0,
                   ".param() (zero-arity) and .param(TYPE) are mutually "
                   "exclusive");
     static_assert(Mode != ParamMode::kVarargs,
                   ".param() (zero-arity) and .varargs() are mutually "
                   "exclusive");
-    FuncBuilder<Func, 0, ParamMode::kFixed> next;
+    FuncBuilder<Func, 0, ParamMode::kFixed, HasPrerun> next;
     next.name_ = name_;
     next.return_type_ = return_type_;
     next.buffer_size_ = buffer_size_;
@@ -203,11 +209,12 @@ class FuncBuilder {
   //   void(vsql::VarArgs, ResultWrapper)
   // The prerun hook is responsible for validating argument count and types.
   // Mutually exclusive with .param() / .param(TYPE).
-  constexpr FuncBuilder<Func, 0, ParamMode::kVarargs> varargs() const {
+  constexpr FuncBuilder<Func, 0, ParamMode::kVarargs, HasPrerun> varargs()
+      const {
     static_assert(Mode != ParamMode::kFixed,
                   ".varargs() is mutually exclusive with .param() and "
                   ".param(TYPE)");
-    FuncBuilder<Func, 0, ParamMode::kVarargs> next;
+    FuncBuilder<Func, 0, ParamMode::kVarargs, HasPrerun> next;
     next.name_ = name_;
     next.return_type_ = return_type_;
     next.buffer_size_ = buffer_size_;
@@ -217,7 +224,8 @@ class FuncBuilder {
     return next;
   }
 
-  constexpr FuncBuilder<Func, NumParams, Mode> &buffer_size(size_t s) {
+  constexpr FuncBuilder<Func, NumParams, Mode, HasPrerun> &buffer_size(
+      size_t s) {
     buffer_size_ = s;
     return *this;
   }
@@ -225,20 +233,36 @@ class FuncBuilder {
   // Marks the function as deterministic: identical inputs always produce
   // identical outputs. The optimizer may cache or elide calls for
   // constant-folding and query rewriting. Defaults to false.
-  constexpr FuncBuilder<Func, NumParams, Mode> &deterministic(bool d = true) {
+  constexpr FuncBuilder<Func, NumParams, Mode, HasPrerun> &deterministic(
+      bool d = true) {
     deterministic_ = d;
     return *this;
   }
 
-  template <vef_prerun_func_t Hook>
-  constexpr FuncBuilder<Func, NumParams, Mode> &prerun() {
-    prerun_ = Hook;
-    return *this;
+  template <auto Hook>
+  constexpr FuncBuilder<Func, NumParams, Mode, true> prerun() const {
+    static_assert(detail::is_typed_prerun<Hook>(),
+                  "prerun<Hook>(): Hook must be void(PrerunArgs, "
+                  "PrerunResult). Raw ABI signatures are not accepted.");
+    FuncBuilder<Func, NumParams, Mode, true> next;
+    next.name_ = name_;
+    next.return_type_ = return_type_;
+    next.buffer_size_ = buffer_size_;
+    next.prerun_ = &detail::typed_prerun_wrapper<Hook>;
+    next.postrun_ = postrun_;
+    next.deterministic_ = deterministic_;
+    for (size_t i = 0; i < NumParams; ++i) {
+      next.param_types_[i] = param_types_[i];
+    }
+    return next;
   }
 
-  template <vef_postrun_func_t Hook>
-  constexpr FuncBuilder<Func, NumParams, Mode> &postrun() {
-    postrun_ = Hook;
+  template <auto Hook>
+  constexpr FuncBuilder<Func, NumParams, Mode, HasPrerun> &postrun() {
+    static_assert(detail::is_typed_postrun<Hook>(),
+                  "postrun<Hook>(): Hook must be void(PostrunArgs). Raw ABI "
+                  "signatures are not accepted.");
+    postrun_ = &detail::typed_postrun_wrapper<Hook>;
     return *this;
   }
 
@@ -253,31 +277,86 @@ class FuncBuilder {
 
     using AllParams = typename detail::FuncParamTypes<decltype(Func)>::type;
     using ReturnType = typename detail::FuncReturnType<decltype(Func)>::type;
-    using Shape = detail::func_signature_shape<AllParams, NumParams>;
     static_assert(std::is_void_v<ReturnType>,
                   "make_func: C++ function must return void and set the SQL "
                   "result through the final typed result wrapper parameter");
-    static_assert(Mode == ParamMode::kVarargs ||
-                      std::tuple_size_v<AllParams> == NumParams + 1,
-                  "make_func: C++ function must have one typed result wrapper "
-                  "after the declared SQL parameters; check the number of "
-                  ".param(...) calls");
-    static_assert(
-        std::tuple_size_v<AllParams> != NumParams + 1 || Shape::args_ok,
-        "make_func: every C++ function parameter before the result "
-        "must be a typed argument wrapper such as IntArg, RealArg, "
-        "StringArg, CustomArg, or CustomArgWith<P>");
-    static_assert(
-        std::tuple_size_v<AllParams> != NumParams + 1 || Shape::result_ok,
-        "make_func: final C++ function parameter must be a typed "
-        "result wrapper such as IntResult, RealResult, StringResult, "
-        "CustomResult, or CustomResultWith<P>");
+
+    // Detect state-style signatures: first parameter is `void*` or any
+    // lvalue reference (State& / const State&). Aggregate result-shape
+    // functions also have a `const State&` first parameter but go through
+    // AggFuncBuilder, not here. Varargs VDFs do not use state.
+    constexpr bool has_state_param = []() constexpr {
+      if constexpr (std::tuple_size_v<AllParams> >= 1) {
+        using First = std::tuple_element_t<0, AllParams>;
+        return std::is_same_v<First, void *> ||
+               std::is_lvalue_reference_v<First>;
+      } else {
+        return false;
+      }
+    }();
 
     detail::FuncWithMetadata meta{};
     if constexpr (Mode == ParamMode::kVarargs) {
       meta.f = &detail::VarArgsWrapper<Func>::invoke;
       meta.is_varargs = true;
+    } else if constexpr (has_state_param) {
+      // Shapes:
+      //   void(State&, TypedArgs..., ResultWrapper)     — typed state, mutable
+      //   void(const State&, TypedArgs..., ResultWrapper) — typed state, const
+      //   void(void*, TypedArgs..., ResultWrapper)      — raw state
+      static_assert(HasPrerun,
+                    "VDF declares state (State& or void*) but no prerun is "
+                    "configured. user_data would be nullptr at every call. "
+                    "Attach a .prerun<>() that calls set_user_data(), or "
+                    "drop the state parameter.");
+      static_assert(std::tuple_size_v<AllParams> == NumParams + 2,
+                    "make_func: state-style VDF must have one State (or "
+                    "void*) parameter, then the declared SQL parameters, "
+                    "then a typed result wrapper");
+      // TODO(villagesql-beta): also run args/result shape and runtime
+      // signature checks (declared .param/.returns vs C++ wrappers) for
+      // state-style VDFs. Today these run only for stateless shapes.
+      using First = std::tuple_element_t<0, AllParams>;
+      if constexpr (std::is_same_v<First, void *>) {
+        meta.f = &detail::WrapperVoidState<Func, NumParams>::invoke;
+      } else {
+        // Both `State&` and `const State&` route to WrapperTypedState; the
+        // implicit conversion from `State&` to `const State&` happens at
+        // the call site if the user opted for read-only.
+        using State = std::remove_const_t<std::remove_reference_t<First>>;
+        meta.f = &detail::WrapperTypedState<Func, State, NumParams>::invoke;
+      }
+    } else {
+      using Shape = detail::func_signature_shape<AllParams, NumParams>;
+      static_assert(
+          std::tuple_size_v<AllParams> == NumParams + 1,
+          "make_func: C++ function must have one typed result wrapper "
+          "after the declared SQL parameters; check the number of "
+          ".param(...) calls");
+      static_assert(
+          std::tuple_size_v<AllParams> != NumParams + 1 || Shape::args_ok,
+          "make_func: every C++ function parameter before the result "
+          "must be a typed argument wrapper such as IntArg, RealArg, "
+          "StringArg, CustomArg, or CustomArgWith<P>");
+      static_assert(
+          std::tuple_size_v<AllParams> != NumParams + 1 || Shape::result_ok,
+          "make_func: final C++ function parameter must be a typed "
+          "result wrapper such as IntResult, RealResult, StringResult, "
+          "CustomResult, or CustomResultWith<P>");
+      if constexpr (std::tuple_size_v<AllParams> == NumParams + 1 &&
+                    Shape::args_ok && Shape::result_ok) {
+        using UniquePTuple =
+            typename detail::unique_params_types<AllParams>::type;
+        meta.f = &detail::Wrapper<Func, NumParams>::invoke;
+        if constexpr (std::tuple_size_v<UniquePTuple> > 0) {
+          meta.check_params_cache_bound =
+              &detail::apply_params_cache_checker<UniquePTuple>::check;
+        }
+        meta.check_signature =
+            &detail::signature_checker<AllParams, NumParams>::check;
+      }
     }
+
     meta.prerun = prerun_;
     meta.postrun = postrun_;
     meta.return_type = detail::to_vef_type(return_type_);
@@ -286,18 +365,6 @@ class FuncBuilder {
     meta.deterministic = deterministic_;
     for (size_t i = 0; i < NumParams; ++i) {
       meta.param_types[i] = detail::to_vef_type(param_types_[i]);
-    }
-    if constexpr (std::tuple_size_v<AllParams> == NumParams + 1 &&
-                  Shape::args_ok && Shape::result_ok) {
-      using UniquePTuple =
-          typename detail::unique_params_types<AllParams>::type;
-      meta.f = &detail::Wrapper<Func, NumParams>::invoke;
-      if constexpr (std::tuple_size_v<UniquePTuple> > 0) {
-        meta.check_params_cache_bound =
-            &detail::apply_params_cache_checker<UniquePTuple>::check;
-      }
-      meta.check_signature =
-          &detail::signature_checker<AllParams, NumParams>::check;
     }
 
     return detail::StaticFuncDesc<NumParams>(name_, meta);
@@ -321,11 +388,12 @@ class FuncBuilder {
   vef_postrun_func_t postrun_;
   bool deterministic_;
 
-  template <auto F, size_t M, ParamMode N>
+  template <auto F, size_t M, ParamMode N, bool HP>
   friend class FuncBuilder;
 
   template <auto F>
-  friend constexpr FuncBuilder<F, 0> make_func(const char *);
+  friend constexpr FuncBuilder<F, 0, ParamMode::kUnset, false> make_func(
+      const char *);
 };
 
 // =============================================================================
@@ -504,7 +572,8 @@ constexpr AggFuncBuilder<State, Func, 0> make_aggregate_func(const char *name) {
 
 // make_func<&impl>("name")
 template <auto Func>
-constexpr FuncBuilder<Func, 0> make_func(const char *name) {
+constexpr FuncBuilder<Func, 0, ParamMode::kUnset, false> make_func(
+    const char *name) {
   using AllParams = typename detail::FuncParamTypes<decltype(Func)>::type;
   static_assert(
       std::tuple_size_v<AllParams> == 0 ||
@@ -512,7 +581,7 @@ constexpr FuncBuilder<Func, 0> make_func(const char *name) {
       "vsql make_func: deprecated vef_context_t* first parameter not "
       "supported; use a typed function or make_aggregate_func (see "
       "extension.h)");
-  FuncBuilder<Func, 0> builder;
+  FuncBuilder<Func, 0, ParamMode::kUnset, false> builder;
   builder.name_ = name;
   return builder;
 }

--- a/villagesql/sdk/include/villagesql/vsql/pre_post_run.h
+++ b/villagesql/sdk/include/villagesql/vsql/pre_post_run.h
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+#ifndef VILLAGESQL_VSQL_PRE_POST_RUN_H
+#define VILLAGESQL_VSQL_PRE_POST_RUN_H
+
+// Typed wrappers for the per-statement lifecycle hooks (prerun and postrun).
+//
+// Extension authors register hooks via .prerun<&fn>() / .postrun<&fn>() on
+// the func builder. Only the typed signatures are accepted; the SDK
+// installs wrappers that adapt to the raw ABI:
+//
+//   prerun:  void(PrerunArgs, PrerunResult)
+//   postrun: void(PostrunArgs)
+//
+// Raw vef_prerun_func_t / vef_postrun_func_t signatures are rejected at
+// compile time. Extensions that need to drop to the raw ABI for these
+// hooks would have to skip the vsql builder entirely.
+//
+// State lifetime is explicit: if prerun stores a pointer via set_user_data,
+// postrun is responsible for freeing it. PostrunArgs::delete_state<T>() is
+// the typed convenience for the common case of `new T{}` + `delete`.
+//
+// vef_postrun_result_t is currently empty in the ABI, so there is no
+// PostrunResult wrapper. If/when the result struct gains fields, a typed
+// wrapper class will be added and the postrun signature will become
+// `void(PostrunArgs, PostrunResult)`.
+//
+// TODO(villagesql-beta): add a typed-state mechanism (working name
+// `.state<T>()` on FuncBuilder) so extensions can declare a per-statement
+// state type and have the SDK manage its lifetime automatically — no
+// matched prerun/postrun pair required just to free state. Implementable
+// without ABI changes by having .state<T>() install SDK-generated prerun
+// and postrun wrappers that new/delete the T into the existing user_data
+// slot; the user's optional prerun/postrun receive the typed reference.
+// .state<T>() and raw set_user_data become mutually exclusive.
+
+#include <cstddef>
+#include <cstring>
+#include <string_view>
+#include <utility>
+
+#include <villagesql/abi/types.h>
+
+namespace vsql {
+
+// Type-only view of one prerun-time argument. Prerun runs before any rows
+// are read, so it sees only the declared type of each argument, not the
+// runtime values.
+class PrerunArgType {
+ public:
+  explicit PrerunArgType(const vef_type_t *t) : t_(t) {}
+
+  vef_type_id type() const { return t_->id; }
+  bool is_int() const { return t_->id == VEF_TYPE_INT; }
+  bool is_real() const { return t_->id == VEF_TYPE_REAL; }
+  bool is_str() const { return t_->id == VEF_TYPE_STRING; }
+  bool is_custom() const { return t_->id == VEF_TYPE_CUSTOM; }
+
+  // For CUSTOM types: the unqualified type name (no extension prefix).
+  // Empty string_view for non-CUSTOM types.
+  std::string_view custom_type() const {
+    return t_->custom_type ? std::string_view(t_->custom_type)
+                           : std::string_view{};
+  }
+
+ private:
+  const vef_type_t *t_;
+};
+
+class PrerunArgs {
+ public:
+  explicit PrerunArgs(const vef_prerun_args_t *a) : a_(a) {}
+
+  size_t size() const { return a_->arg_count; }
+
+  PrerunArgType type_at(size_t i) const {
+    return PrerunArgType(&a_->arg_types[i]);
+  }
+
+  // TODO(villagesql-beta): expose const_at(i) returning the serialized
+  // literal bytes for constant arguments. Blocked on vdf_handler.cc
+  // populating vef_prerun_args_t::const_values / const_lengths; today both
+  // are unconditionally nullptr at the prerun call site.
+
+ private:
+  const vef_prerun_args_t *a_;
+};
+
+class PrerunResult {
+ public:
+  explicit PrerunResult(vef_prerun_result_t *r) : r_(r) {}
+
+  // Stash a pointer the extension owns. The VDF and postrun read it back
+  // via PostrunArgs::user_data() or PostrunArgs::state<T>(). The SDK does
+  // not free anything stashed here; pair this with a postrun that calls
+  // PostrunArgs::delete_state<T>() (or free()) on the same pointer.
+  void set_user_data(void *p) { r_->user_data = p; }
+
+  // Request that the per-row result buffer be at least n bytes. The server
+  // allocates the buffer before invoking the VDF; useful for STRING/CUSTOM
+  // return types where the default size is too small for this function.
+  void request_buffer_size(size_t n) { r_->result_buffer_size = n; }
+
+  // Report a prerun failure. The query is aborted with this error message.
+  void error(std::string_view msg) {
+    r_->type = VEF_RESULT_ERROR;
+    size_t n =
+        msg.size() < VEF_MAX_ERROR_LEN - 1 ? msg.size() : VEF_MAX_ERROR_LEN - 1;
+    std::memcpy(r_->error_msg, msg.data(), n);
+    r_->error_msg[n] = '\0';
+  }
+
+ private:
+  vef_prerun_result_t *r_;
+};
+
+class PostrunArgs {
+ public:
+  explicit PostrunArgs(const vef_postrun_args_t *a) : a_(a) {}
+
+  // Read the raw user_data slot — whatever prerun stored via set_user_data.
+  // Use this for non-C++ allocations (malloc/arena/pool) or anything that
+  // doesn't fit a single typed T.
+  void *user_data() const { return a_->user_data; }
+
+  // Convenience: static_cast user_data to a T*. Pair with prerun's
+  // set_user_data(new T{...}).
+  template <typename T>
+  T *state() const {
+    return static_cast<T *>(a_->user_data);
+  }
+
+  // Convenience: `delete state<T>()` in one call. Pair with prerun's
+  // set_user_data(new T{...}).
+  template <typename T>
+  void delete_state() const {
+    delete state<T>();
+  }
+
+ private:
+  const vef_postrun_args_t *a_;
+};
+
+}  // namespace vsql
+
+#endif  // VILLAGESQL_VSQL_PRE_POST_RUN_H


### PR DESCRIPTION
sdk: typed prerun/postrun hooks

Introduce typed C++ wrappers for the per-statement lifecycle hooks
(prerun and postrun). Extension authors no longer touch raw ABI
structs to write these hooks; only the typed signatures are accepted.

Why
---
Extension authors writing prerun/postrun previously had to:

  void my_prerun(vef_context_t *, vef_prerun_args_t *args,
                 vef_prerun_result_t *result) {
    if (args->arg_count == 0) {
      result->type = VEF_RESULT_ERROR;
      snprintf(result->error_msg, VEF_MAX_ERROR_LEN, "...");
      return;
    }
    result->result_buffer_size = N;
    result->user_data = new MyState{};
  }

Two problems: raw ABI in the user-facing API (against the SDK's
direction; see #548) and bespoke error-reporting plumbing.

After this PR:

  void my_prerun(vsql::PrerunArgs args, vsql::PrerunResult out) {
    if (args.size() == 0) {
      out.error("at least one argument required");
      return;
    }
    out.request_buffer_size(N);
    out.set_user_data(new MyState{});
  }

  void my_postrun(vsql::PostrunArgs args) {
    args.delete_state<MyState>();
  }

  void my_vdf(MyState &state, IntResult out) { ... }

State lifetime stays explicit in this PR: prerun stashes the pointer,
postrun frees it. A follow-up will add auto-cleanup (see "Not in this
PR" below).

Where to start reviewing
------------------------
Read the layers in this order:

1. villagesql/sdk/include/villagesql/vsql/pre_post_run.h
   New public types: PrerunArgs, PrerunArgType, PrerunResult,
   PostrunArgs. This is what extension authors see.

2. villagesql/examples/vsql-simple/src/extension.cc
   The ba_call_index demo: set_user_data in prerun, mutable State&
   in the VDF, delete_state in postrun.

3. mysql-test/suite/villagesql/extension/t/extension_simple_type_usage.test
   What it looks like at the SQL surface.

4. villagesql/sdk/include/villagesql/extension.h
   Refreshed user-facing docs for the typed hook shape.

The remaining file is SDK plumbing:

5. villagesql/sdk/include/villagesql/vsql/func_builder.h
   - .prerun<>() / .postrun<>() are typed-only; static_assert
     rejects raw vef_prerun_func_t / vef_postrun_func_t.
   - WrapperTypedState / WrapperVoidState dispatch on the first
     param of the VDF: State& / const State& / void* selects how
     user_data is forwarded.
   - typed_prerun_thunk / typed_postrun_thunk adapt the user's
     typed signature to the raw ABI shape the server invokes.

Not in this PR
--------------
- Auto-cleanup for SDK-allocated state. Requires an ABI side channel
  (e.g. a user_data_deleter slot on vef_prerun_result_t) so the SDK
  can register a destructor independent of the user_data pointer
  that extensions also use for raw/custom allocations. Marked
  TODO(villagesql-beta) in pre_post_run.h.
- A `.state<T>()` builder that records State at the template level
  and routes typed signatures of the form `void(T&, ...)`. Will land
  with the auto-cleanup mechanism above.
- Typed VarArgs/AnyArg wrappers for varargs VDFs (the other raw-ABI
  place in extension code, only reached via PR #254).
- vef_postrun_result_t is empty in the ABI today, so there is no
  PostrunResult wrapper. Will add when the struct grows.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
