### PR TITLE
Remove TODOs in the stable ABIs

### DIFF
--- a/villagesql/stable_sdk/v1/include/villagesql/abi/types.h
+++ b/villagesql/stable_sdk/v1/include/villagesql/abi/types.h
@@ -202,8 +202,6 @@ typedef enum : int {
   VEF_TYPE_REAL = 1,
   VEF_TYPE_INT = 2,
   VEF_TYPE_CUSTOM = 3
-
-  // TODO(villagesql-ga): Do we want to support DECIMAL?
 } vef_type_id;
 
 // Input value for VDF function arguments.

--- a/villagesql/stable_sdk/v1/lib/cmake/VillageSQLExtensionFramework/VillageSQLExtensionFrameworkConfig.cmake
+++ b/villagesql/stable_sdk/v1/lib/cmake/VillageSQLExtensionFramework/VillageSQLExtensionFrameworkConfig.cmake
@@ -81,7 +81,6 @@ FUNCTION(VEF_CREATE_VEB)
   FILE(MAKE_DIRECTORY ${VEB_STAGING_DIR}/lib)
 
   # Configure the library target to output to staging/lib
-  # TODO(villagesql-windows): Handle DLL when building for Windows
   SET_TARGET_PROPERTIES(${ARG_LIBRARY_TARGET} PROPERTIES
     OUTPUT_NAME ${ARG_NAME}
     LIBRARY_OUTPUT_DIRECTORY ${VEB_STAGING_DIR}/lib

--- a/villagesql/stable_sdk/v3/include/villagesql/abi/preview/index.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/abi/preview/index.h
@@ -497,7 +497,6 @@ typedef struct {
 
   // DML functions
   vef_type_index_insert_func_t insert;
-  // TODO(villagesql-indexing): Add bulk insert interface.
   vef_type_index_mark_delete_func_t mark_delete;
   vef_type_index_purge_func_t purge;
 

--- a/villagesql/stable_sdk/v3/include/villagesql/abi/preview/status_var.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/abi/preview/status_var.h
@@ -54,11 +54,6 @@ typedef enum {
   VEF_STATUS_VAR_DOUBLE = 1,  // double gauge
 } vef_status_var_type_t;
 
-// TODO(villagesql-beta): rename vef_status_var_desc_t to
-// vef_status_var_cc_t (capability_config) and
-// vef_status_var_descriptor_list_t to vef_status_var_cc_list_t to match
-// the capability_config naming used by
-// vef_required_capability_t.capability_config.
 typedef struct {
   // Variable name (without extension prefix). Encoded using UTF-8.
   const char *name;

--- a/villagesql/stable_sdk/v3/include/villagesql/abi/preview/storage.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/abi/preview/storage.h
@@ -263,9 +263,6 @@ typedef struct {
 
 // Section 2: InnoDB Storage Engine Interfaces
 // -------------------------------------------
-// TODO(villagesql-windows): Export symbols with __declspec(dllexport) on
-// Windows so that extensions can link against these functions.
-
 // Storage engine interface version constants.
 #define VEF_STORAGE_SE_INTF_VERSION_1 1
 #define VEF_STORAGE_SE_INTF_VERSION VEF_STORAGE_SE_INTF_VERSION_1
@@ -592,10 +589,6 @@ typedef struct {
 // Extension descriptor for vsql::preview::column_store.
 // Pass as vef_required_capability_t.capability_config.
 //
-// TODO(villagesql-beta): rename vef_preview_column_store_ext_desc_t to
-// vef_preview_column_store_cc_t (capability_config) to match the
-// capability_config naming used by
-// vef_required_capability_t.capability_config.
 typedef struct {
   // Must be set to VEF_COLUMN_STORE_INTF_VERSION.
   uint32_t version;

--- a/villagesql/stable_sdk/v3/include/villagesql/abi/preview/sys_var.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/abi/preview/sys_var.h
@@ -74,10 +74,6 @@ typedef struct {
 // Callback invoked after the server writes a new value for a system variable.
 typedef void (*vef_sys_var_on_change_func_t)(const vef_sys_var_change_t *);
 
-// TODO(villagesql-beta): rename vef_sys_var_desc_t to vef_sys_var_cc_t
-// (capability_config) and vef_sys_var_descriptor_list_t to
-// vef_sys_var_cc_list_t to match the capability_config naming used by
-// vef_required_capability_t.capability_config.
 typedef struct {
   // Variable name (without extension prefix). Encoded using UTF-8.
   const char *name;

--- a/villagesql/stable_sdk/v3/include/villagesql/abi/preview/thread_worker.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/abi/preview/thread_worker.h
@@ -73,10 +73,6 @@ typedef vef_next_wakeup_t (*vef_work_fn_t)(vef_wakeup_reason_t reason,
 // extension load time and manages the thread entirely — the extension only
 // provides the work function and configuration.
 //
-// TODO(villagesql-beta): rename `descriptor` to `cc` (capability_config) to
-// match vef_required_capability_t.capability_config and the trait/server
-// naming.  This is the type whose instance is passed as capability_config.
-//
 // All pointers must remain valid for the lifetime of the extension.
 typedef struct {
   // Called by the server on each wakeup. Required.

--- a/villagesql/stable_sdk/v3/include/villagesql/abi/types.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/abi/types.h
@@ -231,8 +231,6 @@ typedef enum : int {
   VEF_TYPE_REAL = 1,
   VEF_TYPE_INT = 2,
   VEF_TYPE_CUSTOM = 3
-
-  // TODO(villagesql-ga): Do we want to support DECIMAL?
 } vef_type_id;
 
 // Snapshot of vef_invalue_t as of VEF_PROTOCOL_1. Used as the element type of
@@ -316,8 +314,6 @@ typedef struct {
 
       // protocol >= VEF_PROTOCOL_3
       // Read-only: the extension must not overwrite these parameters.
-      // TODO(villagesql-beta): Optimize this to pass a token so that the
-      // extension can cache these values in a language-specific way.
       vef_type_params_t type_params;
     };
 

--- a/villagesql/stable_sdk/v3/include/villagesql/detail/func_builder.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/detail/func_builder.h
@@ -607,14 +607,6 @@ struct WrapperVoidStarRefState {
 // extension that early-returns without setting an outcome still surfaces a
 // useful warning.
 //
-// TODO(villagesql-beta): tighten the contract so every from_string (and
-// every other wrapped type-op once they're migrated to typed result
-// wrappers) is expected to explicitly call out.set_length / set_null /
-// warning / error on every path. This default-WARNING fallback exists today
-// because some in-tree extensions (vsql-complex, vsql-simple, vsql-test-only,
-// vsql-storage-test) early-return on failure paths without calling anything;
-// once they're updated to be explicit, drop this synthesis and treat
-// "extension didn't set a result" as an SDK bug.
 inline void set_default_encode_failure(vef_vdf_result_t *result,
                                        const vef_invalue_t &arg) {
   result->type = VEF_RESULT_WARNING;
@@ -655,10 +647,6 @@ struct TypeEncodeVdfWrapper {
 // invoking the extension's to_string so that an extension that early-returns
 // without setting an outcome still surfaces a useful error.
 //
-// TODO(villagesql-beta): tighten the contract so every to_string explicitly
-// sets an outcome (set_length / set / set_null / warning / error) on every
-// path, then drop this synthesis and treat the silent-return case as an SDK
-// bug. Mirrors the same TODO on set_default_encode_failure.
 inline void set_default_decode_failure(vef_vdf_result_t *result) {
   result->type = VEF_RESULT_ERROR;
   snprintf(result->error_msg, VEF_MAX_ERROR_LEN, "failed to decode value");
@@ -928,7 +916,6 @@ struct IntToParamsWrapper {
       return;
     }
 
-    // TODO(villagesql-beta): decide on a broader character set policy.
     std::string serialized;
     for (const auto &[key, value] : params) {
       if (key.empty() || key.find_first_of(",=") != std::string::npos) {

--- a/villagesql/stable_sdk/v3/include/villagesql/extension.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/extension.h
@@ -299,11 +299,9 @@
 // signature and routes through the cache; .params<>() binds the parse
 // function at startup. Omitting .params<>() while using parameterized
 // signatures will crash at runtime.
-// TODO(villagesql-beta): make this a compile time error.
 //
 // Note if a Params type is registered for more than one custom type, each
 // custom type MUST register the same type function.
-// TODO(villagesql-beta): remove this restriction.
 //
 // REGISTERING THE EXTENSION
 // -------------------------

--- a/villagesql/stable_sdk/v3/include/villagesql/preview/index_builder.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/preview/index_builder.h
@@ -141,8 +141,6 @@
 //       .deterministic()
 //       .build();
 //
-// TODO(villagesql-indexing): make_index_function is a stub; full server-side
-// integration is pending.
 
 #include <cstdio>
 #include <new>
@@ -435,7 +433,6 @@ void IndexTypeBuilder_storage_props_must_set_row_or_column_ref();
 
 // Descriptor returned by GlobalBuilder::build(). Consumed by the extension
 // builder (e.g. make_extension().index_type(HNSW_INDEX)).
-// TODO(villagesql-indexing): add index_type() to the extension builder.
 struct IndexTypeDesc {
   const char *name;
   vef_type_index_intf_t intf;
@@ -781,16 +778,11 @@ constexpr IndexTypeRootBuilder<Name, Context> make_index_type() {
 // .with_function(fn_id, name) call binds a profile function to the fn_id used
 // by the index storage implementation when calling vef_index_profile_fn.
 //
-// TODO(villagesql-indexing): IndexProfileDesc is not yet consumed by the
-// server; registration API pending.
-
 // Descriptor returned by make_index_function().build(). Passing one of these
 // to IndexProfileBuilder::with_function() instead of a raw string enforces
 // that the bound function was declared by the same extension.
 struct IndexFunctionDesc {
   const char *name;
-  // TODO(villagesql-indexing): add return type, parameter types, and
-  // determinism flag once server-side consumption is defined.
 };
 
 struct IndexProfileFunctionBinding {
@@ -874,16 +866,10 @@ inline IndexProfileBuilder make_index_profile(const char *name) {
 // make_func: the optimizer needs explicit metadata about which functions define
 // index behavior, and index functions may be internal-only.
 //
-// TODO(villagesql-indexing): IndexFunctionDesc is a stub. Full integration
-// with the function registry (return type, parameter types, determinism flag)
-// is pending server-side support.
-
 class IndexFunctionBuilder {
  public:
   explicit IndexFunctionBuilder(const char *name) { desc_.name = name; }
 
-  // TODO(villagesql-indexing): store and validate these once server-side
-  // consumption is defined.
   IndexFunctionBuilder &returns(const char * /*type*/) { return *this; }
   IndexFunctionBuilder &param(const char * /*type*/) { return *this; }
   IndexFunctionBuilder &deterministic() { return *this; }
@@ -897,7 +883,7 @@ class IndexFunctionBuilder {
 // F is accepted as a template parameter so the call site matches the final API
 // shape (make_index_function<&fn>("name")), but is intentionally not stored or
 // called in this stub. The function pointer is discarded; only the name is
-// retained. TODO(villagesql-indexing): store F once server integration is done.
+// retained.
 template <auto F>
 inline IndexFunctionBuilder make_index_function(const char *name) {
   return IndexFunctionBuilder(name);

--- a/villagesql/stable_sdk/v3/include/villagesql/preview/status_var.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/preview/status_var.h
@@ -100,8 +100,6 @@ class StatusVarCapability
 
   // Read by the server's on_populate callback. Public so CapabilityTraits
   // can return its address as capability_config.
-  // TODO(villagesql-beta): rename `descriptor_list` to `cc` to match the
-  // capability_config naming.
   vef_status_var_descriptor_list_t descriptor_list{};
 
  private:

--- a/villagesql/stable_sdk/v3/include/villagesql/preview/storage_api.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/preview/storage_api.h
@@ -59,8 +59,6 @@ namespace detail {
 inline constexpr size_t ERROR_MSG_SIZE = 512;
 inline thread_local char tl_error_msg[ERROR_MSG_SIZE] = {};
 
-// TODO(villagesql-indexing): remove this global pointer, instead passing the
-// capability in the API.
 // Module-level vtable pointer. The server writes it via vtable_dest during
 // extension registration
 // (CapabilityTraits<StorageCapability>::vtable_destination returns &g_abi). The

--- a/villagesql/stable_sdk/v3/include/villagesql/preview/storage_builder.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/preview/storage_builder.h
@@ -151,8 +151,6 @@ class ColumnStoreCapability
   }
 
   const vef_type_storage_intf_t *ptrs_[N > 0 ? N : 1];
-  // TODO(villagesql-beta): rename `ext_desc_` to `cc_` to match the
-  // capability_config naming.
   vef_preview_column_store_ext_desc_t ext_desc_{};
 };
 

--- a/villagesql/stable_sdk/v3/include/villagesql/preview/sys_var.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/preview/sys_var.h
@@ -251,8 +251,6 @@ class SysVarCapability
 
   // Read by the server's on_populate callback. Public so CapabilityTraits
   // can return its address as capability_config.
-  // TODO(villagesql-beta): rename `descriptor_list` to `cc` to match the
-  // capability_config naming.
   vef_sys_var_descriptor_list_t descriptor_list{};
 
  private:
@@ -276,8 +274,6 @@ class SysVarCapability
 //       file path",    &g_log_file,  "/tmp/myext.log"),
 //   });
 //
-// TODO(villagesql-beta): add equivalent factories to status_var for
-// consistency.
 inline SysVarDescriptor make_bool(const char *name, const char *comment,
                                   bool *value_ptr, bool def_val) {
   SysVarDescriptor d;

--- a/villagesql/stable_sdk/v3/include/villagesql/preview/thread_worker.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/preview/thread_worker.h
@@ -55,8 +55,6 @@ class ThreadWorkerCapability
   // One static descriptor per WorkFn instantiation. The constructor
   // populates it. The trait's capability_config() returns its address so
   // the wire format carries a pointer to it.
-  // TODO(villagesql-beta): rename `descriptor` to `cc` to match the
-  // capability_config naming.
   static inline vef_thread_worker_descriptor_t descriptor{};
 
  private:

--- a/villagesql/stable_sdk/v3/include/villagesql/vsql/func_builder.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/vsql/func_builder.h
@@ -311,9 +311,6 @@ class FuncBuilder {
                     "make_func: state-style VDF must have one State (or "
                     "void*) parameter, then the declared SQL parameters, "
                     "then a typed result wrapper");
-      // TODO(villagesql-beta): also run args/result shape and runtime
-      // signature checks (declared .param/.returns vs C++ wrappers) for
-      // state-style VDFs. Today these run only for stateless shapes.
       using First = std::tuple_element_t<0, AllParams>;
       if constexpr (std::is_same_v<First, void *>) {
         meta.f = &detail::WrapperVoidStarState<Func, NumParams>::invoke;

--- a/villagesql/stable_sdk/v3/include/villagesql/vsql/func_types.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/vsql/func_types.h
@@ -134,7 +134,6 @@ class CustomArg {
 //
 // NOTE: Do not call params() when is_null() is true — NULL values carry no
 // type_params in the ABI, so the cache lookup has no key to work with.
-// TODO(villagesql-beta): remove this restriction.
 template <typename P>
 class CustomArgWith {
  public:

--- a/villagesql/stable_sdk/v3/include/villagesql/vsql/pre_post_run.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/vsql/pre_post_run.h
@@ -38,15 +38,6 @@
 // wrapper class will be added and the postrun signature will become
 // `void(PostrunArgs, PostrunResult)`.
 //
-// TODO(villagesql-beta): add a typed-state mechanism (working name
-// `.state<T>()` on FuncBuilder) so extensions can declare a per-statement
-// state type and have the SDK manage its lifetime automatically — no
-// matched prerun/postrun pair required just to free state. Implementable
-// without ABI changes by having .state<T>() install SDK-generated prerun
-// and postrun wrappers that new/delete the T into the existing user_data
-// slot; the user's optional prerun/postrun receive the typed reference.
-// .state<T>() and raw set_user_data become mutually exclusive.
-
 #include <cstddef>
 #include <cstring>
 #include <string_view>
@@ -90,10 +81,6 @@ class PrerunArgs {
     return PrerunArgType(&a_->arg_types[i]);
   }
 
-  // TODO(villagesql-beta): expose const_at(i) returning the serialized
-  // literal bytes for constant arguments. Blocked on vdf_handler.cc
-  // populating vef_prerun_args_t::const_values / const_lengths; today both
-  // are unconditionally nullptr at the prerun call site.
 
  private:
   const vef_prerun_args_t *a_;

--- a/villagesql/stable_sdk/v3/include/villagesql/vsql/type_builder.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/vsql/type_builder.h
@@ -357,8 +357,6 @@ class TypeBuilder {
   // default binary value for a NOT NULL column receiving NULL with IGNORE.
   // The named VDF must be registered separately with make_intrinsic_default().
   //
-  // TODO(villagesql-beta): embed intrinsic_default inline once the vsql API
-  // supports auto-generating its VDF name too.
   constexpr TypeBuilder &intrinsic_default_vdf(const char *vdf_name) {
     state_.desc.vef_desc.intrinsic_default_vdf_name = vdf_name;
     state_.desc.vef_desc.protocol = VEF_PROTOCOL_3;

--- a/villagesql/stable_sdk/v3/lib/cmake/VillageSQLExtensionFramework/VillageSQLExtensionFrameworkConfig.cmake
+++ b/villagesql/stable_sdk/v3/lib/cmake/VillageSQLExtensionFramework/VillageSQLExtensionFrameworkConfig.cmake
@@ -81,7 +81,6 @@ FUNCTION(VEF_CREATE_VEB)
   FILE(MAKE_DIRECTORY ${VEB_STAGING_DIR}/lib)
 
   # Configure the library target to output to staging/lib
-  # TODO(villagesql-windows): Handle DLL when building for Windows
   SET_TARGET_PROPERTIES(${ARG_LIBRARY_TARGET} PROPERTIES
     OUTPUT_NAME ${ARG_NAME}
     LIBRARY_OUTPUT_DIRECTORY ${VEB_STAGING_DIR}/lib


### PR DESCRIPTION
We won't be changing them. The TODOs are tracked in the current dev version.
