### PR TITLE
release: strip '-dev' and add the SDK

### DIFF
--- a/.github/workflows/release-dev-server.yml
+++ b/.github/workflows/release-dev-server.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing tag to build a release for (e.g. 0.0.3)'
+        description: 'Git tag to build (e.g. 0.0.4). This is the tag name only — do not include the pre-release suffix here.'
         required: true
       pre_release_version:
         description: 'Pre-release suffix to embed in the version (e.g. "dev"). Leave empty for a clean release build.'
@@ -138,6 +138,12 @@ jobs:
         with:
           pattern: devserver-*
           merge-multiple: true
+          path: packages/
+
+      - name: Download SDK
+        uses: actions/download-artifact@v4
+        with:
+          name: sdk-linux-x86_64
           path: packages/
 
       - name: Attach artifacts to release

--- a/.github/workflows/release-dev-server.yml
+++ b/.github/workflows/release-dev-server.yml
@@ -16,30 +16,59 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Git tag to build (e.g. 0.0.4). This is the tag name only — do not include the pre-release suffix here.'
+        description: 'Git tag, branch, or SHA to build from (e.g. 0.0.4 or main).'
         required: true
-      pre_release_version:
-        description: 'Pre-release suffix to embed in the version (e.g. "dev"). Leave empty for a clean release build.'
+      release_tag:
+        description: 'GitHub Release to attach artifacts to. Defaults to "tag". Leave blank to skip upload (useful for test builds — artifacts are still available for download from the Actions run page).'
         required: false
-        default: 'dev'
+        default: ''
+      release_build:
+        description: 'Release build: strip the -dev suffix from the version. Leave unchecked to include -dev (safe default).'
+        required: false
+        type: boolean
+        default: false
+      platform:
+        description: 'Platform(s) to build. Use a single platform to speed up test runs.'
+        required: false
+        type: choice
+        options:
+          - all
+          - linux-x86_64
+          - linux-aarch64
+          - macos-arm64
+        default: all
 
 jobs:
+  compute-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set.outputs.matrix }}
+    steps:
+      - id: set
+        run: |
+          case "${{ inputs.platform }}" in
+            linux-x86_64)
+              M='{"include":[{"runner":["self-hosted","linux","x86_64"],"platform":"linux-x86_64","os":"linux"}]}'
+              ;;
+            linux-aarch64)
+              M='{"include":[{"runner":"ubuntu-24.04-arm","platform":"linux-aarch64","os":"linux"}]}'
+              ;;
+            macos-arm64)
+              M='{"include":[{"runner":"macos-latest","platform":"macos-arm64","os":"macos"}]}'
+              ;;
+            *)
+              M='{"include":[{"runner":["self-hosted","linux","x86_64"],"platform":"linux-x86_64","os":"linux"},{"runner":"ubuntu-24.04-arm","platform":"linux-aarch64","os":"linux"},{"runner":"macos-latest","platform":"macos-arm64","os":"macos"}]}'
+              ;;
+          esac
+          echo "matrix=$M" >> "$GITHUB_OUTPUT"
+
   build-package:
+    needs: compute-matrix
     name: Build (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - runner: [self-hosted, linux, x86_64]
-            platform: linux-x86_64
-            os: linux
-          - runner: ubuntu-24.04-arm
-            platform: linux-aarch64
-            os: linux
-          - runner: macos-latest
-            platform: macos-arm64
-            os: macos
+      matrix: ${{ fromJSON(needs.compute-matrix.outputs.matrix) }}
 
     env:
       BUILD_DIR: ${{ github.workspace }}/build
@@ -82,7 +111,11 @@ jobs:
         run: |
           mkdir -p "$BUILD_DIR" "$OUTPUT_DIR"
 
-          PRE_RELEASE="${{ inputs.pre_release_version }}"
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" || "${{ inputs.release_build }}" == "true" ]]; then
+            PRE_RELEASE=""
+          else
+            PRE_RELEASE="dev"
+          fi
           echo "pre_release_version: '${PRE_RELEASE}'"
 
           EXTRA_FLAGS="-DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost -DVSQL_PRE_RELEASE_VERSION=${PRE_RELEASE}"
@@ -93,6 +126,7 @@ jobs:
           BUILD_DIR="$BUILD_DIR" \
           OUTPUT_DIR="$OUTPUT_DIR" \
           CMAKE_EXTRA_FLAGS="$EXTRA_FLAGS" \
+          VSQL_PRE_RELEASE_VERSION="${PRE_RELEASE}" \
             source/scripts/make_villagesql_dev_server.sh
 
       - name: Run integration tests
@@ -128,7 +162,7 @@ jobs:
         id: tag
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ inputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "tag=${{ inputs.release_tag || inputs.tag }}" >> "$GITHUB_OUTPUT"
           else
             echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi
@@ -152,4 +186,8 @@ jobs:
           GH_REPO: ${{ github.repository }}
         run: |
           TAG="${{ steps.tag.outputs.tag }}"
-          gh release upload "$TAG" packages/*.tar.gz --clobber
+          if gh release view "$TAG" &>/dev/null; then
+            gh release upload "$TAG" packages/*.tar.gz --clobber
+          else
+            echo "No GitHub Release found for '$TAG' — skipping upload. Download artifacts from the Actions run page."
+          fi

--- a/.github/workflows/release-dev-server.yml
+++ b/.github/workflows/release-dev-server.yml
@@ -18,6 +18,10 @@ on:
       tag:
         description: 'Existing tag to build a release for (e.g. 0.0.3)'
         required: true
+      pre_release_version:
+        description: 'Pre-release suffix to embed in the version (e.g. "dev"). Leave empty for a clean release build.'
+        required: false
+        default: 'dev'
 
 jobs:
   build-package:
@@ -78,7 +82,10 @@ jobs:
         run: |
           mkdir -p "$BUILD_DIR" "$OUTPUT_DIR"
 
-          EXTRA_FLAGS="-DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost"
+          PRE_RELEASE="${{ inputs.pre_release_version }}"
+          echo "pre_release_version: '${PRE_RELEASE}'"
+
+          EXTRA_FLAGS="-DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost -DVSQL_PRE_RELEASE_VERSION=${PRE_RELEASE}"
           if [ "${{ matrix.os }}" = "macos" ]; then
             EXTRA_FLAGS="$EXTRA_FLAGS -DWITH_SSL=$(brew --prefix openssl)"
           fi

--- a/scripts/vsql_script_utils.sh
+++ b/scripts/vsql_script_utils.sh
@@ -35,7 +35,9 @@ vsql_parse_version() {
         VSQL_PRE=$(grep "^VSQL_PRE_RELEASE_VERSION=" "$f" | cut -d'=' -f2)
     fi
     VSQL_VERSION="${VSQL_MAJOR}.${VSQL_MINOR}.${VSQL_PATCH}"
-    [[ -n "$VSQL_PRE" ]] && VSQL_VERSION="${VSQL_VERSION}-${VSQL_PRE}"
+    if [[ -n "$VSQL_PRE" ]]; then
+        VSQL_VERSION="${VSQL_VERSION}-${VSQL_PRE}"
+    fi
 }
 
 # Set PLATFORM (linux|macos) and ARCH (x86_64|aarch64|arm64) for this machine.

--- a/scripts/vsql_script_utils.sh
+++ b/scripts/vsql_script_utils.sh
@@ -28,7 +28,12 @@ vsql_parse_version() {
     VSQL_MAJOR=$(grep "^VSQL_MAJOR_VERSION=" "$f" | cut -d'=' -f2)
     VSQL_MINOR=$(grep "^VSQL_MINOR_VERSION=" "$f" | cut -d'=' -f2)
     VSQL_PATCH=$(grep "^VSQL_PATCH_VERSION=" "$f" | cut -d'=' -f2)
-    VSQL_PRE=$(grep "^VSQL_PRE_RELEASE_VERSION=" "$f" | cut -d'=' -f2)
+    # VSQL_PRE_RELEASE_VERSION env var overrides the file (set to "" to strip the suffix)
+    if [[ "${VSQL_PRE_RELEASE_VERSION+set}" == "set" ]]; then
+        VSQL_PRE="$VSQL_PRE_RELEASE_VERSION"
+    else
+        VSQL_PRE=$(grep "^VSQL_PRE_RELEASE_VERSION=" "$f" | cut -d'=' -f2)
+    fi
     VSQL_VERSION="${VSQL_MAJOR}.${VSQL_MINOR}.${VSQL_PATCH}"
     [[ -n "$VSQL_PRE" ]] && VSQL_VERSION="${VSQL_VERSION}-${VSQL_PRE}"
 }


### PR DESCRIPTION
  - VSQL_PRE_RELEASE_VERSION can now be overridden at cmake time and via env var; the release workflow sets it to "" so
  tag-triggered and manual release builds produce clean version strings (e.g. 0.0.4 not 0.0.4-dev)
  - SDK tarball is now attached to the GitHub Release alongside the dev-server tarballs
  - Manual dispatch gains a pre_release_version input (default "") and a release_tag input (defaults to tag) to allow test builds
  without uploading to a release
