### PR TITLE
harden GitHub Actions workflows

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -100,7 +100,7 @@ runs:
 
     - name: Upload test results and logs on failure
       if: failure()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: ${{ inputs.artifact-name }}
         path: |

--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -100,7 +100,7 @@ runs:
 
     - name: Upload test results and logs on failure
       if: failure()
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.artifact-name }}
         path: |

--- a/.github/actions/setup-villagesql-build/action.yml
+++ b/.github/actions/setup-villagesql-build/action.yml
@@ -22,7 +22,7 @@ runs:
 
     - name: Setup ccache
       if: inputs.setup-ccache == 'true'
-      uses: hendrikmuhs/ccache-action@5ebbd400eff9e74630f759d94ddd7b6c26299639  # v1.2
+      uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03  # v1.2.23
       with:
         key: ${{ runner.os }}-${{ inputs.cache-key-prefix }}-${{ github.sha }}
         restore-keys: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         # Get enough history for submodules and dependencies
         fetch-depth: 50

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         # Get enough history for submodules and dependencies
         fetch-depth: 50

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -51,7 +51,7 @@ jobs:
           ((contains(github.event.comment.body, 'recheck') ||
             contains(github.event.comment.body, 'I have read the CLA Document and I hereby sign the CLA')) ||
            github.event_name == 'pull_request_target')
-        uses: contributor-assistant/github-action@v2.6.1
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PAT }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,10 +25,6 @@ jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
       # No-op step that runs when the PR doesn't need a CLA check:
       #   - `upstream-merge` label: PRs that bring in vanilla MySQL changes
       #   - OWNER / MEMBER / COLLABORATOR: people with repo access already

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -25,6 +25,10 @@ jobs:
   CLAAssistant:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
       # No-op step that runs when the PR doesn't need a CLA check:
       #   - `upstream-merge` label: PRs that bring in vanilla MySQL changes
       #   - OWNER / MEMBER / COLLABORATOR: people with repo access already

--- a/.github/workflows/extension-compat.yml
+++ b/.github/workflows/extension-compat.yml
@@ -51,11 +51,6 @@ jobs:
       build-matrix: ${{ steps.build-matrix.outputs.build-matrix }}
       test-matrix: ${{ steps.build-matrix.outputs.test-matrix }}
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
@@ -98,13 +93,6 @@ jobs:
       OUTPUT_DIR: ${{ github.workspace }}/output
 
     steps:
-      # harden-runner supports only GitHub-hosted runners; skip on self-hosted.
-      - name: Harden the runner
-        if: runner.environment == 'github-hosted'
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
@@ -170,13 +158,6 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      # harden-runner supports only GitHub-hosted runners; skip on self-hosted.
-      - name: Harden the runner
-        if: runner.environment == 'github-hosted'
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
@@ -270,11 +251,6 @@ jobs:
     if: always() && inputs.notify != 'false'
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
       - name: Compute overall status
         id: status
         run: |

--- a/.github/workflows/extension-compat.yml
+++ b/.github/workflows/extension-compat.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
           ref: ${{ inputs.ref || github.ref }}
@@ -105,7 +105,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
           path: source
@@ -120,7 +120,7 @@ jobs:
         run: brew install bison cmake openssl
 
       - name: Cache Boost
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/boost
           key: boost-${{ runner.os }}-${{ runner.arch }}
@@ -143,14 +143,14 @@ jobs:
             source/scripts/make_villagesql_dev_server.sh
 
       - name: Upload dev server
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: devserver-${{ matrix.platform }}
           path: ${{ env.OUTPUT_DIR }}/*.tar.gz
           retention-days: 3
 
       - name: Upload SDK
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sdk-${{ matrix.platform }}
           path: ${{ env.BUILD_DIR }}/villagesql-extension-sdk-*.tar.gz
@@ -177,20 +177,20 @@ jobs:
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
           sparse-checkout: scripts/
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Download dev server
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: devserver-${{ matrix.platform }}
           path: artifacts/
 
       - name: Download SDK
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sdk-${{ matrix.platform }}
           path: artifacts/
@@ -257,7 +257,7 @@ jobs:
 
       - name: Upload MTR results on failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mtr-results-${{ matrix.extension }}-${{ matrix.platform }}-${{ matrix.abi }}
           path: ${{ env.PACKAGE_DIR }}/mysql-test/var/log/
@@ -295,7 +295,7 @@ jobs:
           fi
 
       - name: Send Slack notification
-        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/extension-compat.yml
+++ b/.github/workflows/extension-compat.yml
@@ -48,6 +48,11 @@ jobs:
       build-matrix: ${{ steps.build-matrix.outputs.build-matrix }}
       test-matrix: ${{ steps.build-matrix.outputs.test-matrix }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
@@ -90,6 +95,13 @@ jobs:
       OUTPUT_DIR: ${{ github.workspace }}/output
 
     steps:
+      # harden-runner supports only GitHub-hosted runners; skip on self-hosted.
+      - name: Harden the runner
+        if: runner.environment == 'github-hosted'
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
@@ -155,6 +167,13 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
+      # harden-runner supports only GitHub-hosted runners; skip on self-hosted.
+      - name: Harden the runner
+        if: runner.environment == 'github-hosted'
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
@@ -248,6 +267,11 @@ jobs:
     if: always() && inputs.notify != 'false'
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: Compute overall status
         id: status
         run: |

--- a/.github/workflows/extension-compat.yml
+++ b/.github/workflows/extension-compat.yml
@@ -48,7 +48,7 @@ jobs:
       build-matrix: ${{ steps.build-matrix.outputs.build-matrix }}
       test-matrix: ${{ steps.build-matrix.outputs.test-matrix }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           ref: ${{ inputs.ref || github.ref }}
@@ -90,7 +90,7 @@ jobs:
       OUTPUT_DIR: ${{ github.workspace }}/output
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           path: source
@@ -105,7 +105,7 @@ jobs:
         run: brew install bison cmake openssl
 
       - name: Cache Boost
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: /tmp/boost
           key: boost-${{ runner.os }}-${{ runner.arch }}
@@ -128,14 +128,14 @@ jobs:
             source/scripts/make_villagesql_dev_server.sh
 
       - name: Upload dev server
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: devserver-${{ matrix.platform }}
           path: ${{ env.OUTPUT_DIR }}/*.tar.gz
           retention-days: 3
 
       - name: Upload SDK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sdk-${{ matrix.platform }}
           path: ${{ env.BUILD_DIR }}/villagesql-extension-sdk-*.tar.gz
@@ -155,20 +155,20 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           sparse-checkout: scripts/
           ref: ${{ inputs.ref || github.ref }}
 
       - name: Download dev server
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: devserver-${{ matrix.platform }}
           path: artifacts/
 
       - name: Download SDK
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: sdk-${{ matrix.platform }}
           path: artifacts/
@@ -235,7 +235,7 @@ jobs:
 
       - name: Upload MTR results on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: mtr-results-${{ matrix.extension }}-${{ matrix.platform }}-${{ matrix.abi }}
           path: ${{ env.PACKAGE_DIR }}/mysql-test/var/log/
@@ -268,7 +268,7 @@ jobs:
           fi
 
       - name: Send Slack notification
-        uses: slackapi/slack-github-action@v2
+        uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a # v2.1.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/.github/workflows/extension-compat.yml
+++ b/.github/workflows/extension-compat.yml
@@ -37,6 +37,9 @@ on:
         type: boolean
         default: true
 
+permissions:
+  contents: read
+
 jobs:
   # Reads bundled_extensions.txt and builds a cross-product matrix of
   # (platform x extension x abi), filtered by any workflow_dispatch inputs.

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         ref: ${{ inputs.ref }}
         fetch-depth: 50

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         ref: ${{ inputs.ref }}
         fetch-depth: 50

--- a/.github/workflows/nightly-tag-test.yml
+++ b/.github/workflows/nightly-tag-test.yml
@@ -11,6 +11,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   # Determine the tag to test
   get-tag:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         fetch-depth: 1
         fetch-tags: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         fetch-depth: 1
         fetch-tags: true

--- a/.github/workflows/project-reopen.yml
+++ b/.github/workflows/project-reopen.yml
@@ -3,6 +3,9 @@ on:
   issues:
     types: [reopened]
 
+permissions:
+  contents: read
+
 jobs:
   reset-status:
     runs-on: ubuntu-latest

--- a/.github/workflows/project-reopen.yml
+++ b/.github/workflows/project-reopen.yml
@@ -10,11 +10,6 @@ jobs:
   reset-status:
     runs-on: ubuntu-latest
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
       - name: Get project item ID
         id: get-item
         env:

--- a/.github/workflows/project-reopen.yml
+++ b/.github/workflows/project-reopen.yml
@@ -7,6 +7,11 @@ jobs:
   reset-status:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: Get project item ID
         id: get-item
         env:

--- a/.github/workflows/release-dev-server.yml
+++ b/.github/workflows/release-dev-server.yml
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
           path: source
@@ -59,7 +59,7 @@ jobs:
         run: brew install bison cmake openssl
 
       - name: Cache Boost
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: /tmp/boost
           key: boost-${{ runner.os }}-${{ runner.arch }}
@@ -88,13 +88,13 @@ jobs:
           rm -rf "$TEST_DIR"
 
       - name: Upload package
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: devserver-${{ matrix.platform }}
           path: ${{ env.OUTPUT_DIR }}/*.tar.gz
 
       - name: Upload SDK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: sdk-${{ matrix.platform }}
           path: ${{ env.BUILD_DIR }}/villagesql-extension-sdk-*.tar.gz
@@ -117,7 +117,7 @@ jobs:
           fi
 
       - name: Download all packages
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           pattern: devserver-*
           merge-multiple: true

--- a/.github/workflows/release-dev-server.yml
+++ b/.github/workflows/release-dev-server.yml
@@ -43,6 +43,13 @@ jobs:
       BUILD_BUNDLED_EXTENSIONS: "1"
 
     steps:
+      # harden-runner supports only GitHub-hosted runners; skip on self-hosted.
+      - name: Harden the runner
+        if: runner.environment == 'github-hosted'
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -107,6 +114,11 @@ jobs:
       contents: write
 
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+        with:
+          egress-policy: audit
+
       - name: Determine release tag
         id: tag
         run: |

--- a/.github/workflows/release-dev-server.yml
+++ b/.github/workflows/release-dev-server.yml
@@ -54,7 +54,7 @@ jobs:
           egress-policy: audit
 
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 1
           path: source
@@ -69,7 +69,7 @@ jobs:
         run: brew install bison cmake openssl
 
       - name: Cache Boost
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /tmp/boost
           key: boost-${{ runner.os }}-${{ runner.arch }}
@@ -98,13 +98,13 @@ jobs:
           rm -rf "$TEST_DIR"
 
       - name: Upload package
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: devserver-${{ matrix.platform }}
           path: ${{ env.OUTPUT_DIR }}/*.tar.gz
 
       - name: Upload SDK
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sdk-${{ matrix.platform }}
           path: ${{ env.BUILD_DIR }}/villagesql-extension-sdk-*.tar.gz
@@ -132,7 +132,7 @@ jobs:
           fi
 
       - name: Download all packages
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: devserver-*
           merge-multiple: true

--- a/.github/workflows/release-dev-server.yml
+++ b/.github/workflows/release-dev-server.yml
@@ -19,6 +19,9 @@ on:
         description: 'Existing tag to build a release for (e.g. 0.0.3)'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build-package:
     name: Build (${{ matrix.platform }})

--- a/.github/workflows/release-dev-server.yml
+++ b/.github/workflows/release-dev-server.yml
@@ -46,13 +46,6 @@ jobs:
       BUILD_BUNDLED_EXTENSIONS: "1"
 
     steps:
-      # harden-runner supports only GitHub-hosted runners; skip on self-hosted.
-      - name: Harden the runner
-        if: runner.environment == 'github-hosted'
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -117,11 +110,6 @@ jobs:
       contents: write
 
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-        with:
-          egress-policy: audit
-
       - name: Determine release tag
         id: tag
         run: |

--- a/.github/workflows/testall.yml
+++ b/.github/workflows/testall.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
     - name: Get ref to test
       id: get-ref
-      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
       with:
         script: |
           if (context.eventName === 'workflow_dispatch') {

--- a/.github/workflows/testall.yml
+++ b/.github/workflows/testall.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
     - name: Get ref to test
       id: get-ref
-      uses: actions/github-script@v7
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
       with:
         script: |
           if (context.eventName === 'workflow_dispatch') {

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         ref: ${{ inputs.ref || github.ref }}
         fetch-depth: 50

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         ref: ${{ inputs.ref || github.ref }}
         fetch-depth: 50

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -28,7 +28,7 @@ jobs:
         egress-policy: audit
 
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
         # Checkout the merge commit that GitHub creates for PRs
         ref: ${{ github.sha }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:
         # Checkout the merge commit that GitHub creates for PRs
         ref: ${{ github.sha }}

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -22,11 +22,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Harden the runner
-      uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
-      with:
-        egress-policy: audit
-
     - name: Checkout code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate PR

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -19,6 +19,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Harden the runner
+      uses: step-security/harden-runner@ab7a9404c0f3da075243ca237b5fac12c98deaa5 # v2.19.3
+      with:
+        egress-policy: audit
+
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       with:


### PR DESCRIPTION
## Description
Supply-chain hardening for GitHub Actions:

- Pin all third-party actions to commit SHAs (immutable refs).
- Add least-privilege `contents: read` to workflows that lacked explicit permissions.
- Bump every pinned action that has a Node 24 release off the deprecated Node 20 runtime: `checkout` v4→v6, `upload-artifact` v4→v7, `download-artifact` v4→v8, `cache` v4→v5, `github-script` v7→v8, `slack-github-action` v2→v3, `ccache-action`→v1.2.23. `contributor-assistant/github-action` stays on v2.6.1 (no Node 24 release yet).
<!-- What does this PR do? Briefly describe the change. -->

## Related Issue
Relates to #616 (migrate GitHub Actions off the deprecated Node 20 runtime).
<!-- Link the GitHub issue this PR addresses, e.g. Fixes #123 -->

## How was this tested?
CI config only. Validated with `actionlint` + YAML parse; every pinned SHA round-trips to its tag (`gh apirepos/<repo>/commits/<tag>`). Exercised by this PR's CI run.

<!-- Describe how you verified your changes. Include test commands you ran. -->

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4

