### PR TITLE
Custom Index: descriptors

### DIFF
--- a/villagesql/schema/CMakeLists.txt
+++ b/villagesql/schema/CMakeLists.txt
@@ -20,6 +20,8 @@ SET(VILLAGESQL_SCHEMA_SOURCES
   victionary_client.cc
   descriptor/extension_descriptor.cc
   descriptor/func_descriptor.cc
+  descriptor/index_profile_descriptor.cc
+  descriptor/index_type_descriptor.cc
   descriptor/type_context.cc
   descriptor/type_descriptor.cc
   systable/custom_columns.cc

--- a/villagesql/schema/descriptor/index_profile_descriptor.cc
+++ b/villagesql/schema/descriptor/index_profile_descriptor.cc
@@ -1,0 +1,44 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#include "villagesql/schema/descriptor/index_profile_descriptor.h"
+
+#include "villagesql/schema/systable/helpers.h"
+
+namespace villagesql {
+
+IndexProfileDescriptorKey::IndexProfileDescriptorKey(
+    std::string profile_name, std::string extension_name,
+    std::string extension_version)
+    : profile_name_(std::move(profile_name)),
+      extension_name_(std::move(extension_name)),
+      extension_version_(std::move(extension_version)),
+      normalized_key_(normalize_extension_name(profile_name_) + "." +
+                      normalize_extension_name(extension_name_) + "." +
+                      normalize_extension_name(extension_version_)) {}
+
+IndexProfileDescriptor::IndexProfileDescriptor(
+    IndexProfileDescriptorKey key, TypeDescriptorKeyPrefix type_ref,
+    IndexTypeDescriptorKeyPrefix index_type_ref,
+    std::vector<vef_index_profile_fn_binding_t> functions, bool ordering_asc,
+    bool default_for_type)
+    : key_(std::move(key)),
+      type_ref_(std::move(type_ref)),
+      index_type_ref_(std::move(index_type_ref)),
+      functions_(std::move(functions)),
+      ordering_asc_(ordering_asc),
+      default_for_type_(default_for_type) {}
+
+}  // namespace villagesql

--- a/villagesql/schema/descriptor/index_profile_descriptor.h
+++ b/villagesql/schema/descriptor/index_profile_descriptor.h
@@ -1,0 +1,168 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+// IndexProfileDescriptor: In-memory descriptor for a VillageSQL index profile.
+// A profile binds a custom index type to a data type and declares the index
+// functions and ordering to use. Built from extension registration
+// (IndexProfileDesc) and held in VictionaryClient for the lifetime of the
+// loaded extension.
+
+#ifndef VILLAGESQL_SCHEMA_DESCRIPTOR_INDEX_PROFILE_DESCRIPTOR_H_
+#define VILLAGESQL_SCHEMA_DESCRIPTOR_INDEX_PROFILE_DESCRIPTOR_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "villagesql/schema/descriptor/index_type_descriptor.h"
+#include "villagesql/schema/descriptor/type_descriptor.h"
+#include "villagesql/schema/systable/helpers.h"
+#include "villagesql/sdk/include/villagesql/abi/preview/index.h"
+
+namespace villagesql {
+
+template <typename EntryType>
+struct TableTraits;
+
+// Prefix key for querying IndexProfileDescriptors by profile name (and
+// optionally extension name). Format: "normalized_profile_name." or
+// "normalized_profile_name.normalized_ext_name."
+struct IndexProfileDescriptorKeyPrefix {
+  // Query by profile name only (for unqualified lookups).
+  explicit IndexProfileDescriptorKeyPrefix(std::string profile_name)
+      : profile_name_(std::move(profile_name)),
+        normalized_prefix_(normalize_extension_name(profile_name_) + ".") {}
+
+  // Query by profile name + extension name.
+  IndexProfileDescriptorKeyPrefix(std::string profile_name,
+                                  std::string extension_name)
+      : profile_name_(std::move(profile_name)),
+        extension_name_(std::move(extension_name)),
+        normalized_prefix_(
+            normalize_extension_name(profile_name_) + "." +
+            (extension_name_.empty()
+                 ? ""
+                 : normalize_extension_name(extension_name_) + ".")) {}
+
+  const std::string &str() const { return normalized_prefix_; }
+  const std::string &profile_name() const { return profile_name_; }
+  const std::string &extension_name() const { return extension_name_; }
+
+ private:
+  std::string profile_name_;
+  std::string extension_name_;
+  std::string normalized_prefix_;
+};
+
+// Key for IndexProfileDescriptor entries.
+// Format:
+// "normalized_profile_name.normalized_extension_name.normalized_version"
+// Version is included because a profile is defined by a specific extension
+// version, matching the TypeDescriptorKey and IndexTypeDescriptorKey pattern.
+struct IndexProfileDescriptorKey {
+ public:
+  IndexProfileDescriptorKey() = default;
+
+  IndexProfileDescriptorKey(std::string profile_name,
+                            std::string extension_name,
+                            std::string extension_version);
+
+  const std::string &str() const { return normalized_key_; }
+  const std::string &profile_name() const { return profile_name_; }
+  const std::string &extension_name() const { return extension_name_; }
+  const std::string &extension_version() const { return extension_version_; }
+
+  bool operator<(const IndexProfileDescriptorKey &other) const {
+    return normalized_key_ < other.normalized_key_;
+  }
+  bool operator==(const IndexProfileDescriptorKey &other) const {
+    return normalized_key_ == other.normalized_key_;
+  }
+
+ private:
+  std::string profile_name_;
+  std::string extension_name_;
+  std::string extension_version_;
+  std::string normalized_key_;
+};
+
+// IndexProfileDescriptor: Immutable in-memory descriptor for an index profile.
+// Records which data type and index type the profile applies to, the function
+// bindings, scan ordering, and whether this is the default profile for the
+// (data_type, index_type) pair.
+class IndexProfileDescriptor {
+ public:
+  using key_type = IndexProfileDescriptorKey;
+  using key_prefix_type = IndexProfileDescriptorKeyPrefix;
+
+  IndexProfileDescriptor(IndexProfileDescriptorKey key,
+                         TypeDescriptorKeyPrefix type_ref,
+                         IndexTypeDescriptorKeyPrefix index_type_ref,
+                         std::vector<vef_index_profile_fn_binding_t> functions,
+                         bool ordering_asc, bool default_for_type);
+
+  // Disable copy, enable move.
+  IndexProfileDescriptor(const IndexProfileDescriptor &) = delete;
+  IndexProfileDescriptor &operator=(const IndexProfileDescriptor &) = delete;
+  IndexProfileDescriptor(IndexProfileDescriptor &&) = default;
+  IndexProfileDescriptor &operator=(IndexProfileDescriptor &&) = default;
+
+  const IndexProfileDescriptorKey &key() const { return key_; }
+  const std::string &profile_name() const { return key_.profile_name(); }
+  const std::string &extension_name() const { return key_.extension_name(); }
+  const std::string &extension_version() const {
+    return key_.extension_version();
+  }
+
+  // Prefix key for resolving the data type reference in VictionaryClient.
+  const TypeDescriptorKeyPrefix &type_ref() const { return type_ref_; }
+
+  // Prefix key for resolving the index type reference in VictionaryClient.
+  const IndexTypeDescriptorKeyPrefix &index_type_ref() const {
+    return index_type_ref_;
+  }
+
+  // Bare name accessors (no extension qualifier) for diagnostics.
+  const std::string &type_name() const { return type_ref_.type_name(); }
+  const std::string &index_type_name() const {
+    return index_type_ref_.index_type_name();
+  }
+
+  const std::vector<vef_index_profile_fn_binding_t> &functions() const {
+    return functions_;
+  }
+
+  bool ordering_asc() const { return ordering_asc_; }
+
+  // True if this profile is the default for its (type_name, index_type_name)
+  // pair — used when no profile is named at CREATE INDEX time.
+  bool default_for_type() const { return default_for_type_; }
+
+ private:
+  IndexProfileDescriptorKey key_;
+  TypeDescriptorKeyPrefix type_ref_;
+  IndexTypeDescriptorKeyPrefix index_type_ref_;
+  std::vector<vef_index_profile_fn_binding_t> functions_;
+  bool ordering_asc_{true};
+  bool default_for_type_{false};
+};
+
+// TableTraits specialization — MEMORY_ONLY, no backing table.
+template <>
+struct TableTraits<IndexProfileDescriptor> {};
+
+}  // namespace villagesql
+
+#endif  // VILLAGESQL_SCHEMA_DESCRIPTOR_INDEX_PROFILE_DESCRIPTOR_H_

--- a/villagesql/schema/descriptor/index_type_descriptor.cc
+++ b/villagesql/schema/descriptor/index_type_descriptor.cc
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#include "villagesql/schema/descriptor/index_type_descriptor.h"
+
+#include "villagesql/schema/systable/helpers.h"
+
+namespace villagesql {
+
+IndexTypeDescriptorKey::IndexTypeDescriptorKey(std::string index_type_name,
+                                               std::string extension_name,
+                                               std::string extension_version)
+    : index_type_name_(std::move(index_type_name)),
+      extension_name_(std::move(extension_name)),
+      extension_version_(std::move(extension_version)),
+      normalized_key_(normalize_type_name(index_type_name_) + "." +
+                      normalize_extension_name(extension_name_) + "." +
+                      normalize_extension_name(extension_version_)) {}
+
+IndexTypeDescriptor::IndexTypeDescriptor(IndexTypeDescriptorKey key,
+                                         vef_type_index_intf_t intf)
+    : key_(std::move(key)), intf_(intf) {}
+
+}  // namespace villagesql

--- a/villagesql/schema/descriptor/index_type_descriptor.h
+++ b/villagesql/schema/descriptor/index_type_descriptor.h
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+// IndexTypeDescriptor: In-memory descriptor for a VillageSQL custom index type.
+// Built from extension registration (IndexTypeDesc) and held in
+// VictionaryClient for the lifetime of the loaded extension.
+
+#ifndef VILLAGESQL_SCHEMA_DESCRIPTOR_INDEX_TYPE_DESCRIPTOR_H_
+#define VILLAGESQL_SCHEMA_DESCRIPTOR_INDEX_TYPE_DESCRIPTOR_H_
+
+#include <string>
+
+#include "villagesql/schema/systable/helpers.h"
+#include "villagesql/sdk/include/villagesql/abi/preview/index.h"
+
+namespace villagesql {
+
+template <typename EntryType>
+struct TableTraits;
+
+// Prefix key for querying IndexTypeDescriptors by index type name (and
+// optionally extension name). Format: "normalized_index_type_name." or
+// "normalized_index_type_name.normalized_ext_name."
+struct IndexTypeDescriptorKeyPrefix {
+  // Query by index type name only (for unqualified lookups).
+  explicit IndexTypeDescriptorKeyPrefix(std::string index_type_name)
+      : index_type_name_(std::move(index_type_name)),
+        normalized_prefix_(normalize_type_name(index_type_name_) + ".") {}
+
+  // Query by index type name + extension name.
+  IndexTypeDescriptorKeyPrefix(std::string index_type_name,
+                               std::string extension_name)
+      : index_type_name_(std::move(index_type_name)),
+        extension_name_(std::move(extension_name)),
+        normalized_prefix_(
+            normalize_type_name(index_type_name_) + "." +
+            (extension_name_.empty()
+                 ? ""
+                 : normalize_extension_name(extension_name_) + ".")) {}
+
+  const std::string &str() const { return normalized_prefix_; }
+  const std::string &index_type_name() const { return index_type_name_; }
+  const std::string &extension_name() const { return extension_name_; }
+
+ private:
+  std::string index_type_name_;
+  std::string extension_name_;
+  std::string normalized_prefix_;
+};
+
+// Key for IndexTypeDescriptor entries.
+// Format:
+// "normalized_index_type_name.normalized_extension_name.normalized_version"
+struct IndexTypeDescriptorKey {
+ public:
+  IndexTypeDescriptorKey() = default;
+
+  IndexTypeDescriptorKey(std::string index_type_name,
+                         std::string extension_name,
+                         std::string extension_version);
+
+  const std::string &str() const { return normalized_key_; }
+  const std::string &index_type_name() const { return index_type_name_; }
+  const std::string &extension_name() const { return extension_name_; }
+  const std::string &extension_version() const { return extension_version_; }
+
+  bool operator<(const IndexTypeDescriptorKey &other) const {
+    return normalized_key_ < other.normalized_key_;
+  }
+  bool operator==(const IndexTypeDescriptorKey &other) const {
+    return normalized_key_ == other.normalized_key_;
+  }
+
+ private:
+  std::string index_type_name_;
+  std::string extension_name_;
+  std::string extension_version_;
+  std::string normalized_key_;
+};
+
+// IndexTypeDescriptor: Immutable in-memory descriptor for a custom index type.
+// Holds the ABI interface table (function pointers) registered by the
+// extension.
+class IndexTypeDescriptor {
+ public:
+  using key_type = IndexTypeDescriptorKey;
+  using key_prefix_type = IndexTypeDescriptorKeyPrefix;
+
+  IndexTypeDescriptor() = default;
+
+  IndexTypeDescriptor(IndexTypeDescriptorKey key, vef_type_index_intf_t intf);
+
+  // Disable copy, enable move.
+  IndexTypeDescriptor(const IndexTypeDescriptor &) = delete;
+  IndexTypeDescriptor &operator=(const IndexTypeDescriptor &) = delete;
+  IndexTypeDescriptor(IndexTypeDescriptor &&) = default;
+  IndexTypeDescriptor &operator=(IndexTypeDescriptor &&) = default;
+
+  const IndexTypeDescriptorKey &key() const { return key_; }
+  const std::string &index_type_name() const { return key_.index_type_name(); }
+  const std::string &extension_name() const { return key_.extension_name(); }
+  const std::string &extension_version() const {
+    return key_.extension_version();
+  }
+  const vef_type_index_intf_t &intf() const { return intf_; }
+
+ private:
+  IndexTypeDescriptorKey key_;
+  vef_type_index_intf_t intf_{};
+};
+
+// TableTraits specialization — MEMORY_ONLY, no backing table.
+template <>
+struct TableTraits<IndexTypeDescriptor> {};
+
+}  // namespace villagesql
+
+#endif  // VILLAGESQL_SCHEMA_DESCRIPTOR_INDEX_TYPE_DESCRIPTOR_H_

--- a/villagesql/schema/systable/helpers.h
+++ b/villagesql/schema/systable/helpers.h
@@ -72,11 +72,15 @@ inline bool is_qualified_name(std::string_view name) {
   return name.find('.') != std::string_view::npos;
 }
 
-// Splits a potentially qualified name into (extension_name, bare_name).
+struct ParsedQualifiedName {
+  std::string extension_name;  // empty if unqualified
+  std::string bare_name;
+};
+
+// Splits a potentially qualified name into {extension_name, bare_name}.
 // "ext.name" -> {"ext", "name"}
 // "name"     -> {"",    "name"}
-inline std::pair<std::string, std::string> parse_qualified_name(
-    std::string_view name) {
+inline ParsedQualifiedName parse_qualified_name(std::string_view name) {
   auto dot = name.find('.');
   if (dot == std::string_view::npos) return {"", std::string(name)};
   return {std::string(name.substr(0, dot)), std::string(name.substr(dot + 1))};

--- a/villagesql/schema/systable/helpers.h
+++ b/villagesql/schema/systable/helpers.h
@@ -72,6 +72,16 @@ inline bool is_qualified_name(std::string_view name) {
   return name.find('.') != std::string_view::npos;
 }
 
+// Splits a potentially qualified name into (extension_name, bare_name).
+// "ext.name" -> {"ext", "name"}
+// "name"     -> {"",    "name"}
+inline std::pair<std::string, std::string> parse_qualified_name(
+    std::string_view name) {
+  auto dot = name.find('.');
+  if (dot == std::string_view::npos) return {"", std::string(name)};
+  return {std::string(name.substr(0, dot)), std::string(name.substr(dot + 1))};
+}
+
 // Helper functions for reading a value from a Field.
 void read_string_field(Field *f, std::string &out);
 void read_unsigned_field(Field *f, unsigned int &out);

--- a/villagesql/schema/victionary_client.h
+++ b/villagesql/schema/victionary_client.h
@@ -43,6 +43,8 @@
 #include "villagesql/include/error.h"
 #include "villagesql/schema/descriptor/extension_descriptor.h"
 #include "villagesql/schema/descriptor/func_descriptor.h"
+#include "villagesql/schema/descriptor/index_profile_descriptor.h"
+#include "villagesql/schema/descriptor/index_type_descriptor.h"
 #include "villagesql/schema/descriptor/type_context.h"
 #include "villagesql/schema/descriptor/type_descriptor.h"
 #include "villagesql/schema/systable/custom_columns.h"
@@ -684,6 +686,12 @@ class VictionaryClient {
   }
   ExtensionObjectMap<TypeContext> &type_contexts() { return m_type_contexts; }
   ExtensionObjectMap<FuncDescriptor> &funcs() { return m_funcs; }
+  ExtensionObjectMap<IndexTypeDescriptor> &index_type_descriptors() {
+    return m_index_type_descriptors;
+  }
+  ExtensionObjectMap<IndexProfileDescriptor> &index_profile_descriptors() {
+    return m_index_profile_descriptors;
+  }
   SystemTableMap<IndexEntry> &custom_indexes() { return m_custom_indexes; }
   SystemTableMap<IndexColumnEntry> &custom_index_columns() {
     return m_custom_index_columns;
@@ -707,6 +715,14 @@ class VictionaryClient {
     return m_type_contexts;
   }
   const ExtensionObjectMap<FuncDescriptor> &funcs() const { return m_funcs; }
+  const ExtensionObjectMap<IndexTypeDescriptor> &index_type_descriptors()
+      const {
+    return m_index_type_descriptors;
+  }
+  const ExtensionObjectMap<IndexProfileDescriptor> &index_profile_descriptors()
+      const {
+    return m_index_profile_descriptors;
+  }
   const SystemTableMap<IndexEntry> &custom_indexes() const {
     return m_custom_indexes;
   }
@@ -828,6 +844,8 @@ class VictionaryClient {
         m_extension_descriptors(&m_lock),
         m_type_contexts(&m_lock),
         m_funcs(&m_lock),
+        m_index_type_descriptors(&m_lock),
+        m_index_profile_descriptors(&m_lock),
         m_custom_indexes(&m_lock),
         m_custom_index_columns(&m_lock) {}
   ~VictionaryClient();
@@ -903,6 +921,8 @@ class VictionaryClient {
   ExtensionObjectMap<ExtensionDescriptor> m_extension_descriptors;
   ExtensionObjectMap<TypeContext> m_type_contexts;
   ExtensionObjectMap<FuncDescriptor> m_funcs;
+  ExtensionObjectMap<IndexTypeDescriptor> m_index_type_descriptors;
+  ExtensionObjectMap<IndexProfileDescriptor> m_index_profile_descriptors;
 
   // Custom index maps
   SystemTableMap<IndexEntry> m_custom_indexes;


### PR DESCRIPTION
## Description

Adds schema-layer descriptors for custom index types and profiles, providing the server-side representation of registered extension-defined index metadata and wiring them into VictionaryClient.

Part of #384 