### PR TITLE
ci: retry apt-get's

### DIFF
--- a/scripts/setup_linux_build_env.sh
+++ b/scripts/setup_linux_build_env.sh
@@ -4,8 +4,9 @@
 
 set -e
 
-apt-get update
-apt-get install -y --no-install-recommends \
+APT_OPTS=(-o Acquire::Retries=5)
+apt-get "${APT_OPTS[@]}" update
+apt-get "${APT_OPTS[@]}" install -y --no-install-recommends \
          build-essential \
          cmake \
          libssl-dev \

--- a/scripts/setup_linux_ext_deps.sh
+++ b/scripts/setup_linux_ext_deps.sh
@@ -7,8 +7,9 @@
 
 set -e
 
-apt-get update
-apt-get install -y --no-install-recommends \
+APT_OPTS=(-o Acquire::Retries=5)
+apt-get "${APT_OPTS[@]}" update
+apt-get "${APT_OPTS[@]}" install -y --no-install-recommends \
   build-essential \
   cmake \
   libssl-dev \


### PR DESCRIPTION
apt-get's can fail (e.g., https://github.com/villagesql/villagesql-server/actions/runs/26146368297 )

These seem to be intermittent errors (as evidence by many of them passing).

So we'll retry apt-gets to be more resilient to flakiness.