### PR TITLE
sdk: add v1 disclaimer

### DIFF
--- a/villagesql/sdk/include/villagesql/extension.h
+++ b/villagesql/sdk/include/villagesql/extension.h
@@ -16,6 +16,10 @@
 #ifndef VILLAGESQL_SDK_EXTENSION_H
 #define VILLAGESQL_SDK_EXTENSION_H
 
+// Do not write new code against this header. It is included only for backward
+// compatibility and will be removed before Beta. Use the C++ API in
+// <villagesql/vsql.h> instead.
+
 // =============================================================================
 // VillageSQL Extension Framework
 // =============================================================================

--- a/villagesql/sdk/include/villagesql/extension_builder.h
+++ b/villagesql/sdk/include/villagesql/extension_builder.h
@@ -16,6 +16,10 @@
 #ifndef VILLAGESQL_SDK_EXTENSION_BUILDER_H
 #define VILLAGESQL_SDK_EXTENSION_BUILDER_H
 
+// Do not write new code against this header. It is included only for backward
+// compatibility and will be removed before Beta. Use the C++ API in
+// <villagesql/vsql.h> instead.
+
 // =============================================================================
 // Extension Builder - Registration via Fluent Builder API
 // =============================================================================

--- a/villagesql/sdk/include/villagesql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/func_builder.h
@@ -16,6 +16,10 @@
 #ifndef VILLAGESQL_SDK_FUNC_BUILDER_H
 #define VILLAGESQL_SDK_FUNC_BUILDER_H
 
+// Do not write new code against this header. It is included only for backward
+// compatibility and will be removed before Beta. Use the C++ API in
+// <villagesql/vsql.h> instead.
+
 // V1 function builder — supports raw ABI (vef_vdf_func_t) VDFs only.
 //
 // For the typed C++ API (IntArg, RealArg, Span<>, aggregate support, etc.)

--- a/villagesql/sdk/include/villagesql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/type_builder.h
@@ -16,6 +16,10 @@
 #ifndef VILLAGESQL_SDK_TYPE_BUILDER_H
 #define VILLAGESQL_SDK_TYPE_BUILDER_H
 
+// Do not write new code against this header. It is included only for backward
+// compatibility and will be removed before Beta. Use the C++ API in
+// <villagesql/vsql.h> instead.
+
 // Type descriptor builder.
 //
 // TypeDescriptor and the VDF-name-based TypeBuilder are used internally by


### PR DESCRIPTION
In old headers telling users ot prefer vsql.h

