### PR TITLE
VERSION clause to INSTALL EXTENSION

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_install_version.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_install_version.result
@@ -1,0 +1,18 @@
+# INSTALL with wrong VERSION fails and installs nothing
+INSTALL EXTENSION vsql_simple VERSION '9.9.9';
+ERROR HY000: Cannot install extension 'vsql_simple': manifest version is '0.0.1' but VERSION '9.9.9' was specified
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+EXTENSION_NAME	EXTENSION_VERSION
+# INSTALL with matching VERSION succeeds
+INSTALL EXTENSION vsql_simple VERSION '0.0.1';
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+EXTENSION_NAME	EXTENSION_VERSION
+vsql_simple	0.0.1
+UNINSTALL EXTENSION vsql_simple;
+# INSTALL without VERSION still works (backward compat)
+INSTALL EXTENSION vsql_simple;
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+EXTENSION_NAME	EXTENSION_VERSION
+vsql_simple	0.0.1
+UNINSTALL EXTENSION vsql_simple;
+include/rpl/deprecated/show_binlog_events.inc

--- a/mysql-test/suite/villagesql/extension/t/extension_install_version.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_install_version.test
@@ -1,0 +1,22 @@
+# Test INSTALL EXTENSION ... VERSION 'x.y.z' manifest-match clause.
+# When VERSION is specified, the VEB manifest version must match or install
+# fails. When omitted, install behaves as before.
+
+--source include/villagesql/binlog_check_begin.inc
+
+--echo # INSTALL with wrong VERSION fails and installs nothing
+--error ER_VILLAGESQL_GENERIC_ERROR
+INSTALL EXTENSION vsql_simple VERSION '9.9.9';
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+
+--echo # INSTALL with matching VERSION succeeds
+INSTALL EXTENSION vsql_simple VERSION '0.0.1';
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+UNINSTALL EXTENSION vsql_simple;
+
+--echo # INSTALL without VERSION still works (backward compat)
+INSTALL EXTENSION vsql_simple;
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+UNINSTALL EXTENSION vsql_simple;
+
+--source include/villagesql/binlog_check_end.inc

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -18282,11 +18282,12 @@ install_stmt:
             $$ = nullptr;
           }
         // TODO(villagesql-rebase): INSTALL EXTENSION grammar rule, check placement during MySQL rebase
-        | INSTALL_SYM EXTENSION_SYM IDENT_sys
+        | INSTALL_SYM EXTENSION_SYM IDENT_sys opt_extension_version
           {
             LEX *lex= Lex;
             lex->sql_command= SQLCOM_INSTALL_EXTENSION;
-            lex->m_sql_cmd= new (YYMEM_ROOT) Sql_cmd_install_extension(to_lex_cstring($3));
+            lex->m_sql_cmd= new (YYMEM_ROOT)
+                Sql_cmd_install_extension(to_lex_cstring($3), $4);
             $$ = nullptr;
           }
         | INSTALL_SYM COMPONENT_SYM TEXT_STRING_sys_list opt_install_set_value_list

--- a/villagesql/veb/sql_extension.cc
+++ b/villagesql/veb/sql_extension.cc
@@ -148,6 +148,17 @@ bool Sql_cmd_install_extension::execute(THD *thd) {
     return end_transaction(thd, true);
   }
 
+  std::string expected_version =
+      m_version.str ? to_string(m_version) : std::string();
+  if (!expected_version.empty() && version != expected_version) {
+    villagesql_error(
+        "Cannot install extension '%s': manifest version is '%s' but "
+        "VERSION '%s' was specified",
+        MYF(0), extension_name.c_str(), version.c_str(),
+        expected_version.c_str());
+    return end_transaction(thd, true);
+  }
+
   auto &victionary = villagesql::VictionaryClient::instance();
 
   // Early check: fail fast if extension already exists (from in-memory cache).

--- a/villagesql/veb/sql_extension.h
+++ b/villagesql/veb/sql_extension.h
@@ -33,7 +33,10 @@ extern char opt_veb_dir[FN_REFLEN];
 // This class implements the INSTALL EXTENSION statement.
 class Sql_cmd_install_extension : public Sql_cmd {
  public:
-  explicit Sql_cmd_install_extension(const LEX_CSTRING &name) : m_name(name) {}
+  // version: asserted VEB-manifest version (m_version.str == nullptr if no
+  // VERSION clause). When set, install fails unless the manifest matches.
+  Sql_cmd_install_extension(const LEX_CSTRING &name, const LEX_CSTRING &version)
+      : m_name(name), m_version(version) {}
 
   enum_sql_command sql_command_code() const override {
     return SQLCOM_INSTALL_EXTENSION;
@@ -46,6 +49,7 @@ class Sql_cmd_install_extension : public Sql_cmd {
 
  private:
   LEX_CSTRING m_name;
+  LEX_CSTRING m_version;
 };
 
 // This class implements the UNINSTALL EXTENSION statement.


### PR DESCRIPTION
## Description

`INSTALL EXTENSION foo VERSION '0.0.1'` asserts the VEB manifest version at install time. On mismatch the statement fails before any rows are written; omitting the clause keeps prior behavior. Companion to #345 (UNINSTALL VERSION) and mirrors its implementation.

## Related Issue

Fixes #501

## How was this tested?

New `extension_install_version` mysql-test: wrong VERSION fails and installs nothing, matching VERSION succeeds, no VERSION still works.

`./mysql-test-run.pl --suite=villagesql/extension extension_install_version`

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4