### PR TITLE
Add vsql -boolean and -rest to bundle

### DIFF
--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -21,6 +21,6 @@ https://github.com/villagesql/vsql-crypto main
 https://github.com/villagesql/vsql-cube main
 https://github.com/villagesql/vsql-http main
 https://github.com/villagesql/vsql-network-address main
-https://github.com/villagesql/vsql-rest main
+https://github.com/villagesql/vsql-rest main abi=dev
 https://github.com/villagesql/vsql-uuid main
 https://github.com/villagesql/vsql-vector main bundle=false

--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -16,9 +16,11 @@
 #
 # Comments and blank lines are ignored.
 https://github.com/villagesql/vsql-ai main
+https://github.com/villagesql/vsql-boolean main
 https://github.com/villagesql/vsql-crypto main
 https://github.com/villagesql/vsql-cube main
 https://github.com/villagesql/vsql-http main
 https://github.com/villagesql/vsql-network-address main
+https://github.com/villagesql/vsql-rest main
 https://github.com/villagesql/vsql-uuid main
 https://github.com/villagesql/vsql-vector main bundle=false


### PR DESCRIPTION
## Description
Adds vsql-boolean and vsql-rest to bundled extensions list.
AI=CLAUDE

## Related Issue
n/a

## How was this tested?
n/a - ci list change

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
