### PR TITLE
extension register bug

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-preview/r/preview_ping_multi_extension.result
+++ b/mysql-test/suite/villagesql/extension/vsql-preview/r/preview_ping_multi_extension.result
@@ -1,0 +1,17 @@
+SET PERSIST vsql_allow_preview_extensions = ON;
+INSTALL EXTENSION vsql_preview_ping_test;
+INSTALL EXTENSION vsql_preview_ping_alt_test;
+# Both extensions can call the same server-side ping capability.
+SELECT vsql_preview_ping_test.ping() < vsql_preview_ping_alt_test.ping()
+AS cross_extension_ping_increases;
+cross_extension_ping_increases
+1
+UNINSTALL EXTENSION vsql_preview_ping_alt_test;
+# The first extension still works after the second is uninstalled.
+SELECT vsql_preview_ping_test.ping() < vsql_preview_ping_test.ping()
+AS first_extension_still_works;
+first_extension_still_works
+1
+UNINSTALL EXTENSION vsql_preview_ping_test;
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/mysql-test/suite/villagesql/extension/vsql-preview/t/preview_ping_multi_extension.test
+++ b/mysql-test/suite/villagesql/extension/vsql-preview/t/preview_ping_multi_extension.test
@@ -1,0 +1,22 @@
+# Test that two extension .so files with the same registration shape keep
+# independent SDK-side registration storage.
+
+SET PERSIST vsql_allow_preview_extensions = ON;
+
+INSTALL EXTENSION vsql_preview_ping_test;
+INSTALL EXTENSION vsql_preview_ping_alt_test;
+
+--echo # Both extensions can call the same server-side ping capability.
+SELECT vsql_preview_ping_test.ping() < vsql_preview_ping_alt_test.ping()
+  AS cross_extension_ping_increases;
+
+UNINSTALL EXTENSION vsql_preview_ping_alt_test;
+
+--echo # The first extension still works after the second is uninstalled.
+SELECT vsql_preview_ping_test.ping() < vsql_preview_ping_test.ping()
+  AS first_extension_still_works;
+
+UNINSTALL EXTENSION vsql_preview_ping_test;
+
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/villagesql/sdk/include/villagesql/detail/vef_register.h
+++ b/villagesql/sdk/include/villagesql/detail/vef_register.h
@@ -218,9 +218,11 @@ const char *vef_check_params_cache(const Ext &e, std::index_sequence<Is...>) {
 // compile-time constants without relying on VLAs.
 template <typename Ext, size_t FuncCount, size_t TypeCount,
           size_t RequiredCapabilityCount>
-vef_registration_t *vef_register_impl(vef_registration_t &reg,
-                                      bool &initialized,
-                                      vef_register_arg_t *arg, const Ext &ext) {
+vef_registration_t *vef_register_impl(
+    vef_registration_t &reg, bool &initialized, vef_func_desc_t **func_ptrs,
+    vef_type_desc_t **type_ptrs,
+    vef_required_capability_t *required_capability_reqs,
+    vef_register_arg_t *arg, const Ext &ext) {
   if (initialized) return &reg;
 
   if (arg->protocol < ext.min_protocol()) {
@@ -233,11 +235,6 @@ vef_registration_t *vef_register_impl(vef_registration_t &reg,
     reg.error_msg = error_buf;
     return &reg;
   }
-
-  static vef_func_desc_t *func_ptrs[FuncCount > 0 ? FuncCount : 1];
-  static vef_type_desc_t *type_ptrs[TypeCount > 0 ? TypeCount : 1];
-  static vef_required_capability_t required_capability_reqs
-      [RequiredCapabilityCount > 0 ? RequiredCapabilityCount : 1];
 
   if constexpr (FuncCount > 0) {
     vef_init_auto_names(ext, std::make_index_sequence<FuncCount>{});

--- a/villagesql/sdk/include/villagesql/extension_builder.h
+++ b/villagesql/sdk/include/villagesql/extension_builder.h
@@ -120,20 +120,29 @@ constexpr auto make_extension(std::string_view /*name*/,
 // descriptors after registration for testing). Otherwise use
 // VEF_GENERATE_ENTRY_POINTS which generates the full extern "C" entry points.
 
-#define VEF_GENERATE_REGISTRATION(ext)                                     \
-  namespace {                                                              \
-  vef_registration_t _vef_reg;                                             \
-  bool _vef_reg_initialized = false;                                       \
-  }                                                                        \
-                                                                           \
-  static vef_registration_t *_vef_do_register(vef_register_arg_t *arg) {   \
-    using namespace villagesql::extension_builder;                         \
-    static constexpr auto kExt = (ext);                                    \
-    using ExtType = decltype(kExt);                                        \
-    return villagesql::detail::vef_register_impl<                          \
-        decltype(kExt), ExtType::kFuncCount, ExtType::kTypeCount,          \
-        ExtType::kRequiredCapabilityCount>(_vef_reg, _vef_reg_initialized, \
-                                           arg, kExt);                     \
+#define VEF_GENERATE_REGISTRATION(ext)                                   \
+  namespace {                                                            \
+  vef_registration_t _vef_reg;                                           \
+  bool _vef_reg_initialized = false;                                     \
+  }                                                                      \
+                                                                         \
+  static vef_registration_t *_vef_do_register(vef_register_arg_t *arg) { \
+    using namespace villagesql::extension_builder;                       \
+    static constexpr auto kExt = (ext);                                  \
+    using ExtType = decltype(kExt);                                      \
+    static vef_func_desc_t                                               \
+        *func_ptrs[ExtType::kFuncCount > 0 ? ExtType::kFuncCount : 1];   \
+    static vef_type_desc_t                                               \
+        *type_ptrs[ExtType::kTypeCount > 0 ? ExtType::kTypeCount : 1];   \
+    static vef_required_capability_t                                     \
+        required_capability_reqs[ExtType::kRequiredCapabilityCount > 0   \
+                                     ? ExtType::kRequiredCapabilityCount \
+                                     : 1];                               \
+    return villagesql::detail::vef_register_impl<                        \
+        decltype(kExt), ExtType::kFuncCount, ExtType::kTypeCount,        \
+        ExtType::kRequiredCapabilityCount>(                              \
+        _vef_reg, _vef_reg_initialized, func_ptrs, type_ptrs,            \
+        required_capability_reqs, arg, kExt);                            \
   }
 
 // VEF_GENERATE_ENTRY_POINTS
@@ -141,26 +150,35 @@ constexpr auto make_extension(std::string_view /*name*/,
 // Generates the extern "C" vef_register and vef_unregister functions.
 // Must be called in a .cc file, not a header (defines functions/variables).
 
-#define VEF_GENERATE_ENTRY_POINTS(ext)                                     \
-  namespace {                                                              \
-  vef_registration_t vef_reg_;                                             \
-  bool vef_reg_initialized_ = false;                                       \
-  }                                                                        \
-                                                                           \
-  extern "C" vef_registration_t *vef_register(vef_register_arg_t *arg) {   \
-    using namespace villagesql::extension_builder;                         \
-    static constexpr auto kExt = (ext);                                    \
-    using ExtType = decltype(kExt);                                        \
-    return villagesql::detail::vef_register_impl<                          \
-        decltype(kExt), ExtType::kFuncCount, ExtType::kTypeCount,          \
-        ExtType::kRequiredCapabilityCount>(vef_reg_, vef_reg_initialized_, \
-                                           arg, kExt);                     \
-  }                                                                        \
-                                                                           \
-  extern "C" void vef_unregister(vef_unregister_arg_t *arg,                \
-                                 vef_registration_t *reg) {                \
-    (void)arg;                                                             \
-    (void)reg;                                                             \
+#define VEF_GENERATE_ENTRY_POINTS(ext)                                   \
+  namespace {                                                            \
+  vef_registration_t vef_reg_;                                           \
+  bool vef_reg_initialized_ = false;                                     \
+  }                                                                      \
+                                                                         \
+  extern "C" vef_registration_t *vef_register(vef_register_arg_t *arg) { \
+    using namespace villagesql::extension_builder;                       \
+    static constexpr auto kExt = (ext);                                  \
+    using ExtType = decltype(kExt);                                      \
+    static vef_func_desc_t                                               \
+        *func_ptrs[ExtType::kFuncCount > 0 ? ExtType::kFuncCount : 1];   \
+    static vef_type_desc_t                                               \
+        *type_ptrs[ExtType::kTypeCount > 0 ? ExtType::kTypeCount : 1];   \
+    static vef_required_capability_t                                     \
+        required_capability_reqs[ExtType::kRequiredCapabilityCount > 0   \
+                                     ? ExtType::kRequiredCapabilityCount \
+                                     : 1];                               \
+    return villagesql::detail::vef_register_impl<                        \
+        decltype(kExt), ExtType::kFuncCount, ExtType::kTypeCount,        \
+        ExtType::kRequiredCapabilityCount>(                              \
+        vef_reg_, vef_reg_initialized_, func_ptrs, type_ptrs,            \
+        required_capability_reqs, arg, kExt);                            \
+  }                                                                      \
+                                                                         \
+  extern "C" void vef_unregister(vef_unregister_arg_t *arg,              \
+                                 vef_registration_t *reg) {              \
+    (void)arg;                                                           \
+    (void)reg;                                                           \
   }
 
 #endif  // VILLAGESQL_SDK_EXTENSION_BUILDER_H

--- a/villagesql/sdk/include/villagesql/vsql/extension_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/extension_builder.h
@@ -131,20 +131,29 @@ constexpr auto make_extension() {
 // descriptors after registration for testing). Otherwise use
 // VEF_GENERATE_ENTRY_POINTS which generates the full extern "C" entry points.
 
-#define VEF_GENERATE_REGISTRATION(ext)                                     \
-  namespace {                                                              \
-  vef_registration_t _vef_reg;                                             \
-  bool _vef_reg_initialized = false;                                       \
-  }                                                                        \
-                                                                           \
-  static vef_registration_t *_vef_do_register(vef_register_arg_t *arg) {   \
-    using namespace vsql;                                                  \
-    static constexpr auto kExt = (ext);                                    \
-    using ExtType = decltype(kExt);                                        \
-    return villagesql::detail::vef_register_impl<                          \
-        decltype(kExt), ExtType::kFuncCount, ExtType::kTypeCount,          \
-        ExtType::kRequiredCapabilityCount>(_vef_reg, _vef_reg_initialized, \
-                                           arg, kExt);                     \
+#define VEF_GENERATE_REGISTRATION(ext)                                   \
+  namespace {                                                            \
+  vef_registration_t _vef_reg;                                           \
+  bool _vef_reg_initialized = false;                                     \
+  }                                                                      \
+                                                                         \
+  static vef_registration_t *_vef_do_register(vef_register_arg_t *arg) { \
+    using namespace vsql;                                                \
+    static constexpr auto kExt = (ext);                                  \
+    using ExtType = decltype(kExt);                                      \
+    static vef_func_desc_t                                               \
+        *func_ptrs[ExtType::kFuncCount > 0 ? ExtType::kFuncCount : 1];   \
+    static vef_type_desc_t                                               \
+        *type_ptrs[ExtType::kTypeCount > 0 ? ExtType::kTypeCount : 1];   \
+    static vef_required_capability_t                                     \
+        required_capability_reqs[ExtType::kRequiredCapabilityCount > 0   \
+                                     ? ExtType::kRequiredCapabilityCount \
+                                     : 1];                               \
+    return villagesql::detail::vef_register_impl<                        \
+        decltype(kExt), ExtType::kFuncCount, ExtType::kTypeCount,        \
+        ExtType::kRequiredCapabilityCount>(                              \
+        _vef_reg, _vef_reg_initialized, func_ptrs, type_ptrs,            \
+        required_capability_reqs, arg, kExt);                            \
   }
 
 // VEF_GENERATE_ENTRY_POINTS (vsql variant)
@@ -152,26 +161,35 @@ constexpr auto make_extension() {
 // Generates the extern "C" vef_register and vef_unregister functions.
 // Must be called in a .cc file, not a header (defines functions/variables).
 
-#define VEF_GENERATE_ENTRY_POINTS(ext)                                     \
-  namespace {                                                              \
-  vef_registration_t vef_reg_;                                             \
-  bool vef_reg_initialized_ = false;                                       \
-  }                                                                        \
-                                                                           \
-  extern "C" vef_registration_t *vef_register(vef_register_arg_t *arg) {   \
-    using namespace vsql;                                                  \
-    static constexpr auto kExt = (ext);                                    \
-    using ExtType = decltype(kExt);                                        \
-    return villagesql::detail::vef_register_impl<                          \
-        decltype(kExt), ExtType::kFuncCount, ExtType::kTypeCount,          \
-        ExtType::kRequiredCapabilityCount>(vef_reg_, vef_reg_initialized_, \
-                                           arg, kExt);                     \
-  }                                                                        \
-                                                                           \
-  extern "C" void vef_unregister(vef_unregister_arg_t *arg,                \
-                                 vef_registration_t *reg) {                \
-    (void)arg;                                                             \
-    (void)reg;                                                             \
+#define VEF_GENERATE_ENTRY_POINTS(ext)                                   \
+  namespace {                                                            \
+  vef_registration_t vef_reg_;                                           \
+  bool vef_reg_initialized_ = false;                                     \
+  }                                                                      \
+                                                                         \
+  extern "C" vef_registration_t *vef_register(vef_register_arg_t *arg) { \
+    using namespace vsql;                                                \
+    static constexpr auto kExt = (ext);                                  \
+    using ExtType = decltype(kExt);                                      \
+    static vef_func_desc_t                                               \
+        *func_ptrs[ExtType::kFuncCount > 0 ? ExtType::kFuncCount : 1];   \
+    static vef_type_desc_t                                               \
+        *type_ptrs[ExtType::kTypeCount > 0 ? ExtType::kTypeCount : 1];   \
+    static vef_required_capability_t                                     \
+        required_capability_reqs[ExtType::kRequiredCapabilityCount > 0   \
+                                     ? ExtType::kRequiredCapabilityCount \
+                                     : 1];                               \
+    return villagesql::detail::vef_register_impl<                        \
+        decltype(kExt), ExtType::kFuncCount, ExtType::kTypeCount,        \
+        ExtType::kRequiredCapabilityCount>(                              \
+        vef_reg_, vef_reg_initialized_, func_ptrs, type_ptrs,            \
+        required_capability_reqs, arg, kExt);                            \
+  }                                                                      \
+                                                                         \
+  extern "C" void vef_unregister(vef_unregister_arg_t *arg,              \
+                                 vef_registration_t *reg) {              \
+    (void)arg;                                                           \
+    (void)reg;                                                           \
   }
 
 #endif  // VILLAGESQL_VSQL_EXTENSION_BUILDER_H

--- a/villagesql/test-extensions/CMakeLists.txt
+++ b/villagesql/test-extensions/CMakeLists.txt
@@ -24,6 +24,7 @@
 #   3. Add a vsql_add_test_extension() line below.
 
 vsql_add_test_extension(vsql-preview-ping-test         vsql_preview_ping_test)
+vsql_add_test_extension(vsql-preview-ping-alt-test     vsql_preview_ping_alt_test)
 vsql_add_test_extension(vsql-preview-unknown-cap-test  vsql_preview_unknown_cap_test)
 vsql_add_test_extension(vsql-keyring-reader            vsql_keyring_reader)
 vsql_add_test_extension(vsql-lifecycle-test            vsql_lifecycle_test)

--- a/villagesql/test-extensions/vsql-preview-ping-alt-test/manifest.json
+++ b/villagesql/test-extensions/vsql-preview-ping-alt-test/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "vsql_preview_ping_alt_test",
+  "version": "0.0.1",
+  "description": "VillageSQL test extension for multi-extension preview capability registration",
+  "author": "VillageSQL Community",
+  "license": "GPL-2.0"
+}

--- a/villagesql/test-extensions/vsql-preview-ping-alt-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-preview-ping-alt-test/src/extension.cc
@@ -1,0 +1,31 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+// vsql_preview_ping_alt_test extension: a second .so that requires the same
+// preview ping capability as vsql_preview_ping_test.
+
+#include <villagesql/preview/ping.h>
+#include <villagesql/vsql.h>
+
+using namespace vsql;
+
+static vsql::preview_ping::PingCapability PING;
+
+static void ping_impl(IntResult out) { out.set(PING.ping()); }
+
+VEF_GENERATE_ENTRY_POINTS(
+    make_extension()
+        .func(make_func<&ping_impl>("ping").returns(INT).build())
+        .with(PING))


### PR DESCRIPTION
SDK-generated registration arrays were shared across same-shaped extensions
