### PR TITLE
support variable-length custom types

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_varvec_create_table.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_varvec_create_table.result
@@ -1,0 +1,99 @@
+# Install the variable-length, non-parameterized vector extension.
+INSTALL EXTENSION vsql_varvec_test;
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+EXTENSION_NAME	EXTENSION_VERSION
+vsql_varvec_test	0.0.1
+# A column of a variable-length type declared WITHOUT parameters; the
+# length is decided per value.
+CREATE TABLE vecs (
+id INT PRIMARY KEY,
+v vsql_varvec_test.VARVEC
+);
+# Vectors of DIFFERENT element counts coexist in the same column.
+INSERT INTO vecs VALUES (1, '[1,2,3]');
+INSERT INTO vecs VALUES (2, '[10,20]');
+INSERT INTO vecs VALUES (3, '[-5,0,5,100,-100]');
+INSERT INTO vecs VALUES (4, '[]');
+# Each value round-trips at its own length; the element count is derived
+# from the stored byte length, not from a type parameter.
+SELECT id, v, vsql_varvec_test.varvec_dim(v) AS n_elems
+FROM vecs ORDER BY id;
+id	v	n_elems
+1	[1,2,3]	3
+2	[10,20]	2
+3	[-5,0,5,100,-100]	5
+4	[]	0
+# Predicate comparisons use the type's element-wise compare across
+# vectors of differing lengths.
+SELECT id FROM vecs WHERE v > '[1,2,3]' ORDER BY id;
+id
+2
+SELECT id FROM vecs WHERE v = '[10,20]' ORDER BY id;
+id
+2
+# UPDATE may grow or shrink the vector's length.
+UPDATE vecs SET v = '[7,7,7,7]' WHERE id = 2;
+SELECT id, v, vsql_varvec_test.varvec_dim(v) AS n_elems
+FROM vecs WHERE id = 2;
+id	v	n_elems
+2	[7,7,7,7]	4
+# A CUSTOM-returning VDF (the type's from_string) sizes its result buffer
+# from max_persisted_length, not the default 256-byte buffer. A 200-element
+# vector is 400 stored bytes (> 256); from_string must keep all 200
+# elements rather than truncating or dropping the value.
+SELECT vsql_varvec_test.varvec_dim(
+VARVEC::from_string(CONCAT('[', REPEAT('9,', 199), '9', ']'))) AS n_elems;
+n_elems
+200
+# A string EXPRESSION (not a literal) is not implicitly cast to the
+# custom type; explicit conversion is required.
+INSERT INTO vecs VALUES (5, CONCAT('[', REPEAT('9,', 199), '9', ']'));
+ERROR HY000: Incorrect VARVEC value: cannot implicitly cast string expression. Use explicit conversion for column 'v' at row 1
+# With an explicit from_string conversion the large vector stores and
+# reads back at its full 200-element length.
+INSERT INTO vecs VALUES (5, VARVEC::from_string(CONCAT('[', REPEAT('9,', 199), '9', ']')));
+SELECT id, vsql_varvec_test.varvec_dim(v) AS n_elems FROM vecs WHERE id = 5;
+id	n_elems
+5	200
+# varvec_concat(VARVEC, VARVEC) -> VARVEC appends two vectors that may
+# have different lengths; the result length is the sum of the inputs.
+SELECT vsql_varvec_test.varvec_concat(
+VARVEC::from_string('[1,2,3]'),
+VARVEC::from_string('[4,5]')) AS combined;
+combined
+[1,2,3,4,5]
+# Concatenating with an empty vector returns the other vector unchanged.
+SELECT vsql_varvec_test.varvec_concat(
+VARVEC::from_string('[1,2,3]'),
+VARVEC::from_string('[]')) AS combined;
+combined
+[1,2,3]
+# A NULL input yields a NULL result.
+SELECT vsql_varvec_test.varvec_concat(
+VARVEC::from_string('[1,2,3]'), NULL) AS combined;
+combined
+NULL
+# Concatenation works on stored columns of differing lengths too.
+SELECT vsql_varvec_test.varvec_concat(a.v, b.v) AS combined
+FROM vecs a JOIN vecs b ON a.id = 1 AND b.id = 3;
+combined
+[1,2,3,-5,0,5,100,-100]
+# A concatenation that would exceed max_persisted_length is rejected with
+# a warning (result NULL) rather than silently truncated.
+SELECT vsql_varvec_test.varvec_dim(
+vsql_varvec_test.varvec_concat(
+VARVEC::from_string(CONCAT('[', REPEAT('9,', 199), '9', ']')),
+VARVEC::from_string(CONCAT('[', REPEAT('9,', 199), '9', ']')))) AS n;
+n
+NULL
+Warnings:
+Warning	3200	VDF error in function 'varvec_concat': VARVEC: concatenated value exceeds max length
+# The type is variable-length and parameterless (no int_to_params), so a
+# length specification is rejected.
+CREATE TABLE bad (id INT, v vsql_varvec_test.VARVEC(3));
+ERROR 42000: Type 'vsql_varvec_test.VARVEC' does not accept a length specification near 'vsql_varvec_test.VARVEC(3))' at line 1
+# Clean up.
+DROP TABLE vecs;
+UNINSTALL EXTENSION vsql_varvec_test;
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+EXTENSION_NAME	EXTENSION_VERSION

--- a/mysql-test/suite/villagesql/extension/t/extension_varvec_create_table.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_varvec_create_table.test
@@ -1,0 +1,101 @@
+# Acceptance test for issue #535:
+#   "Support variable-length, non-parameterized types"
+#
+# VARVEC is a vector of int16 elements whose count is decided per value, not by
+# a type parameter. A column is declared WITHOUT any length or parameters:
+#   CREATE TABLE t (v vsql_varvec_test.VARVEC);
+# and vectors of different lengths coexist in the same column, like VARBINARY.
+#
+# Fixture: vsql_varvec_test exposes VARVEC with persisted_length = -1, a
+# max_persisted_length upper bound, and NO params/int_to_params/resolve_params.
+# This contrasts with a parameterized vector (PVEC(N)), whose dimension is fixed
+# per column. The backing field is a VARCHAR(max_persisted_length): only the
+# actual encoded bytes are stored per value (the VARCHAR length prefix records
+# the per-value length), and the element count is recovered on decode from the
+# value's byte length.
+
+--echo # Install the variable-length, non-parameterized vector extension.
+INSTALL EXTENSION vsql_varvec_test;
+
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+
+--echo # A column of a variable-length type declared WITHOUT parameters; the
+--echo # length is decided per value.
+CREATE TABLE vecs (
+  id INT PRIMARY KEY,
+  v vsql_varvec_test.VARVEC
+);
+
+--echo # Vectors of DIFFERENT element counts coexist in the same column.
+INSERT INTO vecs VALUES (1, '[1,2,3]');
+INSERT INTO vecs VALUES (2, '[10,20]');
+INSERT INTO vecs VALUES (3, '[-5,0,5,100,-100]');
+INSERT INTO vecs VALUES (4, '[]');
+
+--echo # Each value round-trips at its own length; the element count is derived
+--echo # from the stored byte length, not from a type parameter.
+SELECT id, v, vsql_varvec_test.varvec_dim(v) AS n_elems
+FROM vecs ORDER BY id;
+
+--echo # Predicate comparisons use the type's element-wise compare across
+--echo # vectors of differing lengths.
+SELECT id FROM vecs WHERE v > '[1,2,3]' ORDER BY id;
+SELECT id FROM vecs WHERE v = '[10,20]' ORDER BY id;
+
+--echo # UPDATE may grow or shrink the vector's length.
+UPDATE vecs SET v = '[7,7,7,7]' WHERE id = 2;
+SELECT id, v, vsql_varvec_test.varvec_dim(v) AS n_elems
+FROM vecs WHERE id = 2;
+
+--echo # A CUSTOM-returning VDF (the type's from_string) sizes its result buffer
+--echo # from max_persisted_length, not the default 256-byte buffer. A 200-element
+--echo # vector is 400 stored bytes (> 256); from_string must keep all 200
+--echo # elements rather than truncating or dropping the value.
+SELECT vsql_varvec_test.varvec_dim(
+         VARVEC::from_string(CONCAT('[', REPEAT('9,', 199), '9', ']'))) AS n_elems;
+
+--echo # A string EXPRESSION (not a literal) is not implicitly cast to the
+--echo # custom type; explicit conversion is required.
+--error ER_VILLAGESQL_GENERIC_ERROR
+INSERT INTO vecs VALUES (5, CONCAT('[', REPEAT('9,', 199), '9', ']'));
+
+--echo # With an explicit from_string conversion the large vector stores and
+--echo # reads back at its full 200-element length.
+INSERT INTO vecs VALUES (5, VARVEC::from_string(CONCAT('[', REPEAT('9,', 199), '9', ']')));
+SELECT id, vsql_varvec_test.varvec_dim(v) AS n_elems FROM vecs WHERE id = 5;
+
+--echo # varvec_concat(VARVEC, VARVEC) -> VARVEC appends two vectors that may
+--echo # have different lengths; the result length is the sum of the inputs.
+SELECT vsql_varvec_test.varvec_concat(
+         VARVEC::from_string('[1,2,3]'),
+         VARVEC::from_string('[4,5]')) AS combined;
+
+--echo # Concatenating with an empty vector returns the other vector unchanged.
+SELECT vsql_varvec_test.varvec_concat(
+         VARVEC::from_string('[1,2,3]'),
+         VARVEC::from_string('[]')) AS combined;
+
+--echo # A NULL input yields a NULL result.
+SELECT vsql_varvec_test.varvec_concat(
+         VARVEC::from_string('[1,2,3]'), NULL) AS combined;
+
+--echo # Concatenation works on stored columns of differing lengths too.
+SELECT vsql_varvec_test.varvec_concat(a.v, b.v) AS combined
+FROM vecs a JOIN vecs b ON a.id = 1 AND b.id = 3;
+
+--echo # A concatenation that would exceed max_persisted_length is rejected with
+--echo # a warning (result NULL) rather than silently truncated.
+SELECT vsql_varvec_test.varvec_dim(
+         vsql_varvec_test.varvec_concat(
+           VARVEC::from_string(CONCAT('[', REPEAT('9,', 199), '9', ']')),
+           VARVEC::from_string(CONCAT('[', REPEAT('9,', 199), '9', ']')))) AS n;
+
+--echo # The type is variable-length and parameterless (no int_to_params), so a
+--echo # length specification is rejected.
+--error ER_PARSE_ERROR
+CREATE TABLE bad (id INT, v vsql_varvec_test.VARVEC(3));
+
+--echo # Clean up.
+DROP TABLE vecs;
+UNINSTALL EXTENSION vsql_varvec_test;
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -9633,8 +9633,11 @@ Field *make_field(const Create_field &create_field, TABLE_SHARE *share,
       create_field.m_srid, create_field.is_array);
   if (f && create_field.custom_type_context) {
     f->set_type_context(create_field.custom_type_context);
+    // Fixed-length types store exactly persisted_length bytes; variable-length
+    // types (persisted_length == -1) keep their length per value and are backed
+    // by a field sized to the type's max_persisted_length upper bound.
     assert(static_cast<int64_t>(f->field_length) ==
-           create_field.custom_type_context->persisted_length());
+           create_field.custom_type_context->field_buffer_length());
   }
   return f;
 }

--- a/villagesql/schema/descriptor/type_context.h
+++ b/villagesql/schema/descriptor/type_context.h
@@ -281,6 +281,17 @@ class TypeContext {
   int64_t persisted_length() const { return persisted_length_; }
   int64_t max_decode_buffer_length() const { return max_decode_buffer_length_; }
 
+  // Declared length of the backing field for this type instantiation.
+  // Fixed-length and parameter-resolved types store exactly persisted_length
+  // bytes. A variable-length type without parameters keeps persisted_length
+  // == -1 (its length is decided per value, like a roaring bitmap); such a
+  // type is backed by a variable-length field sized to the descriptor's
+  // max_persisted_length upper bound.
+  int64_t field_buffer_length() const {
+    return persisted_length_ < 0 ? descriptor_->max_persisted_length()
+                                 : persisted_length_;
+  }
+
   // Bound type operations. These combine the TypeFunction from the descriptor
   // with this context's TypeParameters.
   // encode_op, decode_op, compare_op assert that the op is set (required ops).

--- a/villagesql/test-extensions/CMakeLists.txt
+++ b/villagesql/test-extensions/CMakeLists.txt
@@ -34,3 +34,4 @@ vsql_add_test_extension(vsql-preview-ping-v2-test      vsql_preview_ping_v2_test
 vsql_add_test_extension(vsql-sys-var-rollback-test     vsql_sys_var_rollback_test)
 vsql_add_test_extension(vsql-noop-test                 vsql_noop_test)
 vsql_add_test_extension(vsql-bad-var-no-resolve-test   vsql_bad_var_no_resolve_test)
+vsql_add_test_extension(vsql-varvec-test               vsql_varvec_test)

--- a/villagesql/test-extensions/vsql-varvec-test/manifest.json
+++ b/villagesql/test-extensions/vsql-varvec-test/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "vsql_varvec_test",
+  "version": "0.0.1",
+  "description": "Variable-length, non-parameterized vector type (VARVEC): persisted_length=-1 with a max_persisted_length upper bound and NO int_to_params/resolve_params. A column is declared without any length or parameters and holds int16 vectors whose element count is decided per value (#535).",
+  "author": "VillageSQL Community",
+  "license": "GPL-2.0"
+}

--- a/villagesql/test-extensions/vsql-varvec-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-varvec-test/src/extension.cc
@@ -1,0 +1,211 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+// Test fixture for issue #535: a variable-length, NON-parameterized vector
+// type whose element count is decided per value.
+//
+// VARVEC stores a vector of little-endian int16 elements. It declares
+// persisted_length = -1 with a max_persisted_length upper bound and NO
+// params/int_to_params/resolve_params. A column is declared without any length
+// or parameters:
+//   CREATE TABLE t (v vsql_varvec_test.VARVEC);
+// and each value keeps its own element count, like VARBINARY -- vectors of
+// different lengths coexist in the same column. This contrasts with a
+// parameterized vector (e.g. PVEC(N)), whose dimension is fixed per column by
+// int_to_params/resolve_params.
+//
+// The backing field is a VARCHAR(max_persisted_length): the in-memory buffer is
+// sized to the upper bound, but only the actual encoded bytes (set via
+// out.set_length()) are written, and the VARCHAR length prefix records the
+// per-value length. The element count is recovered on decode from the value's
+// byte length, not from a type parameter.
+
+#include <villagesql/vsql.h>
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string_view>
+
+// Upper bound on a stored VARVEC value: at most kVarvecMaxElems int16 elements,
+// so kVarvecMaxElems * 2 bytes. Sizes the backing field and the encode buffer.
+constexpr int64_t kVarvecMaxElems = 256;
+constexpr int64_t kVarvecMaxLen = kVarvecMaxElems * 2;
+// Upper bound on the text form "[v1,v2,...]": each int16 prints as at most
+// "-32768," (7 chars), plus the surrounding brackets.
+constexpr int64_t kVarvecMaxText = kVarvecMaxElems * 8 + 2;
+
+static void store_i16(unsigned char *buf, int16_t v) {
+  buf[0] = static_cast<unsigned char>(v & 0xFF);
+  buf[1] = static_cast<unsigned char>((v >> 8) & 0xFF);
+}
+
+static int16_t load_i16(const unsigned char *buf) {
+  return static_cast<int16_t>(static_cast<uint16_t>(buf[0]) |
+                              (static_cast<uint16_t>(buf[1]) << 8));
+}
+
+// STRING -> binary: parse "[v1,v2,...]" into little-endian int16 elements. The
+// element count is decided per value (not a type parameter); the actual byte
+// length is reported via out.set_length(). The buffer is sized to the type's
+// max_persisted_length, so max_elems below is the per-column capacity.
+void varvec_from_string(std::string_view from, vsql::CustomResult out) {
+  auto buf = out.buffer();
+  const size_t max_elems = buf.size() / 2;
+
+  std::string input(from);
+  const char *s = input.c_str();
+  while (*s == ' ') s++;
+  if (*s != '[') {
+    out.warning("VARVEC: expected '['");
+    return;
+  }
+  s++;
+
+  size_t count = 0;
+  while (*s != '\0') {
+    while (*s == ' ') s++;
+    if (*s == ']') break;
+    if (count >= max_elems) {
+      out.warning("VARVEC: too many elements");
+      return;
+    }
+    char *endptr = nullptr;
+    long val = strtol(s, &endptr, 10);
+    if (endptr == s) {
+      out.warning("VARVEC: parse error");
+      return;
+    }
+    store_i16(buf.data() + count * 2, static_cast<int16_t>(val));
+    count++;
+    s = endptr;
+    while (*s == ' ') s++;
+    if (*s == ',') s++;
+  }
+  if (*s != ']') {
+    out.warning("VARVEC: missing ']'");
+    return;
+  }
+  out.set_length(count * 2);
+}
+
+// binary -> STRING: the element count is derived from the value's byte length
+// (data.size() / 2), since this type has no dimension parameter.
+void varvec_to_string(vsql::CustomArg in, vsql::StringResult out) {
+  auto data = in.value();
+  const size_t count = data.size() / 2;
+  auto buf = out.buffer();
+  size_t pos = 0;
+  if (pos >= buf.size()) return;
+  buf[pos++] = '[';
+  for (size_t i = 0; i < count; i++) {
+    if (i > 0) {
+      if (pos >= buf.size()) return;
+      buf[pos++] = ',';
+    }
+    int16_t v = load_i16(data.data() + i * 2);
+    int written =
+        snprintf(buf.data() + pos, buf.size() - pos, "%d", static_cast<int>(v));
+    if (written < 0 || pos + static_cast<size_t>(written) >= buf.size()) return;
+    pos += static_cast<size_t>(written);
+  }
+  if (pos >= buf.size()) return;
+  buf[pos++] = ']';
+  out.set_length(pos);
+}
+
+// Lexicographic element-wise comparison; a shorter vector sorts first on a
+// common prefix (like VARBINARY).
+int varvec_compare(vsql::CustomArg a, vsql::CustomArg b) {
+  auto va = a.value();
+  auto vb = b.value();
+  size_t na = va.size() / 2;
+  size_t nb = vb.size() / 2;
+  size_t n = na < nb ? na : nb;
+  for (size_t i = 0; i < n; i++) {
+    int16_t ea = load_i16(va.data() + i * 2);
+    int16_t eb = load_i16(vb.data() + i * 2);
+    if (ea != eb) return ea < eb ? -1 : 1;
+  }
+  if (na != nb) return na < nb ? -1 : 1;
+  return 0;
+}
+
+// Number of elements in this VARVEC value -- derived per value from the stored
+// byte length, the defining trait of a variable-length, non-parameterized type.
+void varvec_dim(vsql::CustomArg in, vsql::IntResult out) {
+  if (in.is_null()) {
+    out.set_null();
+    return;
+  }
+  out.set(static_cast<long long>(in.value().size() / 2));
+}
+
+// Concatenate two VARVEC values into one: (VARVEC, VARVEC) -> VARVEC. The two
+// inputs may have different element counts; the result holds all elements of a
+// followed by all elements of b, so its byte length is the sum of the inputs'
+// byte lengths. Because each VARVEC value is already a packed sequence of
+// little-endian int16 elements, concatenation is just a byte-wise append.
+//
+// This is a CUSTOM-returning VDF whose output is the SUM of two variable-length
+// inputs: the result buffer is sized to the return type's max_persisted_length,
+// so a concatenation that exceeds that capacity is reported as a warning rather
+// than silently truncated.
+void varvec_concat(vsql::CustomArg a, vsql::CustomArg b,
+                   vsql::CustomResult out) {
+  if (a.is_null() || b.is_null()) {
+    out.set_null();
+    return;
+  }
+  auto va = a.value();
+  auto vb = b.value();
+  auto buf = out.buffer();
+  const size_t total = va.size() + vb.size();
+  if (total > buf.size()) {
+    out.warning("VARVEC: concatenated value exceeds max length");
+    return;
+  }
+  if (va.size() > 0) memcpy(buf.data(), va.data(), va.size());
+  if (vb.size() > 0) memcpy(buf.data() + va.size(), vb.data(), vb.size());
+  out.set_length(total);
+}
+
+static constexpr const char kVarvecTypeName[] = "VARVEC";
+
+constexpr auto VARVEC = vsql::make_type<kVarvecTypeName>()
+                            .persisted_length(-1)
+                            .max_persisted_length(kVarvecMaxLen)
+                            .max_decode_buffer_length(kVarvecMaxText)
+                            .from_string<&varvec_from_string>()
+                            .to_string<&varvec_to_string>()
+                            .compare<&varvec_compare>()
+                            .build();
+
+using namespace vsql;
+
+VEF_GENERATE_ENTRY_POINTS(make_extension()
+                              .type(VARVEC)
+                              .func(make_func<&varvec_dim>("varvec_dim")
+                                        .returns(INT)
+                                        .param(VARVEC)
+                                        .deterministic()
+                                        .build())
+                              .func(make_func<&varvec_concat>("varvec_concat")
+                                        .returns(VARVEC)
+                                        .param(VARVEC)
+                                        .param(VARVEC)
+                                        .deterministic()
+                                        .build()))

--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -84,16 +84,17 @@ class PT_custom_type : public PT_type {
       return;
     }
 
-    // If no length_spec provided, generate it from the TypeContext's
-    // persisted_length. For fixed-length types this comes from the descriptor.
-    // For variable-length types with parameters, this was computed by
-    // resolve_params at TypeContext construction time.
+    // If no length_spec provided, generate it from the TypeContext's storage
+    // length. For fixed-length types this comes from the descriptor; for
+    // variable-length types with parameters it was computed by resolve_params
+    // at TypeContext construction time; for variable-length types without
+    // parameters (length decided per value, like a roaring bitmap) it is the
+    // descriptor's max_persisted_length upper bound.
     if (nullptr == length_spec) {
-      int64_t len = type_context->persisted_length();
-      if (len > 0) {
-        snprintf(length_buffer, sizeof(length_buffer), "%" PRId64, len);
-        length_spec = length_buffer;
-      }
+      int64_t len = type_context->field_buffer_length();
+      assert(len > 0);
+      snprintf(length_buffer, sizeof(length_buffer), "%" PRId64, len);
+      length_spec = length_buffer;
     }
   }
 

--- a/villagesql/types/type_encoder.cc
+++ b/villagesql/types/type_encoder.cc
@@ -30,7 +30,10 @@ namespace villagesql {
 
 TypeEncoder::TypeEncoder(const TypeContext *tc, MEM_ROOT &mem_root)
     : mem_root_(&mem_root),
-      buffer_size_(static_cast<size_t>(tc->persisted_length())) {
+      // Fixed-length types encode into persisted_length bytes; variable-length
+      // types (persisted_length == -1) encode into a buffer sized to the type's
+      // max_persisted_length upper bound and set the actual length per value.
+      buffer_size_(static_cast<size_t>(tc->field_buffer_length())) {
   assert(tc != nullptr);
   assert(buffer_size_ > 0);
 

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -76,16 +76,16 @@ static const char *ER_INCOMPARABLE_TYPES =
 static const char *ER_INCOMPATIBLE_TYPES =
     "Cannot compare values of incompatible types '%s' and '%s'";
 
-// Verify that the Field's storage length matches the TypeContext's
-// persisted_length.
+// Verify that the backing Field's length matches the TypeContext's
+// field_buffer_length.
 static bool CheckFieldLengthMatchesType(const Field *field,
                                         const TypeContext *tc) {
   if (should_assert_if_false(static_cast<int64_t>(field->field_length) ==
-                             tc->persisted_length())) {
+                             tc->field_buffer_length())) {
     LogVSQL(ERROR_LEVEL,
-            "field_length (%u) != persisted_length (%" PRId64
+            "field_length (%u) != field_buffer_length (%" PRId64
             ") for column %s (type %s)",
-            field->field_length, tc->persisted_length(), field->field_name,
+            field->field_length, tc->field_buffer_length(), field->field_name,
             tc->qualified_name().c_str());
     villagesql_error(
         "Internal error: field length mismatch for column %s (type %s); "

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -261,17 +261,20 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
     m_return_type_context = func->get_type_context();
 
     // CUSTOM-returning VDFs (e.g. the type's from_string / encode VDF) emit
-    // output sized to the resolved return type's persisted_length, which is
-    // unknown until SetVDFReturnTypeContext above resolves it from
-    // return_params. Grow the buffer to fit so that, for example,
-    // SVECTOR::from_string('[…1024 floats…]') has room to encode a wide
-    // vector. Mirrors the input-side growth done above for STRING-returning
-    // VDFs. prerun may still have grown the buffer further; keep the max.
+    // output that fits the resolved return type's field. For a
+    // fixed-length or parameter-resolved type that is persisted_length, unknown
+    // until SetVDFReturnTypeContext above resolves it from return_params; for a
+    // variable-length type without parameters (persisted_length == -1) it is
+    // the type's max_persisted_length upper bound. field_buffer_length()
+    // returns the right one. Grow the buffer to fit so that, for example,
+    // SVECTOR::from_string('[…1024 floats…]') has room to encode a wide vector.
+    // Mirrors the input-side growth done above for STRING-returning VDFs.
+    // prerun may still have grown the buffer further; keep the max.
     if (m_return_type_context != nullptr) {
-      const int64_t persisted = m_return_type_context->persisted_length();
-      if (persisted > 0 &&
-          static_cast<size_t>(persisted) > m_result_buffer_size) {
-        m_result_buffer_size = static_cast<size_t>(persisted);
+      const int64_t buffer_len = m_return_type_context->field_buffer_length();
+      assert(buffer_len > 0);
+      if (static_cast<size_t>(buffer_len) > m_result_buffer_size) {
+        m_result_buffer_size = static_cast<size_t>(buffer_len);
         m_result_buffer =
             pointer_cast<char *>((*THR_MALLOC)->Alloc(m_result_buffer_size));
         if (!m_result_buffer) return true;

--- a/villagesql/veb/veb_register_type_v3.cc
+++ b/villagesql/veb/veb_register_type_v3.cc
@@ -235,15 +235,11 @@ std::optional<TypeDescriptor> build_type_descriptor_v3(
   }
 
   if (td->persisted_length == -1) {
-    // Variable-length / parameterized type: resolve_params_vdf_name and
-    // max_persisted_length are both required.
-    if (td->resolve_params_vdf_name == nullptr) {
-      LogVSQL(ERROR_LEVEL,
-              "Type '%s' in extension '%s' has persisted_length=-1 "
-              "(variable-length) but does not set resolve_params_vdf_name",
-              type_name.c_str(), extension_name.c_str());
-      return std::nullopt;
-    }
+    // Variable-length type: max_persisted_length bounds the field and
+    // is always required. resolve_params is required only for parameterized
+    // variants (those that also expose int_to_params, validated below); a bare
+    // variable-length type whose length is decided per value needs only
+    // max_persisted_length.
     if (td->max_persisted_length <= 0) {
       LogVSQL(ERROR_LEVEL,
               "Type '%s' in extension '%s' has persisted_length=-1 "


### PR DESCRIPTION
Problem
-----------

User defines a column of variadic size. For instance a vector, but without fixed size. So far we can only specify a vector of fixed size - for instance PVEC of fixed size.

The size of PVEC gets discover in pvec_int_to_params or pvec_resolve_params first. Then persisted_length gets set. Since PVEC is a vector of int16, it stores 2 bytes per element. Thus the persisted_length == number_of_elements * 2. Number of elements comes from PVEC declaration. For instance PVEC(3) => number_of_elements == 3.

For variadic columns we could either allow specification of max number of elements that the column can hold. For instance VARVEC(max_number_of_element). It's inline with type like VARCHAR(max_number_of_elements). Might be bit conflicting with types like PVEC(number_of_elements) - where size has to be exactly the number_of_elements.

Either way persisted_length is no longer as simple as number_of_elements * size_of_element or even max_number_of_elements * size_of_elements. It can be smaller than that.

For types that can hold variadict number of elements we use persisted_length == -1. However, this doesn't mean variadict persisted_length. It simply means that persisted_length gets discover during pvec_int_to_params/pvec_resolve_params.

Solution #1
---------------

Allow specifying column of variadict size without specifying max column size. For instance CREATE TABLE t1 (VARVEC variadict_vector);

Developer of such type provides persisted_length = -1 and max_persisted_length - as the max size that column can store (as it is now). The developer doesn't provide varvec_int_to_params nor varvec_resolve_params. The in-memory buffer is of size max_persisted_length (instead of persisted_length size). When value of the column gets encoded - we always provide to the server the actual length of the data (variadict_vector_from_string calls out.set_length() for CustomResult/StringResult). The custom field under the hood is a VARCHAR field. When server writes the data to the storage it only uses actual_len of data. VARCHAR field takes care of that. It stores the length in first two bytes.

Solution #2
---------------

Allow specifying column of max variadic size.
For instance
CREATE TABLE t1 (VARVEC(10) variadict_vector).
Developer of such type provides persisted_length = -1 and max_persisted_length - as the max size that column can store (as it is now). The developer PROVIDES varvec_int_to_params and varvec_resolve_params.

The persisted_length is calculated in varvec_resolve_params as max_number_of_elements*size_of_element. Based on this value the in-memory buffer is created. The actual storage length can be smaller. The actual size is written to actual_size. Please read the Solution #1 for details on how VARCHAR is leveraged to store only used data.

---

Implementation (Solution #1; Solution #2 is left as a documented alternative, not implemented here):

- Distinguish a column's buffer capacity from a value's per-row length. persisted_length stays -1 to mean "variable per value"; the backing Field_varstring is sized from the descriptor's max_persisted_length via the new TypeContext::field_buffer_length() (persisted_length when >= 0, else max_persisted_length). Touches type_context, veb_register_type_v3, pt_custom_type, field, util, type_encoder.

- Relax registration: a persisted_length = -1 type needs only max_persisted_length > 0; int_to_params/resolve_params remain required only for the parameterized variant.

- Size CUSTOM-returning VDF result buffers (the type's from_string/encode, and user VDFs like varvec_concat) from field_buffer_length() instead of raw persisted_length(), so a variable-length type's from_string can produce values up to max_persisted_length rather than the default 256 bytes; assert the resolved buffer length is > 0.

Test fixture and coverage:

- vsql_varvec_test exposes VARVEC, a vector of little-endian int16 whose element count is decided per value (persisted_length = -1, max_persisted_length set, no int_to_params/resolve_params). varvec_dim recovers the element count from the stored byte length; varvec_concat(VARVEC, VARVEC) -> VARVEC appends two possibly different-length vectors (a CUSTOM-returning VDF whose output size is the sum of two variable-length inputs).

- extension_varvec_create_table covers: parameterless column declaration, vectors of differing lengths coexisting, per-value round-trip, element-wise compare predicates, UPDATE grow/shrink, rejection of a length specification (VARVEC(N) -> ER_PARSE_ERROR), the >256-byte from_string buffer path, and varvec_concat over differing lengths / empty / NULL / over-capacity warning.

## Related Issue
Fixes #535 https://github.com/villagesql/villagesql-server/issues/535

I have read the CLA Document and I hereby sign the CLA