### PR TITLE
sdk: add preview, ABI disclaimers

### DIFF
--- a/villagesql/sdk/include/villagesql/abi/README.md
+++ b/villagesql/sdk/include/villagesql/abi/README.md
@@ -1,0 +1,33 @@
+# VEF ABI Headers
+
+These headers define the **binary interface** (ABI) between the VillageSQL
+server and extension `.so` files. They are the contract enforced at load
+time.
+
+## Don't write code against these headers
+
+If you are writing an extension, use the C++ API in `<villagesql/vsql.h>`
+instead. The ABI headers define raw C structs and function-pointer
+signatures (`vef_invalue_t`, `vef_vdf_func_t`, etc.) that are intentionally
+minimal and ergonomically poor — the API is what makes them usable.
+
+The ABI exists so:
+
+- The server and extension `.so` files can be compiled separately and still
+  agree on memory layout and calling conventions.
+- An extension built against an older protocol version keeps working when
+  loaded by a newer server, via protocol negotiation.
+
+## Stability
+
+The ABI's stability story is governed by **protocol versions**, not by the
+SDK release cadence. See [../../API_ABI.md](../../API_ABI.md) for the full
+distinction between API and ABI and how each evolves.
+
+Concretely:
+
+- `stable_sdk/v{N}/` snapshots are the frozen ABI surface for protocol N.
+  An extension compiled against a frozen snapshot must continue to load on
+  all future server versions.
+- Headers under `abi/preview/` expose preview-capability ABIs and follow
+  the preview-capability rules in [../preview/README.md](../preview/README.md).

--- a/villagesql/sdk/include/villagesql/abi/preview/index.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/index.h
@@ -14,6 +14,16 @@
  * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 
+// =============================================================================
+// VEF PREVIEW ABI HEADER — UNSTABLE BINARY INTERFACE
+// =============================================================================
+// This header is both:
+//   - an ABI header — extension authors should use the C++ API in
+//     <villagesql/vsql.h>, not these raw types. See villagesql/abi/README.md.
+//   - a preview capability — API and ABI may change or be removed without
+//     notice. See villagesql/preview/README.md.
+// =============================================================================
+
 #ifndef VILLAGESQL_ABI_INDEX_H_
 #define VILLAGESQL_ABI_INDEX_H_
 

--- a/villagesql/sdk/include/villagesql/abi/preview/keyring.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/keyring.h
@@ -13,6 +13,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+// =============================================================================
+// VEF PREVIEW ABI HEADER — UNSTABLE BINARY INTERFACE
+// =============================================================================
+// This header is both:
+//   - an ABI header — extension authors should use the C++ API in
+//     <villagesql/vsql.h>, not these raw types. See villagesql/abi/README.md.
+//   - a preview capability — API and ABI may change or be removed without
+//     notice. See villagesql/preview/README.md.
+// =============================================================================
+
 #ifndef VILLAGESQL_ABI_PREVIEW_KEYRING_H
 #define VILLAGESQL_ABI_PREVIEW_KEYRING_H
 

--- a/villagesql/sdk/include/villagesql/abi/preview/ping.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/ping.h
@@ -13,6 +13,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+// =============================================================================
+// VEF PREVIEW ABI HEADER — UNSTABLE BINARY INTERFACE
+// =============================================================================
+// This header is both:
+//   - an ABI header — extension authors should use the C++ API in
+//     <villagesql/vsql.h>, not these raw types. See villagesql/abi/README.md.
+//   - a preview capability — API and ABI may change or be removed without
+//     notice. See villagesql/preview/README.md.
+// =============================================================================
+
 #ifndef VILLAGESQL_ABI_PREVIEW_PING_H
 #define VILLAGESQL_ABI_PREVIEW_PING_H
 

--- a/villagesql/sdk/include/villagesql/abi/preview/sql_query.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/sql_query.h
@@ -13,6 +13,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+// =============================================================================
+// VEF PREVIEW ABI HEADER — UNSTABLE BINARY INTERFACE
+// =============================================================================
+// This header is both:
+//   - an ABI header — extension authors should use the C++ API in
+//     <villagesql/vsql.h>, not these raw types. See villagesql/abi/README.md.
+//   - a preview capability — API and ABI may change or be removed without
+//     notice. See villagesql/preview/README.md.
+// =============================================================================
+
 #ifndef VILLAGESQL_ABI_PREVIEW_SQL_QUERY_H
 #define VILLAGESQL_ABI_PREVIEW_SQL_QUERY_H
 

--- a/villagesql/sdk/include/villagesql/abi/preview/status_var.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/status_var.h
@@ -13,6 +13,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+// =============================================================================
+// VEF PREVIEW ABI HEADER — UNSTABLE BINARY INTERFACE
+// =============================================================================
+// This header is both:
+//   - an ABI header — extension authors should use the C++ API in
+//     <villagesql/vsql.h>, not these raw types. See villagesql/abi/README.md.
+//   - a preview capability — API and ABI may change or be removed without
+//     notice. See villagesql/preview/README.md.
+// =============================================================================
+
 #ifndef VILLAGESQL_ABI_PREVIEW_STATUS_VAR_H
 #define VILLAGESQL_ABI_PREVIEW_STATUS_VAR_H
 

--- a/villagesql/sdk/include/villagesql/abi/preview/storage.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/storage.h
@@ -14,8 +14,15 @@
  * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 
-// TODO(villagesql-beta): Column storage ABI is not ready for external use.
-// See storage_api.h for details.
+// =============================================================================
+// VEF PREVIEW ABI HEADER — UNSTABLE BINARY INTERFACE
+// =============================================================================
+// This header is both:
+//   - an ABI header — extension authors should use the C++ API in
+//     <villagesql/vsql.h>, not these raw types. See villagesql/abi/README.md.
+//   - a preview capability — API and ABI may change or be removed without
+//     notice. See villagesql/preview/README.md.
+// =============================================================================
 
 #ifndef VILLAGESQL_ABI_PREVIEW_STORAGE_H_
 #define VILLAGESQL_ABI_PREVIEW_STORAGE_H_

--- a/villagesql/sdk/include/villagesql/abi/preview/sys_var.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/sys_var.h
@@ -13,6 +13,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+// =============================================================================
+// VEF PREVIEW ABI HEADER — UNSTABLE BINARY INTERFACE
+// =============================================================================
+// This header is both:
+//   - an ABI header — extension authors should use the C++ API in
+//     <villagesql/vsql.h>, not these raw types. See villagesql/abi/README.md.
+//   - a preview capability — API and ABI may change or be removed without
+//     notice. See villagesql/preview/README.md.
+// =============================================================================
+
 #ifndef VILLAGESQL_ABI_PREVIEW_SYS_VAR_H
 #define VILLAGESQL_ABI_PREVIEW_SYS_VAR_H
 

--- a/villagesql/sdk/include/villagesql/abi/preview/thread_worker.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/thread_worker.h
@@ -13,6 +13,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+// =============================================================================
+// VEF PREVIEW ABI HEADER — UNSTABLE BINARY INTERFACE
+// =============================================================================
+// This header is both:
+//   - an ABI header — extension authors should use the C++ API in
+//     <villagesql/vsql.h>, not these raw types. See villagesql/abi/README.md.
+//   - a preview capability — API and ABI may change or be removed without
+//     notice. See villagesql/preview/README.md.
+// =============================================================================
+
 #ifndef VILLAGESQL_ABI_PREVIEW_THREAD_WORKER_H
 #define VILLAGESQL_ABI_PREVIEW_THREAD_WORKER_H
 

--- a/villagesql/sdk/include/villagesql/abi/types.h
+++ b/villagesql/sdk/include/villagesql/abi/types.h
@@ -14,6 +14,15 @@
  * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 
+// =============================================================================
+// VEF ABI HEADER — DO NOT WRITE CODE AGAINST THIS DIRECTLY
+// =============================================================================
+// This file defines the binary interface between the server and extension
+// .so files. Extension authors should use the C++ API in
+// <villagesql/vsql.h>, not these raw types. See villagesql/abi/README.md
+// for details.
+// =============================================================================
+
 #ifndef VILLAGESQL_ABI_TYPES_H_
 #define VILLAGESQL_ABI_TYPES_H_
 

--- a/villagesql/sdk/include/villagesql/preview/README.md
+++ b/villagesql/sdk/include/villagesql/preview/README.md
@@ -1,0 +1,64 @@
+# Preview Capabilities
+
+Headers in this directory expose **preview capabilities** — VEF features that
+are available for early use and feedback but are not yet part of the stable
+SDK surface.
+
+## What "preview" means
+
+A preview capability is an SDK feature that we want extension authors to be
+able to try, but that we have not committed to keeping stable. Concretely:
+
+- **API may change.** Function names, class shapes, method signatures, and
+  header locations can change between server versions, with no deprecation
+  window.
+- **ABI may change.** A preview capability's ABI version is independent of
+  the VEF protocol version; an extension built against one server's preview
+  ABI is not guaranteed to load on a newer server.
+- **The capability may be removed.** A preview capability can be withdrawn
+  entirely if the design doesn't pan out.
+- **No backwards-compatibility guarantee.** Unlike code that uses only the
+  stable SDK (`villagesql/sdk/include/villagesql/*.h` outside this directory),
+  extensions that use preview capabilities should expect to be recompiled,
+  and possibly rewritten, against future server versions.
+- **Individual capabilities may make stronger guarantees.** A specific
+  preview capability's own header may document narrower commitments (for
+  example, an ABI that is stable even while the API still evolves). When
+  those exist, they override the defaults above for that capability only.
+
+This is intentional. Preview is how we ship a capability early enough to
+get real usage and feedback while we still have room to change its shape.
+
+## Enabling preview capabilities on the server
+
+Extensions that use any preview capability will not load unless the server
+has preview extensions enabled. The relevant system variable is:
+
+```
+vsql_allow_preview_extensions
+```
+
+It defaults to `OFF`. To turn it on, use `SET PERSIST` so the setting
+survives restart (the server rejects plain `SET GLOBAL = ON`):
+
+```sql
+SET PERSIST vsql_allow_preview_extensions = ON;
+```
+
+Once any preview extension is installed, the server will refuse to set this
+variable back to `OFF` until those extensions are uninstalled.
+
+## How to use a preview capability
+
+- Treat preview headers as **opt-in**: an extension that touches a preview
+  capability is opting out of the normal cross-version compatibility story
+  for that capability.
+- **Send us feedback.** Preview exists so we can learn what works before
+  freezing the API; if something is awkward, please tell us.
+
+## Graduation
+
+When a preview capability's shape has settled and we are ready to commit to
+its stability, it will move out of `villagesql/preview/` into the stable
+SDK surface, with appropriate protocol/version guarantees. Until then,
+assume nothing in this directory is stable.

--- a/villagesql/sdk/include/villagesql/preview/index_builder.h
+++ b/villagesql/sdk/include/villagesql/preview/index_builder.h
@@ -13,13 +13,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+// =============================================================================
+// PREVIEW CAPABILITY — UNSTABLE API
+// =============================================================================
+// This header is part of the VEF preview surface. Its API and ABI may change
+// or be removed without notice. See villagesql/preview/README.md for details.
+// =============================================================================
+
 #ifndef VILLAGESQL_PREVIEW_INDEX_BUILDER_H
 #define VILLAGESQL_PREVIEW_INDEX_BUILDER_H
 
-// TODO(villagesql-beta): Custom index storage is not ready for external use.
-// The ABI and API are under active development and will change without notice.
-// Do not use this in production extensions.
-//
 // This file provides the C++ builder API for defining custom index types,
 // index profiles, and index functions.
 //

--- a/villagesql/sdk/include/villagesql/preview/keyring.h
+++ b/villagesql/sdk/include/villagesql/preview/keyring.h
@@ -13,6 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+// =============================================================================
+// PREVIEW CAPABILITY — UNSTABLE API
+// =============================================================================
+// This header is part of the VEF preview surface. Its API and ABI may change
+// or be removed without notice. See villagesql/preview/README.md for details.
+// =============================================================================
+
 #ifndef VILLAGESQL_PREVIEW_KEYRING_H
 #define VILLAGESQL_PREVIEW_KEYRING_H
 

--- a/villagesql/sdk/include/villagesql/preview/ping.h
+++ b/villagesql/sdk/include/villagesql/preview/ping.h
@@ -13,6 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+// =============================================================================
+// PREVIEW CAPABILITY — UNSTABLE API
+// =============================================================================
+// This header is part of the VEF preview surface. Its API and ABI may change
+// or be removed without notice. See villagesql/preview/README.md for details.
+// =============================================================================
+
 #ifndef VILLAGESQL_PREVIEW_PING_H
 #define VILLAGESQL_PREVIEW_PING_H
 

--- a/villagesql/sdk/include/villagesql/preview/sql_query.h
+++ b/villagesql/sdk/include/villagesql/preview/sql_query.h
@@ -13,6 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+// =============================================================================
+// PREVIEW CAPABILITY — UNSTABLE API
+// =============================================================================
+// This header is part of the VEF preview surface. Its API and ABI may change
+// or be removed without notice. See villagesql/preview/README.md for details.
+// =============================================================================
+
 #ifndef VILLAGESQL_PREVIEW_SQL_QUERY_H
 #define VILLAGESQL_PREVIEW_SQL_QUERY_H
 

--- a/villagesql/sdk/include/villagesql/preview/status_var.h
+++ b/villagesql/sdk/include/villagesql/preview/status_var.h
@@ -13,6 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+// =============================================================================
+// PREVIEW CAPABILITY — UNSTABLE API
+// =============================================================================
+// This header is part of the VEF preview surface. Its API and ABI may change
+// or be removed without notice. See villagesql/preview/README.md for details.
+// =============================================================================
+
 #ifndef VILLAGESQL_PREVIEW_STATUS_VAR_H
 #define VILLAGESQL_PREVIEW_STATUS_VAR_H
 

--- a/villagesql/sdk/include/villagesql/preview/storage_api.h
+++ b/villagesql/sdk/include/villagesql/preview/storage_api.h
@@ -14,11 +14,14 @@
  * along with this program; if not, see <https://www.gnu.org/licenses/>.
  */
 
-// Interface to InnoDB for extensions
-//
-// TODO(villagesql-beta): Column storage is not ready for external use. The ABI
-// and API are under active development and will change without notice. Do not
-// use this in production extensions.
+// =============================================================================
+// PREVIEW CAPABILITY — UNSTABLE API
+// =============================================================================
+// This header is part of the VEF preview surface. Its API and ABI may change
+// or be removed without notice. See villagesql/preview/README.md for details.
+// =============================================================================
+
+// Interface to InnoDB for extensions.
 
 #ifndef VILLAGESQL_PREVIEW_STORAGE_API_H_
 #define VILLAGESQL_PREVIEW_STORAGE_API_H_

--- a/villagesql/sdk/include/villagesql/preview/storage_builder.h
+++ b/villagesql/sdk/include/villagesql/preview/storage_builder.h
@@ -13,12 +13,16 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+// =============================================================================
+// PREVIEW CAPABILITY — UNSTABLE API
+// =============================================================================
+// This header is part of the VEF preview surface. Its API and ABI may change
+// or be removed without notice. See villagesql/preview/README.md for details.
+// =============================================================================
+
 #ifndef VILLAGESQL_PREVIEW_STORAGE_BUILDER_H
 #define VILLAGESQL_PREVIEW_STORAGE_BUILDER_H
 
-// TODO(villagesql-beta): Column storage is not ready for external use.
-// See storage_api.h for details.
-//
 // This file provides:
 //   - StorageCapability: capability token passed to make_extension().with().
 //     Declares the InnoDB storage API requirement.

--- a/villagesql/sdk/include/villagesql/preview/sys_var.h
+++ b/villagesql/sdk/include/villagesql/preview/sys_var.h
@@ -13,6 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+// =============================================================================
+// PREVIEW CAPABILITY — UNSTABLE API
+// =============================================================================
+// This header is part of the VEF preview surface. Its API and ABI may change
+// or be removed without notice. See villagesql/preview/README.md for details.
+// =============================================================================
+
 #ifndef VILLAGESQL_PREVIEW_SYS_VAR_H
 #define VILLAGESQL_PREVIEW_SYS_VAR_H
 

--- a/villagesql/sdk/include/villagesql/preview/thread_worker.h
+++ b/villagesql/sdk/include/villagesql/preview/thread_worker.h
@@ -13,6 +13,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
+// =============================================================================
+// PREVIEW CAPABILITY — UNSTABLE API
+// =============================================================================
+// This header is part of the VEF preview surface. Its API and ABI may change
+// or be removed without notice. See villagesql/preview/README.md for details.
+// =============================================================================
+
 #ifndef VILLAGESQL_PREVIEW_THREAD_WORKER_H
 #define VILLAGESQL_PREVIEW_THREAD_WORKER_H
 


### PR DESCRIPTION
1) add a README.md about using VEF ABI and why you shouldn't use it in villagesql/abi/README.md
2) also a preview/README.md
3) add short banners with admonitions to relevant docs and header files that live in preview or abi or both that reference the aforementioned files

Mechanically, I'll wait to land this until after the SDK move is settled. If you approve, I'll make sure to rebase and apply to both the v3 and v4 files.