### PR TITLE
Use bundled-extension.txt for Docker

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -53,14 +53,17 @@ RUN mkdir /build && cd /build && \
 # Build bundled extensions and install .veb files to /install/usr/lib/veb
 ARG VSQL_DEV_ABI=ON
 COPY docker/server/build-bundled-extension.sh /usr/local/bin/
+COPY docker/server/build-bundled-extensions.sh /usr/local/bin/
 RUN mkdir -p /install/usr/lib/veb
+
 # In-tree extensions track the dev API, always use dev ABI
 RUN VSQL_DEV_ABI=ON build-bundled-extension.sh vsql-complex
+
 # Out-of-tree extensions use the configured ABI (stable for release builds)
-RUN VSQL_DEV_ABI=$VSQL_DEV_ABI build-bundled-extension.sh vsql-uuid
-RUN VSQL_DEV_ABI=$VSQL_DEV_ABI build-bundled-extension.sh vsql-network-address
-RUN VSQL_DEV_ABI=$VSQL_DEV_ABI build-bundled-extension.sh vsql-ai
-RUN VSQL_DEV_ABI=$VSQL_DEV_ABI build-bundled-extension.sh vsql-crypto
+# and have additional dependencies
+COPY scripts/setup_linux_ext_deps.sh /tmp/
+RUN /tmp/setup_linux_ext_deps.sh && rm -rf /var/lib/apt/lists/*
+RUN VSQL_DEV_ABI=$VSQL_DEV_ABI build-bundled-extensions.sh
 
 # ---------------------------------------------------------------------------
 # Stage 2: Runtime image

--- a/docker/server/build-bundled-extensions.sh
+++ b/docker/server/build-bundled-extensions.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Copyright (c) 2026 VillageSQL Contributors
+# Build VEB files for bundled VillageSQL extensions.
+#
+# Usage: include_bundled_extensions.sh <dst_dir> <veb_src_dir>
+#
+# <veb_src_dir>: Directory where built .veb files were placed.
+#
+# The extension list is read from villagesql/dev_server/bundled_extensions.txt,
+# located relative to this script's source tree.
+
+set -euo pipefail
+
+EXTENSIONS_LIST="source/villagesql/dev_server/bundled_extensions.txt"
+
+function log_info() { echo "$*"; }
+
+if [[ ! -f "$EXTENSIONS_LIST" ]]; then
+    log_info "Extensions list not found: $EXTENSIONS_LIST"
+    exit 1
+fi
+
+# Read and parse the list of extensions
+while IFS= read -r line; do
+    [[ "$line" =~ ^[[:space:]]*# ]] && continue
+    [[ -z "${line// }" ]] && continue
+
+    # Parse "url [branch-or-tag] [key=value ...]" — all fields after url are optional
+    read -ra FIELDS <<< "$line"
+    SOURCE="${FIELDS[0]%/}"
+    BRANCH="${FIELDS[1]:-}"
+    REPO_NAME="${SOURCE##*/}"
+
+    # Confirm the extension is bundled
+    BUNDLE=true
+    for FIELD in "${FIELDS[@]:2}"; do
+        [[ "$FIELD" == "bundle=false" || "$FIELD" == "bundle=no" ]] && BUNDLE=false
+    done
+    if [[ "$BUNDLE" == "false" ]]; then
+        log_info "Skipping $REPO_NAME (bundle=false)"
+        continue
+    fi
+
+    build-bundled-extension.sh "$REPO_NAME"
+
+done < "$EXTENSIONS_LIST"


### PR DESCRIPTION
## Description

Update the script for the docker image to use the list of bundled extensions
that is provided by the server/bundled_extensions.txt file.

## Related Issue

Closed Issue #545 : [Server]: Build docker image will all types from bundled_extensions.txt