### PR TITLE
support variable-length custom types

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_bitfield_create_table.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_bitfield_create_table.result
@@ -1,0 +1,54 @@
+# Install the variable-length, non-parameterized bit field extension.
+INSTALL EXTENSION vsql_bitfield_test;
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+EXTENSION_NAME	EXTENSION_VERSION
+vsql_bitfield_test	0.0.1
+# A column declared without any length or parameters; the bit length is
+# decided per value.
+CREATE TABLE bits (
+id INT PRIMARY KEY,
+b vsql_bitfield_test.BITFIELD
+);
+# Bit fields of DIFFERENT bit lengths coexist in the same column.
+INSERT INTO bits VALUES (1, '1');
+INSERT INTO bits VALUES (2, '101');
+INSERT INTO bits VALUES (3, '11110000');
+INSERT INTO bits VALUES (4, '1010101010101010');
+INSERT INTO bits VALUES (5, '');
+# Each value round-trips at its own bit length. bitfield_length reports
+# the number of bits; bitfield_popcount the number of set bits. A 16-bit
+# value is packed into 2 bytes, not 16.
+SELECT id, b,
+vsql_bitfield_test.bitfield_length(b) AS nbits,
+vsql_bitfield_test.bitfield_popcount(b) AS nset
+FROM bits ORDER BY id;
+id	b	nbits	nset
+1	1	1	1
+2	101	3	2
+3	11110000	8	4
+4	1010101010101010	16	8
+5		0	0
+# Predicate comparisons use the type's bit-by-bit compare across
+# different lengths.
+SELECT id FROM bits WHERE b > '1' ORDER BY id;
+id
+2
+3
+4
+SELECT id FROM bits WHERE b = '11110000' ORDER BY id;
+id
+3
+# UPDATE may grow or shrink the bit length.
+UPDATE bits SET b = '111' WHERE id = 1;
+SELECT id, b, vsql_bitfield_test.bitfield_length(b) AS nbits
+FROM bits WHERE id = 1;
+id	b	nbits
+1	111	3
+# A character other than '0'/'1' is rejected by from_string.
+INSERT INTO bits VALUES (6, '1021');
+ERROR HY000: Incorrect BITFIELD value: '1021' for column 'b' at row 1
+# Clean up.
+DROP TABLE bits;
+UNINSTALL EXTENSION vsql_bitfield_test;
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+EXTENSION_NAME	EXTENSION_VERSION

--- a/mysql-test/suite/villagesql/extension/r/extension_bitfield_create_table.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_bitfield_create_table.result
@@ -47,6 +47,13 @@ id	b	nbits
 # A character other than '0'/'1' is rejected by from_string.
 INSERT INTO bits VALUES (6, '1021');
 ERROR HY000: Incorrect BITFIELD value: '1021' for column 'b' at row 1
+# BITFIELD is not parameterized, so it does not accept a length or
+# parameter spec. Both the integer-length and the string-parameter forms
+# are rejected at parse time.
+CREATE TABLE bad_bits (b BITFIELD(5));
+ERROR 42000: Type 'vsql_bitfield_test.BITFIELD' is not parameterized and cannot have a length specification near 'BITFIELD(5))' at line 1
+CREATE TABLE bad_bits (b BITFIELD('max_size=5'));
+ERROR 42000: Type 'vsql_bitfield_test.BITFIELD' does not accept parameters near 'BITFIELD('max_size=5'))' at line 1
 # Clean up.
 DROP TABLE bits;
 UNINSTALL EXTENSION vsql_bitfield_test;

--- a/mysql-test/suite/villagesql/extension/r/extension_tarray_create_table.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_tarray_create_table.result
@@ -50,15 +50,35 @@ FROM arrs x JOIN arrs y ON x.id = 1 AND y.id = 2;
 n
 NULL
 Warnings:
-Warning	3200	VDF error in function 'tarray_concat': TARRAY: concatenated size exceeds max_size
+Warning	3200	VDF error in function 'tarray_concat': tarray_concat: concatenated size exceeds max_size
+# tarray_concat requires both arguments to share the same type parameters.
+# Here a is TARRAY(max_size=4,type=int16) and f is
+# TARRAY(max_size=3,type=float): type-parameter disambiguation rejects the
+# call at prepare time rather than letting the VDF run with mismatched
+# parameters.
+SELECT vsql_tarray_test.tarray_concat(x.a, y.f)
+FROM arrs x JOIN arrs y ON x.id = 1 AND y.id = 2;
+ERROR HY000: Cannot initialize function 'tarray_concat': conflicting type parameters for vsql_tarray_test.TARRAY in arguments 1 and 2
+# The conflict is on any differing parameter, not just element type. Here
+# both columns are int16 and differ only in max_size (1 vs 2), and the
+# call is still rejected at prepare time.
+CREATE TABLE arrs2 (
+id INT PRIMARY KEY,
+g vsql_tarray_test.TARRAY(1),
+h vsql_tarray_test.TARRAY(2)
+);
+INSERT INTO arrs2 VALUES (1, '[1]', '[2,3]');
+SELECT vsql_tarray_test.tarray_concat(g, h) FROM arrs2;
+ERROR HY000: Cannot initialize function 'tarray_concat': conflicting type parameters for vsql_tarray_test.TARRAY in arguments 1 and 2
+DROP TABLE arrs2;
 # resolve_params enforces max_size * element_size <= 512:
 # double * 100 = 800 bytes is rejected.
 CREATE TABLE bad1 (id INT, v vsql_tarray_test.TARRAY('max_size=100,type=double'));
-ERROR 42000: TARRAY max_size 100 * element size 8 exceeds the 512-byte limit near 'vsql_tarray_test.TARRAY('max_size=100,type=double'))' at line 1
+ERROR 42000: tarray_resolve_params: TARRAY max_size 100 * element size 8 exceeds the 512-byte limit near 'vsql_tarray_test.TARRAY('max_size=100,type=double'))' at line 1
 # The integer shorthand goes through int_to_params (max_size=300) and is
 # then rejected by resolve_params: int16 * 300 = 600 > 512.
 CREATE TABLE bad2 (id INT, v vsql_tarray_test.TARRAY(300));
-ERROR 42000: TARRAY max_size 300 * element size 2 exceeds the 512-byte limit near 'vsql_tarray_test.TARRAY(300))' at line 1
+ERROR 42000: tarray_resolve_params: TARRAY max_size 300 * element size 2 exceeds the 512-byte limit near 'vsql_tarray_test.TARRAY(300))' at line 1
 # A non-positive shorthand is rejected by the parser before int_to_params.
 CREATE TABLE bad3 (id INT, v vsql_tarray_test.TARRAY(0));
 ERROR 42000: Invalid length '0' for type 'vsql_tarray_test.TARRAY' near 'vsql_tarray_test.TARRAY(0))' at line 1

--- a/mysql-test/suite/villagesql/extension/r/extension_tarray_create_table.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_tarray_create_table.result
@@ -1,0 +1,69 @@
+# Install the typed-array extension.
+INSTALL EXTENSION vsql_tarray_test;
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+EXTENSION_NAME	EXTENSION_VERSION
+vsql_tarray_test	0.0.1
+# TARRAY(N): integer shorthand mapped to max_size by int_to_params (type
+# defaults to int16). TARRAY('max_size=...,type=...'): explicit cap+width.
+CREATE TABLE arrs (
+id INT PRIMARY KEY,
+a vsql_tarray_test.TARRAY(4),
+f vsql_tarray_test.TARRAY('max_size=3,type=float')
+);
+# Counts vary per value, up to max_size.
+INSERT INTO arrs VALUES (1, '[1,2,3]', '[1.5,2.5]');
+INSERT INTO arrs VALUES (2, '[10,20,30,40]', '[0]');
+SELECT id,
+a, vsql_tarray_test.tarray_dim(a) AS na,
+f, vsql_tarray_test.tarray_dim(f) AS nf
+FROM arrs ORDER BY id;
+id	a	na	f	nf
+1	[1,2,3]	3	[1.5,2.5]	2
+2	[10,20,30,40]	4	[0]	1
+# Both parameters round-trip through SHOW CREATE TABLE.
+SHOW CREATE TABLE arrs;
+Table	Create Table
+arrs	CREATE TABLE `arrs` (
+  `id` int NOT NULL,
+  `a` vsql_tarray_test.TARRAY(4) DEFAULT NULL,
+  `f` vsql_tarray_test.TARRAY('max_size=3,type=float') DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# More elements than max_size is rejected by from_string (a has max 4).
+INSERT INTO arrs VALUES (3, '[1,2,3,4,5]', '[1]');
+ERROR HY000: Incorrect TARRAY value: '[1,2,3,4,5]' for column 'a' at row 1
+# Element-wise compare predicate.
+SELECT id FROM arrs WHERE a > '[1,2,3]' ORDER BY id;
+id
+2
+# Concatenation within max_size (f has max 3): [1.5,2.5] + [0] = 3 elems.
+SELECT vsql_tarray_test.tarray_concat(x.f, y.f) AS c,
+vsql_tarray_test.tarray_dim(vsql_tarray_test.tarray_concat(x.f, y.f)) AS n
+FROM arrs x JOIN arrs y ON x.id = 1 AND y.id = 2;
+c	n
+[1.5,2.5,0]	3
+# Concatenation exceeding max_size (a has max 4): 3 + 4 = 7 > 4 -> NULL
+# with a warning.
+SELECT vsql_tarray_test.tarray_dim(
+vsql_tarray_test.tarray_concat(x.a, y.a)) AS n
+FROM arrs x JOIN arrs y ON x.id = 1 AND y.id = 2;
+n
+NULL
+Warnings:
+Warning	3200	VDF error in function 'tarray_concat': TARRAY: concatenated size exceeds max_size
+# resolve_params enforces max_size * element_size <= 512:
+# double * 100 = 800 bytes is rejected.
+CREATE TABLE bad1 (id INT, v vsql_tarray_test.TARRAY('max_size=100,type=double'));
+ERROR 42000: TARRAY max_size 100 * element size 8 exceeds the 512-byte limit near 'vsql_tarray_test.TARRAY('max_size=100,type=double'))' at line 1
+# The integer shorthand goes through int_to_params (max_size=300) and is
+# then rejected by resolve_params: int16 * 300 = 600 > 512.
+CREATE TABLE bad2 (id INT, v vsql_tarray_test.TARRAY(300));
+ERROR 42000: TARRAY max_size 300 * element size 2 exceeds the 512-byte limit near 'vsql_tarray_test.TARRAY(300))' at line 1
+# A non-positive shorthand is rejected by the parser before int_to_params.
+CREATE TABLE bad3 (id INT, v vsql_tarray_test.TARRAY(0));
+ERROR 42000: Invalid length '0' for type 'vsql_tarray_test.TARRAY' near 'vsql_tarray_test.TARRAY(0))' at line 1
+# Clean up.
+DROP TABLE arrs;
+UNINSTALL EXTENSION vsql_tarray_test;
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+EXTENSION_NAME	EXTENSION_VERSION

--- a/mysql-test/suite/villagesql/extension/t/extension_bitfield_create_table.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_bitfield_create_table.test
@@ -52,6 +52,14 @@ FROM bits WHERE id = 1;
 --error ER_TRUNCATED_WRONG_VALUE_FOR_FIELD
 INSERT INTO bits VALUES (6, '1021');
 
+--echo # BITFIELD is not parameterized, so it does not accept a length or
+--echo # parameter spec. Both the integer-length and the string-parameter forms
+--echo # are rejected at parse time.
+--error ER_PARSE_ERROR
+CREATE TABLE bad_bits (b BITFIELD(5));
+--error ER_PARSE_ERROR
+CREATE TABLE bad_bits (b BITFIELD('max_size=5'));
+
 --echo # Clean up.
 DROP TABLE bits;
 UNINSTALL EXTENSION vsql_bitfield_test;

--- a/mysql-test/suite/villagesql/extension/t/extension_bitfield_create_table.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_bitfield_create_table.test
@@ -1,0 +1,58 @@
+# Acceptance test for issue #535:
+#   "Support variable-length, non-parameterized types"
+#
+# BITFIELD is a variable-length bit field whose length (in bits) is decided per
+# value: persisted_length = -1, a max_persisted_length upper bound, and NO
+# params/resolve_params. Its element is a single BIT: from_string packs each
+# '0'/'1' character into one bit (8 bits per byte), so a 64-character bit string
+# stores in 8 packed bytes, not 64.
+#
+# Fixture: vsql_bitfield_test exposes BITFIELD. Stored layout is a 2-byte
+# little-endian bit count followed by the packed bits, so any bit length
+# round-trips exactly.
+
+--echo # Install the variable-length, non-parameterized bit field extension.
+INSTALL EXTENSION vsql_bitfield_test;
+
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+
+--echo # A column declared without any length or parameters; the bit length is
+--echo # decided per value.
+CREATE TABLE bits (
+  id INT PRIMARY KEY,
+  b vsql_bitfield_test.BITFIELD
+);
+
+--echo # Bit fields of DIFFERENT bit lengths coexist in the same column.
+INSERT INTO bits VALUES (1, '1');
+INSERT INTO bits VALUES (2, '101');
+INSERT INTO bits VALUES (3, '11110000');
+INSERT INTO bits VALUES (4, '1010101010101010');
+INSERT INTO bits VALUES (5, '');
+
+--echo # Each value round-trips at its own bit length. bitfield_length reports
+--echo # the number of bits; bitfield_popcount the number of set bits. A 16-bit
+--echo # value is packed into 2 bytes, not 16.
+SELECT id, b,
+       vsql_bitfield_test.bitfield_length(b) AS nbits,
+       vsql_bitfield_test.bitfield_popcount(b) AS nset
+FROM bits ORDER BY id;
+
+--echo # Predicate comparisons use the type's bit-by-bit compare across
+--echo # different lengths.
+SELECT id FROM bits WHERE b > '1' ORDER BY id;
+SELECT id FROM bits WHERE b = '11110000' ORDER BY id;
+
+--echo # UPDATE may grow or shrink the bit length.
+UPDATE bits SET b = '111' WHERE id = 1;
+SELECT id, b, vsql_bitfield_test.bitfield_length(b) AS nbits
+FROM bits WHERE id = 1;
+
+--echo # A character other than '0'/'1' is rejected by from_string.
+--error ER_TRUNCATED_WRONG_VALUE_FOR_FIELD
+INSERT INTO bits VALUES (6, '1021');
+
+--echo # Clean up.
+DROP TABLE bits;
+UNINSTALL EXTENSION vsql_bitfield_test;
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;

--- a/mysql-test/suite/villagesql/extension/t/extension_bitfield_create_table.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_bitfield_create_table.test
@@ -2,10 +2,10 @@
 #   "Support variable-length, non-parameterized types"
 #
 # BITFIELD is a variable-length bit field whose length (in bits) is decided per
-# value: persisted_length = -1, a max_persisted_length upper bound, and NO
-# params/resolve_params. Its element is a single BIT: from_string packs each
-# '0'/'1' character into one bit (8 bits per byte), so a 64-character bit string
-# stores in 8 packed bytes, not 64.
+# value, a max_persisted_length upper bound, and NO params/resolve_params.
+# Its element is a single BIT: from_string packs each '0'/'1' character into
+# one bit (8 bits per byte), so a 64-character bit string stores in 8 packed
+# bytes, not 64.
 #
 # Fixture: vsql_bitfield_test exposes BITFIELD. Stored layout is a 2-byte
 # little-endian bit count followed by the packed bits, so any bit length

--- a/mysql-test/suite/villagesql/extension/t/extension_tarray_create_table.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_tarray_create_table.test
@@ -1,0 +1,72 @@
+# Acceptance test for issue #535:
+#   "Support variable-length, parameterized custom types"
+#
+# TARRAY is a typed array: the element WIDTH is parameterized via 'type', the
+# element COUNT is decided per value (persisted_length = -1), and a 'max_size'
+# parameter caps the element count. The integer shorthand TARRAY(N) maps N to
+# max_size via int_to_params; resolve_params enforces
+# max_size * element_size <= max_persisted_length (512 bytes here).
+#
+# Fixture: vsql_tarray_test exposes TARRAY.
+
+--echo # Install the typed-array extension.
+INSTALL EXTENSION vsql_tarray_test;
+
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
+
+--echo # TARRAY(N): integer shorthand mapped to max_size by int_to_params (type
+--echo # defaults to int16). TARRAY('max_size=...,type=...'): explicit cap+width.
+CREATE TABLE arrs (
+  id INT PRIMARY KEY,
+  a vsql_tarray_test.TARRAY(4),
+  f vsql_tarray_test.TARRAY('max_size=3,type=float')
+);
+
+--echo # Counts vary per value, up to max_size.
+INSERT INTO arrs VALUES (1, '[1,2,3]', '[1.5,2.5]');
+INSERT INTO arrs VALUES (2, '[10,20,30,40]', '[0]');
+
+SELECT id,
+       a, vsql_tarray_test.tarray_dim(a) AS na,
+       f, vsql_tarray_test.tarray_dim(f) AS nf
+FROM arrs ORDER BY id;
+
+--echo # Both parameters round-trip through SHOW CREATE TABLE.
+SHOW CREATE TABLE arrs;
+
+--echo # More elements than max_size is rejected by from_string (a has max 4).
+--error ER_TRUNCATED_WRONG_VALUE_FOR_FIELD
+INSERT INTO arrs VALUES (3, '[1,2,3,4,5]', '[1]');
+
+--echo # Element-wise compare predicate.
+SELECT id FROM arrs WHERE a > '[1,2,3]' ORDER BY id;
+
+--echo # Concatenation within max_size (f has max 3): [1.5,2.5] + [0] = 3 elems.
+SELECT vsql_tarray_test.tarray_concat(x.f, y.f) AS c,
+       vsql_tarray_test.tarray_dim(vsql_tarray_test.tarray_concat(x.f, y.f)) AS n
+FROM arrs x JOIN arrs y ON x.id = 1 AND y.id = 2;
+
+--echo # Concatenation exceeding max_size (a has max 4): 3 + 4 = 7 > 4 -> NULL
+--echo # with a warning.
+SELECT vsql_tarray_test.tarray_dim(
+         vsql_tarray_test.tarray_concat(x.a, y.a)) AS n
+FROM arrs x JOIN arrs y ON x.id = 1 AND y.id = 2;
+
+--echo # resolve_params enforces max_size * element_size <= 512:
+--echo # double * 100 = 800 bytes is rejected.
+--error ER_PARSE_ERROR
+CREATE TABLE bad1 (id INT, v vsql_tarray_test.TARRAY('max_size=100,type=double'));
+
+--echo # The integer shorthand goes through int_to_params (max_size=300) and is
+--echo # then rejected by resolve_params: int16 * 300 = 600 > 512.
+--error ER_PARSE_ERROR
+CREATE TABLE bad2 (id INT, v vsql_tarray_test.TARRAY(300));
+
+--echo # A non-positive shorthand is rejected by the parser before int_to_params.
+--error ER_PARSE_ERROR
+CREATE TABLE bad3 (id INT, v vsql_tarray_test.TARRAY(0));
+
+--echo # Clean up.
+DROP TABLE arrs;
+UNINSTALL EXTENSION vsql_tarray_test;
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;

--- a/mysql-test/suite/villagesql/extension/t/extension_tarray_create_table.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_tarray_create_table.test
@@ -51,6 +51,28 @@ SELECT vsql_tarray_test.tarray_dim(
          vsql_tarray_test.tarray_concat(x.a, y.a)) AS n
 FROM arrs x JOIN arrs y ON x.id = 1 AND y.id = 2;
 
+--echo # tarray_concat requires both arguments to share the same type parameters.
+--echo # Here a is TARRAY(max_size=4,type=int16) and f is
+--echo # TARRAY(max_size=3,type=float): type-parameter disambiguation rejects the
+--echo # call at prepare time rather than letting the VDF run with mismatched
+--echo # parameters.
+--error ER_VILLAGESQL_GENERIC_ERROR
+SELECT vsql_tarray_test.tarray_concat(x.a, y.f)
+FROM arrs x JOIN arrs y ON x.id = 1 AND y.id = 2;
+
+--echo # The conflict is on any differing parameter, not just element type. Here
+--echo # both columns are int16 and differ only in max_size (1 vs 2), and the
+--echo # call is still rejected at prepare time.
+CREATE TABLE arrs2 (
+  id INT PRIMARY KEY,
+  g vsql_tarray_test.TARRAY(1),
+  h vsql_tarray_test.TARRAY(2)
+);
+INSERT INTO arrs2 VALUES (1, '[1]', '[2,3]');
+--error ER_VILLAGESQL_GENERIC_ERROR
+SELECT vsql_tarray_test.tarray_concat(g, h) FROM arrs2;
+DROP TABLE arrs2;
+
 --echo # resolve_params enforces max_size * element_size <= 512:
 --echo # double * 100 = 800 bytes is rejected.
 --error ER_PARSE_ERROR

--- a/mysql-test/suite/villagesql/extension/t/extension_tarray_create_table.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_tarray_create_table.test
@@ -2,9 +2,8 @@
 #   "Support variable-length, parameterized custom types"
 #
 # TARRAY is a typed array: the element WIDTH is parameterized via 'type', the
-# element COUNT is decided per value (persisted_length = -1), and a 'max_size'
-# parameter caps the element count. The integer shorthand TARRAY(N) maps N to
-# max_size via int_to_params; resolve_params enforces
+# element COUNT is decided per value, and a 'max_size' parameter caps the element count.
+# The integer shorthand TARRAY(N) maps N to max_size via int_to_params; resolve_params enforces
 # max_size * element_size <= max_persisted_length (512 bytes here).
 #
 # Fixture: vsql_tarray_test exposes TARRAY.

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -9633,8 +9633,11 @@ Field *make_field(const Create_field &create_field, TABLE_SHARE *share,
       create_field.m_srid, create_field.is_array);
   if (f && create_field.custom_type_context) {
     f->set_type_context(create_field.custom_type_context);
+    // Fixed-length types store exactly persisted_length bytes; variable-length
+    // types (persisted_length == -1) keep their length per value and are backed
+    // by a field sized to the type's max_persisted_length upper bound.
     assert(static_cast<int64_t>(f->field_length) ==
-           create_field.custom_type_context->persisted_length());
+           create_field.custom_type_context->field_buffer_length());
   }
   return f;
 }

--- a/sql/field.cc
+++ b/sql/field.cc
@@ -9634,8 +9634,8 @@ Field *make_field(const Create_field &create_field, TABLE_SHARE *share,
   if (f && create_field.custom_type_context) {
     f->set_type_context(create_field.custom_type_context);
     // Fixed-length types store exactly persisted_length bytes; variable-length
-    // types (persisted_length == -1) keep their length per value and are backed
-    // by a field sized to the type's max_persisted_length upper bound.
+    // types keep their length per value and are backed by a field sized to the
+    // type's max_persisted_length upper bound.
     assert(static_cast<int64_t>(f->field_length) ==
            create_field.custom_type_context->field_buffer_length());
   }

--- a/villagesql/schema/descriptor/type_context.h
+++ b/villagesql/schema/descriptor/type_context.h
@@ -281,15 +281,19 @@ class TypeContext {
   int64_t persisted_length() const { return persisted_length_; }
   int64_t max_decode_buffer_length() const { return max_decode_buffer_length_; }
 
+  // True if the underlying type is variable-length (size decided per value).
+  // Delegates to the descriptor's registration-time marker.
+  bool is_variable_length() const {
+    return descriptor_->length_kind() == LengthKind::Variable;
+  }
+
   // Declared length of the backing field for this type instantiation.
   // Fixed-length and parameter-resolved types store exactly persisted_length
-  // bytes. A variable-length type without parameters keeps persisted_length
-  // == -1 (its length is decided per value, like a roaring bitmap); such a
-  // type is backed by a variable-length field sized to the descriptor's
-  // max_persisted_length upper bound.
+  // bytes. A variable-length type length is decided per value, and the backing
+  // field is sized to the type's max_persisted_length upper bound.
   int64_t field_buffer_length() const {
-    return persisted_length_ < 0 ? descriptor_->max_persisted_length()
-                                 : persisted_length_;
+    return is_variable_length() ? descriptor_->max_persisted_length()
+                                : persisted_length_;
   }
 
   // Bound type operations. These combine the TypeFunction from the descriptor

--- a/villagesql/schema/descriptor/type_context.h
+++ b/villagesql/schema/descriptor/type_context.h
@@ -239,9 +239,7 @@ class TypeContext {
   // Returns true when this TypeContext represents a parameterized type whose
   // parameters have not yet been resolved. A non-parameterized type with empty
   // parameters (e.g. COMPLEX) is fully known and returns false.
-  bool is_unknown() const {
-    return descriptor_->is_parameterized() && parameters().empty();
-  }
+  bool is_unknown() const { return is_parameterized() && parameters().empty(); }
 
   // Types are compatible if they have the same key (type name, extension,
   // version, and parameters). This ensures e.g. TVECTOR(3) != TVECTOR(4).
@@ -286,6 +284,10 @@ class TypeContext {
   bool is_variable_length() const {
     return descriptor_->length_kind() == LengthKind::Variable;
   }
+
+  // True if this type accepts parameters (has a resolve_params callback),
+  // independent of whether it is fixed- or variable-length.
+  bool is_parameterized() const { return descriptor_->is_parameterized(); }
 
   // Declared length of the backing field for this type instantiation.
   // Fixed-length and parameter-resolved types store exactly persisted_length

--- a/villagesql/schema/descriptor/type_context.h
+++ b/villagesql/schema/descriptor/type_context.h
@@ -281,6 +281,17 @@ class TypeContext {
   int64_t persisted_length() const { return persisted_length_; }
   int64_t max_decode_buffer_length() const { return max_decode_buffer_length_; }
 
+  // Declared length of the backing field for this type instantiation.
+  // Fixed-length and parameter-resolved types store exactly persisted_length
+  // bytes. A variable-length type without parameters keeps persisted_length
+  // == -1 (its length is decided per value, like a roaring bitmap); such a
+  // type is backed by a variable-length field sized to the descriptor's
+  // max_persisted_length upper bound.
+  int64_t field_buffer_length() const {
+    return persisted_length_ < 0 ? descriptor_->max_persisted_length()
+                                 : persisted_length_;
+  }
+
   // Bound type operations. These combine the TypeFunction from the descriptor
   // with this context's TypeParameters.
   // encode_op, decode_op, compare_op assert that the op is set (required ops).

--- a/villagesql/test-extensions/CMakeLists.txt
+++ b/villagesql/test-extensions/CMakeLists.txt
@@ -38,3 +38,5 @@ vsql_add_test_extension(vsql-noop-test                 vsql_noop_test)
 # at VEF_PROTOCOL_3 and is rejected by build_type_descriptor_v3 (missing
 # resolve_params) -- a path the current dev SDK can no longer produce.
 vsql_add_test_extension(vsql-bad-var-no-resolve-test   vsql_bad_var_no_resolve_test  ABI v3)
+vsql_add_test_extension(vsql-bitfield-test             vsql_bitfield_test)
+vsql_add_test_extension(vsql-tarray-test               vsql_tarray_test)

--- a/villagesql/test-extensions/vsql-bitfield-test/manifest.json
+++ b/villagesql/test-extensions/vsql-bitfield-test/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "vsql_bitfield_test",
   "version": "0.0.1",
-  "description": "Variable-length, non-parameterized bit field type (BITFIELD): persisted_length=-1 with a max_persisted_length upper bound and NO params/resolve_params. from_string packs each '0'/'1' character into a single bit (8 bits per byte), so the stored size grows with the bit count, not the character count (#535).",
+  "description": "Variable-length, non-parameterized bit field type (BITFIELD): with a max_persisted_length upper bound and NO params/resolve_params. from_string packs each '0'/'1' character into a single bit (8 bits per byte), so the stored size grows with the bit count, not the character count (#535).",
   "author": "VillageSQL Community",
   "license": "GPL-2.0"
 }

--- a/villagesql/test-extensions/vsql-bitfield-test/manifest.json
+++ b/villagesql/test-extensions/vsql-bitfield-test/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "vsql_bitfield_test",
+  "version": "0.0.1",
+  "description": "Variable-length, non-parameterized bit field type (BITFIELD): persisted_length=-1 with a max_persisted_length upper bound and NO params/resolve_params. from_string packs each '0'/'1' character into a single bit (8 bits per byte), so the stored size grows with the bit count, not the character count (#535).",
+  "author": "VillageSQL Community",
+  "license": "GPL-2.0"
+}

--- a/villagesql/test-extensions/vsql-bitfield-test/manifest.json
+++ b/villagesql/test-extensions/vsql-bitfield-test/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "vsql_bitfield_test",
   "version": "0.0.1",
-  "description": "Variable-length, non-parameterized bit field type (BITFIELD): with a max_persisted_length upper bound and NO params/resolve_params. from_string packs each '0'/'1' character into a single bit (8 bits per byte), so the stored size grows with the bit count, not the character count (#535).",
+  "description": "Variable-length, non-parameterized bit field type (BITFIELD): with a max_persisted_length upper bound and NO params/resolve_params. from_string packs each '0'/'1' character into a single bit (8 bits per byte), so the stored size grows with the bit count, not the character count.",
   "author": "VillageSQL Community",
   "license": "GPL-2.0"
 }

--- a/villagesql/test-extensions/vsql-bitfield-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-bitfield-test/src/extension.cc
@@ -16,10 +16,10 @@
 // Test fixture for issue #535: a variable-length, NON-parameterized bit field
 // type whose length (in bits) is decided per value.
 //
-// BITFIELD declares persisted_length = -1 with a max_persisted_length upper
-// bound and NO params/int_to_params/resolve_params, and its element is a single
-// BIT rather than a byte or a fixed-width number. A column is declared without
-// any length or parameters:
+// BITFIELD declares a max_persisted_length upper bound and NO
+// params/int_to_params/resolve_params, and its element is a single BIT rather
+// than a byte or a fixed-width number. A column is declared without any length
+// or parameters:
 //   CREATE TABLE t (b vsql_bitfield_test.BITFIELD);
 // and each value keeps its own bit length; bit fields of different lengths
 // coexist in the same column.
@@ -35,9 +35,9 @@
 // 7-(i%8)). to_string reads the bit count from the header and emits exactly
 // that many '0'/'1' characters, so any bit string round-trips exactly.
 //
-// The backing field is a VARCHAR(max_persisted_length): the in-memory buffer is
-// sized to the upper bound, but only the actual encoded bytes (set via
-// out.set_length()) are written, and the VARCHAR length prefix records the
+// The backing field is a VARBINARY(max_persisted_length): the in-memory buffer
+// is sized to the upper bound, but only the actual encoded bytes (set via
+// out.set_length()) are written, and the VARBINARY length prefix records the
 // per-value byte length.
 
 #include <villagesql/vsql.h>
@@ -67,10 +67,9 @@ static size_t load_bit_count(const unsigned char *buf) {
   return static_cast<size_t>(buf[0]) | (static_cast<size_t>(buf[1]) << 8);
 }
 
-// Read bit i (MSB-first within each byte) from the packed region of `data`,
-// which starts after the 2-byte header.
+// Read bit i (MSB-first within each byte) from the packed region of `data`
 static int get_bit(const unsigned char *data, size_t i) {
-  return (data[kBitfieldHeaderLen + i / 8] >> (7 - (i % 8))) & 1;
+  return (data[i / 8] >> (7 - (i % 8))) & 1;
 }
 
 // STRING -> binary: pack each '0'/'1' character into one bit. The number of
@@ -107,13 +106,14 @@ void bitfield_to_string(vsql::CustomArg in, vsql::StringResult out) {
   auto data = in.value();
   auto buf = out.buffer();
   if (data.size() < static_cast<size_t>(kBitfieldHeaderLen)) {
+    out.warning("bitfield_to_string: doesn't contain enough data for header");
     out.set_length(0);
     return;
   }
   const size_t nbits = load_bit_count(data.data());
   if (nbits > buf.size()) return;
   for (size_t i = 0; i < nbits; i++) {
-    buf[i] = get_bit(data.data(), i) ? '1' : '0';
+    buf[i] = get_bit(data.data() + kBitfieldHeaderLen, i) ? '1' : '0';
   }
   out.set_length(nbits);
 }
@@ -122,19 +122,40 @@ void bitfield_to_string(vsql::CustomArg in, vsql::StringResult out) {
 int bitfield_compare(vsql::CustomArg a, vsql::CustomArg b) {
   auto da = a.value();
   auto db = b.value();
-  size_t na = da.size() >= static_cast<size_t>(kBitfieldHeaderLen)
-                  ? load_bit_count(da.data())
-                  : 0;
-  size_t nb = db.size() >= static_cast<size_t>(kBitfieldHeaderLen)
-                  ? load_bit_count(db.data())
-                  : 0;
-  size_t n = na < nb ? na : nb;
-  for (size_t i = 0; i < n; i++) {
-    int ba = get_bit(da.data(), i);
-    int bb = get_bit(db.data(), i);
+  size_t nabits = da.size() >= static_cast<size_t>(kBitfieldHeaderLen)
+                      ? load_bit_count(da.data())
+                      : 0;
+  size_t nbbits = db.size() >= static_cast<size_t>(kBitfieldHeaderLen)
+                      ? load_bit_count(db.data())
+                      : 0;
+
+  assert(nabits == 0 || (da.size() - kBitfieldHeaderLen) * 8 >= nabits);
+  assert(nbbits == 0 || (db.size() - kBitfieldHeaderLen) * 8 >= nbbits);
+
+  // compare full bytes first for efficiency, then remaining bits
+  size_t nabytes = nabits / 8;
+  size_t nbbytes = nbbits / 8;
+  size_t nbytes = std::min(nabytes, nbbytes);
+
+  if (nbytes > 0) {
+    int rc = memcmp(da.data() + kBitfieldHeaderLen,
+                    db.data() + kBitfieldHeaderLen, nbytes);
+    if (rc != 0) return rc < 0 ? -1 : 1;
+  }
+
+  // compare remaining bits
+  assert(nabits >= nbytes * 8);
+  assert(nbbits >= nbytes * 8);
+  size_t na_remaining_bits = nabits - (nbytes * 8);
+  size_t nb_remaining_bits = nbbits - (nbytes * 8);
+  size_t n_remaining_bits = std::min(na_remaining_bits, nb_remaining_bits);
+  for (size_t i = 0; i < n_remaining_bits; i++) {
+    int ba = get_bit(da.data() + kBitfieldHeaderLen + nbytes, i);
+    int bb = get_bit(db.data() + kBitfieldHeaderLen + nbytes, i);
     if (ba != bb) return ba < bb ? -1 : 1;
   }
-  if (na != nb) return na < nb ? -1 : 1;
+  if (na_remaining_bits != nb_remaining_bits)
+    return na_remaining_bits < nb_remaining_bits ? -1 : 1;
   return 0;
 }
 
@@ -165,7 +186,7 @@ void bitfield_popcount(vsql::CustomArg in, vsql::IntResult out) {
   const size_t nbits = load_bit_count(data.data());
   long long count = 0;
   for (size_t i = 0; i < nbits; i++) {
-    count += get_bit(data.data(), i);
+    count += get_bit(data.data() + kBitfieldHeaderLen, i);
   }
   out.set(count);
 }
@@ -173,7 +194,7 @@ void bitfield_popcount(vsql::CustomArg in, vsql::IntResult out) {
 static constexpr const char kBitfieldTypeName[] = "BITFIELD";
 
 constexpr auto BITFIELD = vsql::make_type<kBitfieldTypeName>()
-                              .persisted_length(-1)
+                              .variable_length_type()
                               .max_persisted_length(kBitfieldMaxLen)
                               .max_decode_buffer_length(kBitfieldMaxText)
                               .from_string<&bitfield_from_string>()

--- a/villagesql/test-extensions/vsql-bitfield-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-bitfield-test/src/extension.cc
@@ -1,0 +1,198 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+// Test fixture for issue #535: a variable-length, NON-parameterized bit field
+// type whose length (in bits) is decided per value.
+//
+// BITFIELD declares persisted_length = -1 with a max_persisted_length upper
+// bound and NO params/int_to_params/resolve_params, and its element is a single
+// BIT rather than a byte or a fixed-width number. A column is declared without
+// any length or parameters:
+//   CREATE TABLE t (b vsql_bitfield_test.BITFIELD);
+// and each value keeps its own bit length; bit fields of different lengths
+// coexist in the same column.
+//
+// from_string packs each '0'/'1' character into one BIT (8 bits per byte), so a
+// 64-character string of bits stores in 8 bytes of packed bits, not 64. The
+// number of bits is not recoverable from the byte length alone (e.g. "101" and
+// "10100000" would both occupy one byte), so the stored layout is:
+//
+//   [ bit count : 2 bytes little-endian ][ packed bits : ceil(bits/8) bytes ]
+//
+// Bits are packed MSB-first within each byte (bit i -> byte i/8, position
+// 7-(i%8)). to_string reads the bit count from the header and emits exactly
+// that many '0'/'1' characters, so any bit string round-trips exactly.
+//
+// The backing field is a VARCHAR(max_persisted_length): the in-memory buffer is
+// sized to the upper bound, but only the actual encoded bytes (set via
+// out.set_length()) are written, and the VARCHAR length prefix records the
+// per-value byte length.
+
+#include <villagesql/vsql.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+
+// Maximum number of bits a BITFIELD value may hold. The bit count is stored in
+// a 2-byte little-endian header, so it must fit in a uint16.
+constexpr int64_t kBitfieldMaxBits = 4096;
+constexpr int64_t kBitfieldHeaderLen = 2;
+// Upper bound on the stored value: 2-byte header plus ceil(maxBits/8) packed
+// bytes. Sizes the backing field and the encode buffer.
+constexpr int64_t kBitfieldMaxLen =
+    kBitfieldHeaderLen + (kBitfieldMaxBits + 7) / 8;
+// Upper bound on the text form: one '0'/'1' character per bit.
+constexpr int64_t kBitfieldMaxText = kBitfieldMaxBits;
+
+// Read/write the 2-byte little-endian bit-count header.
+static void store_bit_count(unsigned char *buf, size_t nbits) {
+  buf[0] = static_cast<unsigned char>(nbits & 0xFF);
+  buf[1] = static_cast<unsigned char>((nbits >> 8) & 0xFF);
+}
+
+static size_t load_bit_count(const unsigned char *buf) {
+  return static_cast<size_t>(buf[0]) | (static_cast<size_t>(buf[1]) << 8);
+}
+
+// Read bit i (MSB-first within each byte) from the packed region of `data`,
+// which starts after the 2-byte header.
+static int get_bit(const unsigned char *data, size_t i) {
+  return (data[kBitfieldHeaderLen + i / 8] >> (7 - (i % 8))) & 1;
+}
+
+// STRING -> binary: pack each '0'/'1' character into one bit. The number of
+// bits is decided per value (not a type parameter); the actual byte length is
+// reported via out.set_length().
+void bitfield_from_string(std::string_view from, vsql::CustomResult out) {
+  auto buf = out.buffer();
+  const size_t nbits = from.size();
+  const size_t nbytes = (nbits + 7) / 8;
+  if (kBitfieldHeaderLen + nbytes > buf.size()) {
+    out.warning("BITFIELD: value exceeds max length");
+    return;
+  }
+
+  // Zero the packed region, then set the 1 bits.
+  memset(buf.data() + kBitfieldHeaderLen, 0, nbytes);
+  for (size_t i = 0; i < nbits; i++) {
+    char c = from[i];
+    if (c != '0' && c != '1') {
+      out.warning("BITFIELD: expected only '0' or '1'");
+      return;
+    }
+    if (c == '1') {
+      buf.data()[kBitfieldHeaderLen + i / 8] |=
+          static_cast<unsigned char>(1u << (7 - (i % 8)));
+    }
+  }
+  store_bit_count(buf.data(), nbits);
+  out.set_length(kBitfieldHeaderLen + nbytes);
+}
+
+// binary -> STRING: emit exactly bit-count '0'/'1' characters, MSB-first.
+void bitfield_to_string(vsql::CustomArg in, vsql::StringResult out) {
+  auto data = in.value();
+  auto buf = out.buffer();
+  if (data.size() < static_cast<size_t>(kBitfieldHeaderLen)) {
+    out.set_length(0);
+    return;
+  }
+  const size_t nbits = load_bit_count(data.data());
+  if (nbits > buf.size()) return;
+  for (size_t i = 0; i < nbits; i++) {
+    buf[i] = get_bit(data.data(), i) ? '1' : '0';
+  }
+  out.set_length(nbits);
+}
+
+// Bit-by-bit comparison; a shorter bit field sorts first on a common prefix.
+int bitfield_compare(vsql::CustomArg a, vsql::CustomArg b) {
+  auto da = a.value();
+  auto db = b.value();
+  size_t na = da.size() >= static_cast<size_t>(kBitfieldHeaderLen)
+                  ? load_bit_count(da.data())
+                  : 0;
+  size_t nb = db.size() >= static_cast<size_t>(kBitfieldHeaderLen)
+                  ? load_bit_count(db.data())
+                  : 0;
+  size_t n = na < nb ? na : nb;
+  for (size_t i = 0; i < n; i++) {
+    int ba = get_bit(da.data(), i);
+    int bb = get_bit(db.data(), i);
+    if (ba != bb) return ba < bb ? -1 : 1;
+  }
+  if (na != nb) return na < nb ? -1 : 1;
+  return 0;
+}
+
+// Number of bits in this BITFIELD value (read from the header).
+void bitfield_length(vsql::CustomArg in, vsql::IntResult out) {
+  if (in.is_null()) {
+    out.set_null();
+    return;
+  }
+  auto data = in.value();
+  long long nbits = data.size() >= static_cast<size_t>(kBitfieldHeaderLen)
+                        ? static_cast<long long>(load_bit_count(data.data()))
+                        : 0;
+  out.set(nbits);
+}
+
+// Number of set bits (population count) in this BITFIELD value.
+void bitfield_popcount(vsql::CustomArg in, vsql::IntResult out) {
+  if (in.is_null()) {
+    out.set_null();
+    return;
+  }
+  auto data = in.value();
+  if (data.size() < static_cast<size_t>(kBitfieldHeaderLen)) {
+    out.set(0);
+    return;
+  }
+  const size_t nbits = load_bit_count(data.data());
+  long long count = 0;
+  for (size_t i = 0; i < nbits; i++) {
+    count += get_bit(data.data(), i);
+  }
+  out.set(count);
+}
+
+static constexpr const char kBitfieldTypeName[] = "BITFIELD";
+
+constexpr auto BITFIELD = vsql::make_type<kBitfieldTypeName>()
+                              .persisted_length(-1)
+                              .max_persisted_length(kBitfieldMaxLen)
+                              .max_decode_buffer_length(kBitfieldMaxText)
+                              .from_string<&bitfield_from_string>()
+                              .to_string<&bitfield_to_string>()
+                              .compare<&bitfield_compare>()
+                              .build();
+
+using namespace vsql;
+
+VEF_GENERATE_ENTRY_POINTS(
+    make_extension()
+        .type(BITFIELD)
+        .func(make_func<&bitfield_length>("bitfield_length")
+                  .returns(INT)
+                  .param(BITFIELD)
+                  .deterministic()
+                  .build())
+        .func(make_func<&bitfield_popcount>("bitfield_popcount")
+                  .returns(INT)
+                  .param(BITFIELD)
+                  .deterministic()
+                  .build()))

--- a/villagesql/test-extensions/vsql-tarray-test/manifest.json
+++ b/villagesql/test-extensions/vsql-tarray-test/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "vsql_tarray_test",
   "version": "0.0.1",
-  "description": "Variable-length typed array (TARRAY): element WIDTH parameterized via 'type', element COUNT decided per value, bounded by a 'max_size' parameter capping the element count. TARRAY(N) maps the integer to max_size via int_to_params; resolve_params enforces max_size * element_size <= max_persisted_length (#535).",
+  "description": "Variable-length typed array (TARRAY): element WIDTH parameterized via 'type', element COUNT decided per value, bounded by a 'max_size' parameter capping the element count. TARRAY(N) maps the integer to max_size via int_to_params; resolve_params enforces max_size * element_size <= max_persisted_length.",
   "author": "VillageSQL Community",
   "license": "GPL-2.0"
 }

--- a/villagesql/test-extensions/vsql-tarray-test/manifest.json
+++ b/villagesql/test-extensions/vsql-tarray-test/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "vsql_tarray_test",
   "version": "0.0.1",
-  "description": "Variable-length typed array (TARRAY): element WIDTH parameterized via 'type', element COUNT decided per value (persisted_length=-1), bounded by a 'max_size' parameter capping the element count. TARRAY(N) maps the integer to max_size via int_to_params; resolve_params enforces max_size * element_size <= max_persisted_length (#535).",
+  "description": "Variable-length typed array (TARRAY): element WIDTH parameterized via 'type', element COUNT decided per value, bounded by a 'max_size' parameter capping the element count. TARRAY(N) maps the integer to max_size via int_to_params; resolve_params enforces max_size * element_size <= max_persisted_length (#535).",
   "author": "VillageSQL Community",
   "license": "GPL-2.0"
 }

--- a/villagesql/test-extensions/vsql-tarray-test/manifest.json
+++ b/villagesql/test-extensions/vsql-tarray-test/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "vsql_tarray_test",
+  "version": "0.0.1",
+  "description": "Variable-length typed array (TARRAY): element WIDTH parameterized via 'type', element COUNT decided per value (persisted_length=-1), bounded by a 'max_size' parameter capping the element count. TARRAY(N) maps the integer to max_size via int_to_params; resolve_params enforces max_size * element_size <= max_persisted_length (#535).",
+  "author": "VillageSQL Community",
+  "license": "GPL-2.0"
+}

--- a/villagesql/test-extensions/vsql-tarray-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-tarray-test/src/extension.cc
@@ -159,9 +159,10 @@ bool tarray_int_to_params(int64_t value,
                           std::map<std::string, std::string> &params,
                           char *error_msg) {
   if (value <= 0) {
-    snprintf(error_msg, VEF_MAX_ERROR_LEN,
-             "TARRAY max_size must be positive (got %lld)",
-             static_cast<long long>(value));
+    snprintf(
+        error_msg, VEF_MAX_ERROR_LEN,
+        "tarray_int_to_params: TARRAY max_size must be positive (got %lld)",
+        static_cast<long long>(value));
     return true;
   }
   params["max_size"] = std::to_string(value);
@@ -178,7 +179,8 @@ bool tarray_resolve_params(const std::map<std::string, std::string> &params,
   if (type_it != params.end() && type_it->second != "float" &&
       type_it->second != "double" && type_it->second != "int16") {
     snprintf(error_msg, VEF_MAX_ERROR_LEN,
-             "TARRAY type must be 'float' or 'double' or 'int16', got '%s'",
+             "tarray_resolve_params: type must be 'float' or 'double' or "
+             "'int16', got '%s'",
              type_it->second.c_str());
     return true;
   }
@@ -186,18 +188,20 @@ bool tarray_resolve_params(const std::map<std::string, std::string> &params,
   auto it = params.find("max_size");
   if (it == params.end()) {
     snprintf(error_msg, VEF_MAX_ERROR_LEN,
-             "TARRAY requires a max_size parameter");
+             "tarray_resolve_params: TARRAY requires a max_size parameter");
     return true;
   }
   char *endptr = nullptr;
   int64_t max_size = strtoll(it->second.c_str(), &endptr, 10);
   if (endptr == it->second.c_str() || *endptr != '\0') {
-    snprintf(error_msg, VEF_MAX_ERROR_LEN, "TARRAY: invalid max_size '%s'",
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "tarray_resolve_params: invalid max_size '%s'",
              it->second.c_str());
     return true;
   }
   if (max_size <= 0) {
-    snprintf(error_msg, VEF_MAX_ERROR_LEN, "TARRAY max_size must be positive");
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "tarray_resolve_params: TARRAY max_size must be positive");
     return true;
   }
 
@@ -205,7 +209,8 @@ bool tarray_resolve_params(const std::map<std::string, std::string> &params,
 
   if (max_size * bpe > kTarrayMaxLen) {
     snprintf(error_msg, VEF_MAX_ERROR_LEN,
-             "TARRAY max_size %lld * element size %lld exceeds the %lld-byte "
+             "tarray_resolve_params: TARRAY max_size %lld * element size %lld "
+             "exceeds the %lld-byte "
              "limit",
              static_cast<long long>(max_size), static_cast<long long>(bpe),
              static_cast<long long>(kTarrayMaxLen));
@@ -214,7 +219,7 @@ bool tarray_resolve_params(const std::map<std::string, std::string> &params,
 
   assert(result->persisted_length <= 0);
   // Upper bound on the text form: at most max_size elements, each printing to
-  // at most kMaxDecodedDoubleElemchars plus the brackets.
+  // at most kMaxDecodedDoubleElem chars plus the brackets.
   result->max_decode_buffer_length = max_size * kMaxDecodedDoubleElem + 2;
   return false;
 }
@@ -231,8 +236,15 @@ void tarray_from_string(vsql::MaybeParams<TarrayParams> &p,
   }
   assert(bpe > 0);
   auto buf = out.buffer();
-  // resolve_params guarantees max_size * bpe <= buffer capacity, so max_size is
-  // the binding cap when the params are known.
+
+  // out buffer size is equal to max_persisted_size. resolve_params guarantees
+  // that max_size*bpe is smaller than max_persisted_size. We want to parse at
+  // most max_size elements from the string into out buffer. In case string has
+  // more than max_size elements - we will return a warning and not write more
+  // than max_size elements into out buffer.
+  assert(!p.is_known() || p.value().max_size > 0);
+  assert(!p.is_known() ||
+         (p.value().max_size * bpe <= static_cast<int64_t>(buf.size())));
   const size_t cap = (p.is_known() && p.value().max_size > 0)
                          ? static_cast<size_t>(p.value().max_size)
                          : buf.size() / static_cast<size_t>(bpe);
@@ -241,7 +253,7 @@ void tarray_from_string(vsql::MaybeParams<TarrayParams> &p,
   const char *s = input.c_str();
   while (*s == ' ') s++;
   if (*s != '[') {
-    out.warning("TARRAY: expected '['");
+    out.warning("tarray_from_string: expected '['");
     return;
   }
   s++;
@@ -260,7 +272,7 @@ void tarray_from_string(vsql::MaybeParams<TarrayParams> &p,
       case TarrayElemType::kInt16: {
         long v = strtol(s, &endptr, 10);
         if (endptr == s) {
-          out.warning("TARRAY: parse error");
+          out.warning("tarray_from_string: parse error when parsing int16");
           return;
         }
         store_i16(slot, static_cast<int16_t>(v));
@@ -269,7 +281,7 @@ void tarray_from_string(vsql::MaybeParams<TarrayParams> &p,
       case TarrayElemType::kFloat: {
         float v = strtof(s, &endptr);
         if (endptr == s) {
-          out.warning("TARRAY: parse error");
+          out.warning("tarray_from_string: parse error when parsing float");
           return;
         }
         store_f32(slot, v);
@@ -278,14 +290,14 @@ void tarray_from_string(vsql::MaybeParams<TarrayParams> &p,
       case TarrayElemType::kDouble: {
         double v = strtod(s, &endptr);
         if (endptr == s) {
-          out.warning("TARRAY: parse error");
+          out.warning("tarray_from_string: parse error when parsing double");
           return;
         }
         store_d64(slot, v);
         break;
       }
       default:
-        out.warning("TARRAY: invalid element type");
+        out.warning("tarray_from_string: invalid element type");
         assert(false);
         return;
     }
@@ -295,7 +307,7 @@ void tarray_from_string(vsql::MaybeParams<TarrayParams> &p,
     if (*s == ',') s++;
   }
   if (*s != ']') {
-    out.warning("TARRAY: missing ']'");
+    out.warning("tarray_from_string: missing ']'");
     return;
   }
   out.set_length(count * static_cast<size_t>(bpe));
@@ -335,7 +347,9 @@ void tarray_to_string(vsql::CustomArgWith<TarrayParams> in,
             snprintf(buf.data() + pos, buf.size() - pos, "%g", load_d64(slot));
         break;
       default:
-        assert(false);
+        out.warning("tarray_to_string: invalid element type");
+        out.set_length(0);
+        assert(written == 0);
     }
     if (written < 0 || pos + static_cast<size_t>(written) >= buf.size()) return;
     pos += static_cast<size_t>(written);
@@ -395,9 +409,10 @@ void tarray_dim(vsql::CustomArgWith<TarrayParams> in, vsql::IntResult out) {
 }
 
 // Concatenate two TARRAY values: (TARRAY, TARRAY) -> TARRAY. Both share the
-// same parameters (type and max_size, guaranteed by type-parameter
-// disambiguation). The result must still respect max_size, so a concatenation
-// whose combined element count exceeds max_size is rejected with a warning.
+// same parameters (type and max_size, guaranteed equal by the
+// parameter-conflict check during VDF argument validation). The result must
+// still respect max_size, so a concatenation whose combined element count
+// exceeds max_size is rejected with a warning.
 void tarray_concat(vsql::CustomArgWith<TarrayParams> a,
                    vsql::CustomArgWith<TarrayParams> b,
                    vsql::CustomResultWith<TarrayParams> out) {
@@ -407,18 +422,20 @@ void tarray_concat(vsql::CustomArgWith<TarrayParams> a,
   }
   const int64_t bpe = a.params().bytes_per_elem;
   assert(bpe > 0);
-  assert(bpe ==
-         b.params()
-             .bytes_per_elem);  // guaranteed by type-parameter disambiguation
+  assert(
+      bpe ==
+      b.params().bytes_per_elem);  // guaranteed equal by the parameter-conflict
+                                   // check during VDF argument validation
   const int64_t max_size = a.params().max_size;
   assert(max_size ==
-         b.params().max_size);  // guaranteed by type-parameter disambiguation
+         b.params().max_size);  // guaranteed equal by the parameter-conflict
+                                // check during VDF argument validation
   auto va = a.value();
   auto vb = b.value();
   const size_t total = va.size() + vb.size();
   const size_t total_elems = total / static_cast<size_t>(bpe);
   if (static_cast<int64_t>(total_elems) > max_size) {
-    out.warning("TARRAY: concatenated size exceeds max_size");
+    out.warning("tarray_concat: concatenated size exceeds max_size");
     return;
   }
   auto buf = out.buffer();

--- a/villagesql/test-extensions/vsql-tarray-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-tarray-test/src/extension.cc
@@ -1,0 +1,415 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+// Test fixture for issue #535: a variable-length typed array (TARRAY).
+//
+// TARRAY is a typed array where the element WIDTH is a 'type' parameter
+// (int16/float/double) and the element COUNT is decided per value
+// (persisted_length = -1), bounded by a 'max_size' parameter that caps how many
+// elements a value may hold:
+//   TARRAY(N)                          -> max_size=N, type defaults to int16
+//   TARRAY('type=float,max_size=10')   -> float elements, at most 10
+// The integer shorthand TARRAY(N) is mapped to max_size by int_to_params. A
+// column must specify the parameters (it is a parameterized type).
+//
+// resolve_params enforces max_size * element_size <= max_persisted_length (the
+// type's static upper bound) and returns persisted_length = -1 (the count is
+// still variable per value, just capped at max_size). from_string rejects a
+// value with more than max_size elements.
+//
+// The backing field is a VARCHAR(max_persisted_length); only the actual encoded
+// bytes are stored per value. Element widths are stored little-endian for
+// portable persistence.
+
+#include <villagesql/vsql.h>
+
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <string>
+#include <string_view>
+
+// Static upper bound on a stored TARRAY value in bytes. resolve_params requires
+// max_size * element_size to stay within this.
+constexpr int64_t kTarrayMaxLen = 512;
+
+// Element widths in bytes for the supported element types.
+constexpr int64_t kElemInt16 = 2;
+constexpr int64_t kElemFloat = 4;
+constexpr int64_t kElemDouble = 8;
+
+// Parameters: element width (from 'type') and element-count cap (from
+// 'max_size').
+struct TarrayParams {
+  int64_t bytes_per_elem = kElemInt16;
+  int64_t max_size = 0;  // 0 = unset; resolve_params rejects a non-positive max
+
+  static TarrayParams parse(const std::map<std::string, std::string> &params) {
+    TarrayParams p;
+    auto t = params.find("type");
+    if (t != params.end()) {
+      if (t->second == "float") {
+        p.bytes_per_elem = kElemFloat;
+      } else if (t->second == "double") {
+        p.bytes_per_elem = kElemDouble;
+      } else {
+        p.bytes_per_elem = kElemInt16;
+      }
+    }
+    auto m = params.find("max_size");
+    if (m != params.end()) p.max_size = strtoll(m->second.c_str(), nullptr, 10);
+    return p;
+  }
+
+  static void to_strings(const TarrayParams &p,
+                         std::map<std::string, std::string> &out) {
+    out["type"] = p.bytes_per_elem == kElemDouble  ? "double"
+                  : p.bytes_per_elem == kElemFloat ? "float"
+                                                   : "int16";
+    out["max_size"] = std::to_string(p.max_size);
+  }
+};
+
+// Little-endian byte serialization primitives, shared by all element widths.
+static void store_bytes(unsigned char *buf, uint64_t bits, int n) {
+  for (int i = 0; i < n; i++) {
+    buf[i] = static_cast<unsigned char>(bits >> (i * 8));
+  }
+}
+
+static uint64_t load_bytes(const unsigned char *buf, int n) {
+  uint64_t bits = 0;
+  for (int i = 0; i < n; i++) {
+    bits |= static_cast<uint64_t>(buf[i]) << (i * 8);
+  }
+  return bits;
+}
+
+static void store_i16(unsigned char *buf, int16_t v) {
+  store_bytes(buf, static_cast<uint16_t>(v), 2);
+}
+
+static int16_t load_i16(const unsigned char *buf) {
+  return static_cast<int16_t>(static_cast<uint16_t>(load_bytes(buf, 2)));
+}
+
+static void store_f32(unsigned char *buf, float v) {
+  uint32_t bits;
+  memcpy(&bits, &v, sizeof(float));
+  store_bytes(buf, bits, 4);
+}
+
+static float load_f32(const unsigned char *buf) {
+  uint32_t bits = static_cast<uint32_t>(load_bytes(buf, 4));
+  float v;
+  memcpy(&v, &bits, sizeof(float));
+  return v;
+}
+
+static void store_d64(unsigned char *buf, double v) {
+  uint64_t bits;
+  memcpy(&bits, &v, sizeof(double));
+  store_bytes(buf, bits, 8);
+}
+
+static double load_d64(const unsigned char *buf) {
+  uint64_t bits = load_bytes(buf, 8);
+  double v;
+  memcpy(&v, &bits, sizeof(double));
+  return v;
+}
+
+// Map a 'type' parameter string to its element width, or report an error.
+static bool elem_bytes_from_params(const std::map<std::string, std::string> &p,
+                                   int64_t *out_bytes, char *error_msg) {
+  auto it = p.find("type");
+  if (it == p.end()) {
+    *out_bytes = kElemInt16;
+    return false;
+  }
+  if (it->second == "int16") {
+    *out_bytes = kElemInt16;
+  } else if (it->second == "float") {
+    *out_bytes = kElemFloat;
+  } else if (it->second == "double") {
+    *out_bytes = kElemDouble;
+  } else {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "TARRAY: type must be int16, float, or double (got '%s')",
+             it->second.c_str());
+    return true;
+  }
+  return false;
+}
+
+// int_to_params: TARRAY(N) maps the integer N to the max_size parameter. The
+// element type defaults to int16 unless given via the string parameter form.
+bool tarray_int_to_params(int64_t value,
+                          std::map<std::string, std::string> &params,
+                          char *error_msg) {
+  if (value <= 0) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "TARRAY max_size must be positive (got %lld)",
+             static_cast<long long>(value));
+    return true;
+  }
+  params["max_size"] = std::to_string(value);
+  return false;
+}
+
+// resolve_params: validate the element width and the max_size cap, and enforce
+// max_size * element_size <= max_persisted_length. persisted_length stays -1
+// (the count is variable per value, capped at max_size).
+bool tarray_resolve_params(const std::map<std::string, std::string> &params,
+                           vsql::ResolvedTypeParams *result, char *error_msg) {
+  int64_t bpe = kElemInt16;
+  if (elem_bytes_from_params(params, &bpe, error_msg)) {
+    return true;
+  }
+  auto it = params.find("max_size");
+  if (it == params.end()) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "TARRAY requires a max_size parameter");
+    return true;
+  }
+  char *endptr = nullptr;
+  int64_t max_size = strtoll(it->second.c_str(), &endptr, 10);
+  if (endptr == it->second.c_str() || *endptr != '\0') {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN, "TARRAY: invalid max_size '%s'",
+             it->second.c_str());
+    return true;
+  }
+  if (max_size <= 0) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN, "TARRAY max_size must be positive");
+    return true;
+  }
+  if (max_size * bpe > kTarrayMaxLen) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "TARRAY max_size %lld * element size %lld exceeds the %lld-byte "
+             "limit",
+             static_cast<long long>(max_size), static_cast<long long>(bpe),
+             static_cast<long long>(kTarrayMaxLen));
+    return true;
+  }
+  result->persisted_length = -1;  // variable count, capped at max_size
+  // Upper bound on the text form: at most max_size elements, each printing to
+  // at most 26 chars (a double in %g), plus the brackets.
+  result->max_decode_buffer_length = max_size * 26 + 2;
+  return false;
+}
+
+// STRING -> binary: parse "[v1,v2,...]" into elements of the parameterized
+// width, rejecting more than max_size elements.
+void tarray_from_string(vsql::MaybeParams<TarrayParams> &p,
+                        std::string_view from, vsql::CustomResult out) {
+  const int64_t bpe = p.is_known() ? p.value().bytes_per_elem : kElemInt16;
+  assert(bpe > 0);
+  auto buf = out.buffer();
+  // resolve_params guarantees max_size * bpe <= buffer capacity, so max_size is
+  // the binding cap when the params are known.
+  const size_t cap = (p.is_known() && p.value().max_size > 0)
+                         ? static_cast<size_t>(p.value().max_size)
+                         : buf.size() / static_cast<size_t>(bpe);
+
+  std::string input(from);
+  const char *s = input.c_str();
+  while (*s == ' ') s++;
+  if (*s != '[') {
+    out.warning("TARRAY: expected '['");
+    return;
+  }
+  s++;
+
+  size_t count = 0;
+  while (*s != '\0') {
+    while (*s == ' ') s++;
+    if (*s == ']') break;
+    if (count >= cap) {
+      out.warning("TARRAY: more elements than max_size");
+      return;
+    }
+    char *endptr = nullptr;
+    unsigned char *slot = buf.data() + count * static_cast<size_t>(bpe);
+    if (bpe == kElemInt16) {
+      long v = strtol(s, &endptr, 10);
+      if (endptr == s) {
+        out.warning("TARRAY: parse error");
+        return;
+      }
+      store_i16(slot, static_cast<int16_t>(v));
+    } else if (bpe == kElemFloat) {
+      float v = strtof(s, &endptr);
+      if (endptr == s) {
+        out.warning("TARRAY: parse error");
+        return;
+      }
+      store_f32(slot, v);
+    } else {
+      double v = strtod(s, &endptr);
+      if (endptr == s) {
+        out.warning("TARRAY: parse error");
+        return;
+      }
+      store_d64(slot, v);
+    }
+    count++;
+    s = endptr;
+    while (*s == ' ') s++;
+    if (*s == ',') s++;
+  }
+  if (*s != ']') {
+    out.warning("TARRAY: missing ']'");
+    return;
+  }
+  out.set_length(count * static_cast<size_t>(bpe));
+}
+
+// binary -> STRING: the element count is the value's byte length divided by the
+// parameterized element width.
+void tarray_to_string(vsql::CustomArgWith<TarrayParams> in,
+                      vsql::StringResult out) {
+  const int64_t bpe = in.params().bytes_per_elem;
+  assert(bpe > 0);
+  auto data = in.value();
+  const size_t count = data.size() / static_cast<size_t>(bpe);
+  auto buf = out.buffer();
+  size_t pos = 0;
+  if (pos >= buf.size()) return;
+  buf[pos++] = '[';
+  for (size_t i = 0; i < count; i++) {
+    if (i > 0) {
+      if (pos >= buf.size()) return;
+      buf[pos++] = ',';
+    }
+    const unsigned char *slot = data.data() + i * static_cast<size_t>(bpe);
+    int written = 0;
+    if (bpe == kElemInt16) {
+      written = snprintf(buf.data() + pos, buf.size() - pos, "%d",
+                         static_cast<int>(load_i16(slot)));
+    } else if (bpe == kElemFloat) {
+      written = snprintf(buf.data() + pos, buf.size() - pos, "%g",
+                         static_cast<double>(load_f32(slot)));
+    } else {
+      written =
+          snprintf(buf.data() + pos, buf.size() - pos, "%g", load_d64(slot));
+    }
+    if (written < 0 || pos + static_cast<size_t>(written) >= buf.size()) return;
+    pos += static_cast<size_t>(written);
+  }
+  if (pos >= buf.size()) return;
+  buf[pos++] = ']';
+  out.set_length(pos);
+}
+
+// Element-wise comparison; a shorter array sorts first on a common prefix.
+int tarray_compare(vsql::CustomArgWith<TarrayParams> a,
+                   vsql::CustomArgWith<TarrayParams> b) {
+  const int64_t bpe = a.params().bytes_per_elem;
+  assert(bpe > 0);
+  auto va = a.value();
+  auto vb = b.value();
+  size_t na = va.size() / static_cast<size_t>(bpe);
+  size_t nb = vb.size() / static_cast<size_t>(bpe);
+  size_t n = na < nb ? na : nb;
+  for (size_t i = 0; i < n; i++) {
+    const unsigned char *pa = va.data() + i * static_cast<size_t>(bpe);
+    const unsigned char *pb = vb.data() + i * static_cast<size_t>(bpe);
+    if (bpe == kElemInt16) {
+      int16_t ea = load_i16(pa), eb = load_i16(pb);
+      if (ea != eb) return ea < eb ? -1 : 1;
+    } else if (bpe == kElemFloat) {
+      float ea = load_f32(pa), eb = load_f32(pb);
+      if (ea != eb) return ea < eb ? -1 : 1;
+    } else {
+      double ea = load_d64(pa), eb = load_d64(pb);
+      if (ea != eb) return ea < eb ? -1 : 1;
+    }
+  }
+  if (na != nb) return na < nb ? -1 : 1;
+  return 0;
+}
+
+// Number of elements in this TARRAY value.
+void tarray_dim(vsql::CustomArgWith<TarrayParams> in, vsql::IntResult out) {
+  if (in.is_null()) {
+    out.set_null();
+    return;
+  }
+  const int64_t bpe = in.params().bytes_per_elem;
+  assert(bpe > 0);
+  out.set(static_cast<long long>(in.value().size() / static_cast<size_t>(bpe)));
+}
+
+// Concatenate two TARRAY values: (TARRAY, TARRAY) -> TARRAY. Both share the
+// same parameters (type and max_size, guaranteed by type-parameter
+// disambiguation). The result must still respect max_size, so a concatenation
+// whose combined element count exceeds max_size is rejected with a warning.
+void tarray_concat(vsql::CustomArgWith<TarrayParams> a,
+                   vsql::CustomArgWith<TarrayParams> b,
+                   vsql::CustomResultWith<TarrayParams> out) {
+  if (a.is_null() || b.is_null()) {
+    out.set_null();
+    return;
+  }
+  const int64_t bpe = a.params().bytes_per_elem;
+  const int64_t max_size = a.params().max_size;
+  assert(bpe > 0);
+  auto va = a.value();
+  auto vb = b.value();
+  const size_t total = va.size() + vb.size();
+  const size_t total_elems = total / static_cast<size_t>(bpe);
+  if (static_cast<int64_t>(total_elems) > max_size) {
+    out.warning("TARRAY: concatenated size exceeds max_size");
+    return;
+  }
+  auto buf = out.buffer();
+  if (va.size() > 0) memcpy(buf.data(), va.data(), va.size());
+  if (vb.size() > 0) memcpy(buf.data() + va.size(), vb.data(), vb.size());
+  out.set_length(total);
+}
+
+static constexpr const char kTarrayTypeName[] = "TARRAY";
+
+constexpr auto TARRAY =
+    vsql::make_type<kTarrayTypeName>()
+        .persisted_length(-1)
+        .max_persisted_length(kTarrayMaxLen)
+        .max_decode_buffer_length(kTarrayMaxLen / kElemInt16 * 8 + 2)
+        .params<TarrayParams, &TarrayParams::parse, &TarrayParams::to_strings>()
+        .int_to_params<&tarray_int_to_params>()
+        .resolve_params<&tarray_resolve_params>()
+        .from_string<&tarray_from_string>()
+        .to_string<&tarray_to_string>()
+        .compare<&tarray_compare>()
+        .build();
+
+using namespace vsql;
+
+VEF_GENERATE_ENTRY_POINTS(make_extension()
+                              .type(TARRAY)
+                              .func(make_func<&tarray_dim>("tarray_dim")
+                                        .returns(INT)
+                                        .param(TARRAY)
+                                        .deterministic()
+                                        .build())
+                              .func(make_func<&tarray_concat>("tarray_concat")
+                                        .returns(TARRAY)
+                                        .param(TARRAY)
+                                        .param(TARRAY)
+                                        .deterministic()
+                                        .build()))

--- a/villagesql/test-extensions/vsql-tarray-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-tarray-test/src/extension.cc
@@ -350,8 +350,10 @@ void tarray_to_string(vsql::CustomArgWith<TarrayParams> in,
         out.warning("tarray_to_string: invalid element type");
         out.set_length(0);
         assert(written == 0);
+        return;
     }
-    if (written < 0 || pos + static_cast<size_t>(written) >= buf.size()) return;
+    if (written <= 0 || pos + static_cast<size_t>(written) >= buf.size())
+      return;
     pos += static_cast<size_t>(written);
   }
   if (pos >= buf.size()) return;
@@ -390,6 +392,8 @@ int tarray_compare(vsql::CustomArgWith<TarrayParams> a,
         break;
       }
       default:
+        // TODO(villagesql): add handling for dealing with invalid element type
+        // in production.
         assert(false);
     }
   }

--- a/villagesql/test-extensions/vsql-tarray-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-tarray-test/src/extension.cc
@@ -16,22 +16,22 @@
 // Test fixture for issue #535: a variable-length typed array (TARRAY).
 //
 // TARRAY is a typed array where the element WIDTH is a 'type' parameter
-// (int16/float/double) and the element COUNT is decided per value
-// (persisted_length = -1), bounded by a 'max_size' parameter that caps how many
-// elements a value may hold:
+// (int16/float/double) and the element COUNT is decided per value,
+// bounded by a 'max_size' parameter that caps how many elements
+// a value may hold:
 //   TARRAY(N)                          -> max_size=N, type defaults to int16
 //   TARRAY('type=float,max_size=10')   -> float elements, at most 10
 // The integer shorthand TARRAY(N) is mapped to max_size by int_to_params. A
 // column must specify the parameters (it is a parameterized type).
 //
 // resolve_params enforces max_size * element_size <= max_persisted_length (the
-// type's static upper bound) and returns persisted_length = -1 (the count is
-// still variable per value, just capped at max_size). from_string rejects a
-// value with more than max_size elements.
+// type's static upper bound, the count is still variable per value, just
+// capped at max_size). from_string rejects a value with more than max_size
+// elements.
 //
-// The backing field is a VARCHAR(max_persisted_length); only the actual encoded
-// bytes are stored per value. Element widths are stored little-endian for
-// portable persistence.
+// The backing field is a VARBINARY(max_persisted_length); only the actual
+// encoded bytes are stored per value. Element widths are stored little-endian
+// for portable persistence.
 
 #include <villagesql/vsql.h>
 
@@ -47,16 +47,23 @@
 // Static upper bound on a stored TARRAY value in bytes. resolve_params requires
 // max_size * element_size to stay within this.
 constexpr int64_t kTarrayMaxLen = 512;
+// max decoded double element (a double in %g). At most 25 characters + 1 for
+// comma.
+constexpr int64_t kMaxDecodedDoubleElem = 25 + 1;
 
 // Element widths in bytes for the supported element types.
 constexpr int64_t kElemInt16 = 2;
 constexpr int64_t kElemFloat = 4;
 constexpr int64_t kElemDouble = 8;
 
+// The element type selected by the 'type' parameter.
+enum class TarrayElemType { kInt16, kFloat, kDouble };
+
 // Parameters: element width (from 'type') and element-count cap (from
 // 'max_size').
 struct TarrayParams {
   int64_t bytes_per_elem = kElemInt16;
+  TarrayElemType elem_type = TarrayElemType::kInt16;
   int64_t max_size = 0;  // 0 = unset; resolve_params rejects a non-positive max
 
   static TarrayParams parse(const std::map<std::string, std::string> &params) {
@@ -65,10 +72,14 @@ struct TarrayParams {
     if (t != params.end()) {
       if (t->second == "float") {
         p.bytes_per_elem = kElemFloat;
+        p.elem_type = TarrayElemType::kFloat;
       } else if (t->second == "double") {
         p.bytes_per_elem = kElemDouble;
+        p.elem_type = TarrayElemType::kDouble;
       } else {
+        assert(t->second == "int16");
         p.bytes_per_elem = kElemInt16;
+        p.elem_type = TarrayElemType::kInt16;
       }
     }
     auto m = params.find("max_size");
@@ -78,9 +89,17 @@ struct TarrayParams {
 
   static void to_strings(const TarrayParams &p,
                          std::map<std::string, std::string> &out) {
-    out["type"] = p.bytes_per_elem == kElemDouble  ? "double"
-                  : p.bytes_per_elem == kElemFloat ? "float"
-                                                   : "int16";
+    switch (p.elem_type) {
+      case TarrayElemType::kInt16:
+        out["type"] = "int16";
+        break;
+      case TarrayElemType::kFloat:
+        out["type"] = "float";
+        break;
+      case TarrayElemType::kDouble:
+        out["type"] = "double";
+        break;
+    }
     out["max_size"] = std::to_string(p.max_size);
   }
 };
@@ -134,29 +153,6 @@ static double load_d64(const unsigned char *buf) {
   return v;
 }
 
-// Map a 'type' parameter string to its element width, or report an error.
-static bool elem_bytes_from_params(const std::map<std::string, std::string> &p,
-                                   int64_t *out_bytes, char *error_msg) {
-  auto it = p.find("type");
-  if (it == p.end()) {
-    *out_bytes = kElemInt16;
-    return false;
-  }
-  if (it->second == "int16") {
-    *out_bytes = kElemInt16;
-  } else if (it->second == "float") {
-    *out_bytes = kElemFloat;
-  } else if (it->second == "double") {
-    *out_bytes = kElemDouble;
-  } else {
-    snprintf(error_msg, VEF_MAX_ERROR_LEN,
-             "TARRAY: type must be int16, float, or double (got '%s')",
-             it->second.c_str());
-    return true;
-  }
-  return false;
-}
-
 // int_to_params: TARRAY(N) maps the integer N to the max_size parameter. The
 // element type defaults to int16 unless given via the string parameter form.
 bool tarray_int_to_params(int64_t value,
@@ -173,14 +169,20 @@ bool tarray_int_to_params(int64_t value,
 }
 
 // resolve_params: validate the element width and the max_size cap, and enforce
-// max_size * element_size <= max_persisted_length. persisted_length stays -1
-// (the count is variable per value, capped at max_size).
+// max_size * element_size <= max_persisted_length (the count is variable per
+// value, capped at max_size).
 bool tarray_resolve_params(const std::map<std::string, std::string> &params,
                            vsql::ResolvedTypeParams *result, char *error_msg) {
-  int64_t bpe = kElemInt16;
-  if (elem_bytes_from_params(params, &bpe, error_msg)) {
+  // Validate "type" parameter if present.
+  auto type_it = params.find("type");
+  if (type_it != params.end() && type_it->second != "float" &&
+      type_it->second != "double" && type_it->second != "int16") {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "TARRAY type must be 'float' or 'double' or 'int16', got '%s'",
+             type_it->second.c_str());
     return true;
   }
+
   auto it = params.find("max_size");
   if (it == params.end()) {
     snprintf(error_msg, VEF_MAX_ERROR_LEN,
@@ -198,6 +200,9 @@ bool tarray_resolve_params(const std::map<std::string, std::string> &params,
     snprintf(error_msg, VEF_MAX_ERROR_LEN, "TARRAY max_size must be positive");
     return true;
   }
+
+  int64_t bpe = TarrayParams::parse(params).bytes_per_elem;
+
   if (max_size * bpe > kTarrayMaxLen) {
     snprintf(error_msg, VEF_MAX_ERROR_LEN,
              "TARRAY max_size %lld * element size %lld exceeds the %lld-byte "
@@ -206,10 +211,11 @@ bool tarray_resolve_params(const std::map<std::string, std::string> &params,
              static_cast<long long>(kTarrayMaxLen));
     return true;
   }
-  result->persisted_length = -1;  // variable count, capped at max_size
+
+  assert(result->persisted_length <= 0);
   // Upper bound on the text form: at most max_size elements, each printing to
-  // at most 26 chars (a double in %g), plus the brackets.
-  result->max_decode_buffer_length = max_size * 26 + 2;
+  // at most kMaxDecodedDoubleElemchars plus the brackets.
+  result->max_decode_buffer_length = max_size * kMaxDecodedDoubleElem + 2;
   return false;
 }
 
@@ -217,7 +223,12 @@ bool tarray_resolve_params(const std::map<std::string, std::string> &params,
 // width, rejecting more than max_size elements.
 void tarray_from_string(vsql::MaybeParams<TarrayParams> &p,
                         std::string_view from, vsql::CustomResult out) {
-  const int64_t bpe = p.is_known() ? p.value().bytes_per_elem : kElemInt16;
+  int64_t bpe = kElemInt16;
+  TarrayElemType elem_type = TarrayElemType::kInt16;
+  if (p.is_known()) {
+    bpe = p.value().bytes_per_elem;
+    elem_type = p.value().elem_type;
+  }
   assert(bpe > 0);
   auto buf = out.buffer();
   // resolve_params guarantees max_size * bpe <= buffer capacity, so max_size is
@@ -245,27 +256,38 @@ void tarray_from_string(vsql::MaybeParams<TarrayParams> &p,
     }
     char *endptr = nullptr;
     unsigned char *slot = buf.data() + count * static_cast<size_t>(bpe);
-    if (bpe == kElemInt16) {
-      long v = strtol(s, &endptr, 10);
-      if (endptr == s) {
-        out.warning("TARRAY: parse error");
-        return;
+    switch (elem_type) {
+      case TarrayElemType::kInt16: {
+        long v = strtol(s, &endptr, 10);
+        if (endptr == s) {
+          out.warning("TARRAY: parse error");
+          return;
+        }
+        store_i16(slot, static_cast<int16_t>(v));
+        break;
       }
-      store_i16(slot, static_cast<int16_t>(v));
-    } else if (bpe == kElemFloat) {
-      float v = strtof(s, &endptr);
-      if (endptr == s) {
-        out.warning("TARRAY: parse error");
-        return;
+      case TarrayElemType::kFloat: {
+        float v = strtof(s, &endptr);
+        if (endptr == s) {
+          out.warning("TARRAY: parse error");
+          return;
+        }
+        store_f32(slot, v);
+        break;
       }
-      store_f32(slot, v);
-    } else {
-      double v = strtod(s, &endptr);
-      if (endptr == s) {
-        out.warning("TARRAY: parse error");
-        return;
+      case TarrayElemType::kDouble: {
+        double v = strtod(s, &endptr);
+        if (endptr == s) {
+          out.warning("TARRAY: parse error");
+          return;
+        }
+        store_d64(slot, v);
+        break;
       }
-      store_d64(slot, v);
+      default:
+        out.warning("TARRAY: invalid element type");
+        assert(false);
+        return;
     }
     count++;
     s = endptr;
@@ -284,6 +306,7 @@ void tarray_from_string(vsql::MaybeParams<TarrayParams> &p,
 void tarray_to_string(vsql::CustomArgWith<TarrayParams> in,
                       vsql::StringResult out) {
   const int64_t bpe = in.params().bytes_per_elem;
+  TarrayElemType elem_type = in.params().elem_type;
   assert(bpe > 0);
   auto data = in.value();
   const size_t count = data.size() / static_cast<size_t>(bpe);
@@ -298,15 +321,21 @@ void tarray_to_string(vsql::CustomArgWith<TarrayParams> in,
     }
     const unsigned char *slot = data.data() + i * static_cast<size_t>(bpe);
     int written = 0;
-    if (bpe == kElemInt16) {
-      written = snprintf(buf.data() + pos, buf.size() - pos, "%d",
-                         static_cast<int>(load_i16(slot)));
-    } else if (bpe == kElemFloat) {
-      written = snprintf(buf.data() + pos, buf.size() - pos, "%g",
-                         static_cast<double>(load_f32(slot)));
-    } else {
-      written =
-          snprintf(buf.data() + pos, buf.size() - pos, "%g", load_d64(slot));
+    switch (elem_type) {
+      case TarrayElemType::kInt16:
+        written = snprintf(buf.data() + pos, buf.size() - pos, "%d",
+                           static_cast<int>(load_i16(slot)));
+        break;
+      case TarrayElemType::kFloat:
+        written = snprintf(buf.data() + pos, buf.size() - pos, "%g",
+                           static_cast<double>(load_f32(slot)));
+        break;
+      case TarrayElemType::kDouble:
+        written =
+            snprintf(buf.data() + pos, buf.size() - pos, "%g", load_d64(slot));
+        break;
+      default:
+        assert(false);
     }
     if (written < 0 || pos + static_cast<size_t>(written) >= buf.size()) return;
     pos += static_cast<size_t>(written);
@@ -329,15 +358,25 @@ int tarray_compare(vsql::CustomArgWith<TarrayParams> a,
   for (size_t i = 0; i < n; i++) {
     const unsigned char *pa = va.data() + i * static_cast<size_t>(bpe);
     const unsigned char *pb = vb.data() + i * static_cast<size_t>(bpe);
-    if (bpe == kElemInt16) {
-      int16_t ea = load_i16(pa), eb = load_i16(pb);
-      if (ea != eb) return ea < eb ? -1 : 1;
-    } else if (bpe == kElemFloat) {
-      float ea = load_f32(pa), eb = load_f32(pb);
-      if (ea != eb) return ea < eb ? -1 : 1;
-    } else {
-      double ea = load_d64(pa), eb = load_d64(pb);
-      if (ea != eb) return ea < eb ? -1 : 1;
+    TarrayElemType elem_type = a.params().elem_type;
+    switch (elem_type) {
+      case TarrayElemType::kInt16: {
+        int16_t ea = load_i16(pa), eb = load_i16(pb);
+        if (ea != eb) return ea < eb ? -1 : 1;
+        break;
+      }
+      case TarrayElemType::kFloat: {
+        float ea = load_f32(pa), eb = load_f32(pb);
+        if (ea != eb) return ea < eb ? -1 : 1;
+        break;
+      }
+      case TarrayElemType::kDouble: {
+        double ea = load_d64(pa), eb = load_d64(pb);
+        if (ea != eb) return ea < eb ? -1 : 1;
+        break;
+      }
+      default:
+        assert(false);
     }
   }
   if (na != nb) return na < nb ? -1 : 1;
@@ -367,8 +406,13 @@ void tarray_concat(vsql::CustomArgWith<TarrayParams> a,
     return;
   }
   const int64_t bpe = a.params().bytes_per_elem;
-  const int64_t max_size = a.params().max_size;
   assert(bpe > 0);
+  assert(bpe ==
+         b.params()
+             .bytes_per_elem);  // guaranteed by type-parameter disambiguation
+  const int64_t max_size = a.params().max_size;
+  assert(max_size ==
+         b.params().max_size);  // guaranteed by type-parameter disambiguation
   auto va = a.value();
   auto vb = b.value();
   const size_t total = va.size() + vb.size();
@@ -387,7 +431,7 @@ static constexpr const char kTarrayTypeName[] = "TARRAY";
 
 constexpr auto TARRAY =
     vsql::make_type<kTarrayTypeName>()
-        .persisted_length(-1)
+        .variable_length_type()
         .max_persisted_length(kTarrayMaxLen)
         .max_decode_buffer_length(kTarrayMaxLen / kElemInt16 * 8 + 2)
         .params<TarrayParams, &TarrayParams::parse, &TarrayParams::to_strings>()

--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -73,7 +73,7 @@ class PT_custom_type : public PT_type {
     }
 
     // Validate length specification against type characteristics
-    if (nullptr != length_spec &&
+    if (nullptr != length_spec && !type_context->is_variable_length() &&
         type_context->descriptor()->persisted_length() != -1) {
       // Fixed-length type with length specification - this is an error
       std::string qname = type_context->qualified_name();
@@ -86,10 +86,8 @@ class PT_custom_type : public PT_type {
 
     // If no length_spec provided, generate it from the TypeContext's storage
     // length. For fixed-length types this comes from the descriptor; for
-    // variable-length types with parameters it was computed by resolve_params
-    // at TypeContext construction time; for variable-length types without
-    // parameters (length decided per value, like a roaring bitmap) it is the
-    // descriptor's max_persisted_length upper bound.
+    // variable-length types it is the descriptor's max_persisted_length
+    // upper bound.
     if (nullptr == length_spec) {
       int64_t len = type_context->field_buffer_length();
       assert(len > 0);
@@ -152,9 +150,12 @@ class PT_custom_type : public PT_type {
       return nullptr;
     }
 
-    // Handle variable-length types (persisted_length == -1)
+    // Handle types that accept a length/parameter spec: variable-length types
+    // (the variable_length flag) and fixed-length parameterized types
+    // (persisted_length == -1).
     if (type_context != nullptr &&
-        type_context->descriptor()->persisted_length() == -1) {
+        (type_context->is_variable_length() ||
+         type_context->descriptor()->persisted_length() == -1)) {
       auto *descriptor = type_context->descriptor();
       if (length != nullptr) {
         // TYPE(N) syntax used - convert N to parameters via callbacks

--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -73,12 +73,11 @@ class PT_custom_type : public PT_type {
     }
 
     // Validate length specification against type characteristics
-    if (nullptr != length_spec && !type_context->is_variable_length() &&
-        type_context->descriptor()->persisted_length() != -1) {
-      // Fixed-length type with length specification - this is an error
+    if (nullptr != length_spec && !type_context->is_parameterized()) {
+      // Non parameterized type with length specification - this is an error
       std::string qname = type_context->qualified_name();
       thd->syntax_error_at(pos,
-                           "Type '%s' is fixed-length and cannot have a "
+                           "Type '%s' is not parameterized and cannot have a "
                            "length specification",
                            qname.c_str());
       return;
@@ -150,12 +149,8 @@ class PT_custom_type : public PT_type {
       return nullptr;
     }
 
-    // Handle types that accept a length/parameter spec: variable-length types
-    // (the variable_length flag) and fixed-length parameterized types
-    // (persisted_length == -1).
-    if (type_context != nullptr &&
-        (type_context->is_variable_length() ||
-         type_context->descriptor()->persisted_length() == -1)) {
+    // Handle types that accept a length/parameter spec
+    if (type_context != nullptr && type_context->is_parameterized()) {
       auto *descriptor = type_context->descriptor();
       if (length != nullptr) {
         // TYPE(N) syntax used - convert N to parameters via callbacks
@@ -204,7 +199,7 @@ class PT_custom_type : public PT_type {
         // length is now consumed - pass nullptr to constructor
         length = nullptr;
       } else {
-        // No length provided for variable-length type
+        // No length provided for a parameterized type
         if (descriptor->int_to_params_fn().has_value()) {
           std::string qname = type_context->qualified_name();
           thd->syntax_error_at(pos, "Type '%s' requires a length specification",

--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -84,16 +84,17 @@ class PT_custom_type : public PT_type {
       return;
     }
 
-    // If no length_spec provided, generate it from the TypeContext's
-    // persisted_length. For fixed-length types this comes from the descriptor.
-    // For variable-length types with parameters, this was computed by
-    // resolve_params at TypeContext construction time.
+    // If no length_spec provided, generate it from the TypeContext's storage
+    // length. For fixed-length types this comes from the descriptor; for
+    // variable-length types with parameters it was computed by resolve_params
+    // at TypeContext construction time; for variable-length types without
+    // parameters (length decided per value, like a roaring bitmap) it is the
+    // descriptor's max_persisted_length upper bound.
     if (nullptr == length_spec) {
-      int64_t len = type_context->persisted_length();
-      if (len > 0) {
-        snprintf(length_buffer, sizeof(length_buffer), "%" PRId64, len);
-        length_spec = length_buffer;
-      }
+      int64_t len = type_context->field_buffer_length();
+      assert(len > 0);
+      snprintf(length_buffer, sizeof(length_buffer), "%" PRId64, len);
+      length_spec = length_buffer;
     }
   }
 

--- a/villagesql/types/type_encoder.cc
+++ b/villagesql/types/type_encoder.cc
@@ -30,7 +30,10 @@ namespace villagesql {
 
 TypeEncoder::TypeEncoder(const TypeContext *tc, MEM_ROOT &mem_root)
     : mem_root_(&mem_root),
-      buffer_size_(static_cast<size_t>(tc->persisted_length())) {
+      // Fixed-length types encode into persisted_length bytes; variable-length
+      // types (persisted_length == -1) encode into a buffer sized to the type's
+      // max_persisted_length upper bound and set the actual length per value.
+      buffer_size_(static_cast<size_t>(tc->field_buffer_length())) {
   assert(tc != nullptr);
   assert(buffer_size_ > 0);
 

--- a/villagesql/types/type_encoder.cc
+++ b/villagesql/types/type_encoder.cc
@@ -31,8 +31,8 @@ namespace villagesql {
 TypeEncoder::TypeEncoder(const TypeContext *tc, MEM_ROOT &mem_root)
     : mem_root_(&mem_root),
       // Fixed-length types encode into persisted_length bytes; variable-length
-      // types (persisted_length == -1) encode into a buffer sized to the type's
-      // max_persisted_length upper bound and set the actual length per value.
+      // types encode into a buffer sized to the type's max_persisted_length
+      // upper bound and set the actual length per value.
       buffer_size_(static_cast<size_t>(tc->field_buffer_length())) {
   assert(tc != nullptr);
   assert(buffer_size_ > 0);

--- a/villagesql/types/type_encoder.h
+++ b/villagesql/types/type_encoder.h
@@ -72,7 +72,7 @@ class TypeEncoder {
  private:
   MEM_ROOT *mem_root_{nullptr};  // owning mem_root, used for overflow growth
   char *buffer_{nullptr};        // pre-allocated from mem_root_
-  size_t buffer_size_{0};        // = tc->persisted_length()
+  size_t buffer_size_{0};        // = tc->field_buffer_length()
   String result_;                // reused String wrapper pointing into buffer_
 
   // Overflow path: reused when VDF output exceeds buffer_size_ (rare).

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -81,16 +81,16 @@ static const char *ER_INCOMPARABLE_TYPES =
 static const char *ER_INCOMPATIBLE_TYPES =
     "Cannot compare values of incompatible types '%s' and '%s'";
 
-// Verify that the Field's storage length matches the TypeContext's
-// persisted_length.
+// Verify that the backing Field's length matches the TypeContext's
+// field_buffer_length.
 static bool CheckFieldLengthMatchesType(const Field *field,
                                         const TypeContext *tc) {
   if (should_assert_if_false(static_cast<int64_t>(field->field_length) ==
-                             tc->persisted_length())) {
+                             tc->field_buffer_length())) {
     LogVSQL(ERROR_LEVEL,
-            "field_length (%u) != persisted_length (%" PRId64
+            "field_length (%u) != field_buffer_length (%" PRId64
             ") for column %s (type %s)",
-            field->field_length, tc->persisted_length(), field->field_name,
+            field->field_length, tc->field_buffer_length(), field->field_name,
             tc->qualified_name().c_str());
     villagesql_error(
         "Internal error: field length mismatch for column %s (type %s); "

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -243,6 +243,7 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
     m_vdf_args.user_data = prerun_result.user_data;
 
     // Handle buffer size request
+    // TODO(villagesql): refactor to MaybeResizeBuffer()
     if (prerun_result.result_buffer_size > m_result_buffer_size) {
       m_result_buffer_size = prerun_result.result_buffer_size;
       m_result_buffer =
@@ -273,6 +274,7 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
     if (m_return_type_context != nullptr) {
       const int64_t buffer_len = m_return_type_context->field_buffer_length();
       assert(buffer_len > 0);
+      // TODO(villagesql): refactor to MaybeResizeBuffer()
       if (static_cast<size_t>(buffer_len) > m_result_buffer_size) {
         m_result_buffer_size = static_cast<size_t>(buffer_len);
         m_result_buffer =

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -264,12 +264,12 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
     // output that fits the resolved return type's field. For a
     // fixed-length or parameter-resolved type that is persisted_length, unknown
     // until SetVDFReturnTypeContext above resolves it from return_params; for a
-    // variable-length type without parameters (persisted_length == -1) it is
-    // the type's max_persisted_length upper bound. field_buffer_length()
-    // returns the right one. Grow the buffer to fit so that, for example,
-    // SVECTOR::from_string('[…1024 floats…]') has room to encode a wide vector.
-    // Mirrors the input-side growth done above for STRING-returning VDFs.
-    // prerun may still have grown the buffer further; keep the max.
+    // variable-length type it is the type's max_persisted_length upper bound.
+    // field_buffer_length() returns the right one. Grow the buffer to fit so
+    // that, for example, SVECTOR::from_string('[…1024 floats…]') has room to
+    // encode a wide vector. Mirrors the input-side growth done above for
+    // STRING-returning VDFs. prerun may still have grown the buffer further;
+    // keep the max.
     if (m_return_type_context != nullptr) {
       const int64_t buffer_len = m_return_type_context->field_buffer_length();
       assert(buffer_len > 0);

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -261,17 +261,20 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
     m_return_type_context = func->get_type_context();
 
     // CUSTOM-returning VDFs (e.g. the type's from_string / encode VDF) emit
-    // output sized to the resolved return type's persisted_length, which is
-    // unknown until SetVDFReturnTypeContext above resolves it from
-    // return_params. Grow the buffer to fit so that, for example,
-    // SVECTOR::from_string('[…1024 floats…]') has room to encode a wide
-    // vector. Mirrors the input-side growth done above for STRING-returning
-    // VDFs. prerun may still have grown the buffer further; keep the max.
+    // output that fits the resolved return type's field. For a
+    // fixed-length or parameter-resolved type that is persisted_length, unknown
+    // until SetVDFReturnTypeContext above resolves it from return_params; for a
+    // variable-length type without parameters (persisted_length == -1) it is
+    // the type's max_persisted_length upper bound. field_buffer_length()
+    // returns the right one. Grow the buffer to fit so that, for example,
+    // SVECTOR::from_string('[…1024 floats…]') has room to encode a wide vector.
+    // Mirrors the input-side growth done above for STRING-returning VDFs.
+    // prerun may still have grown the buffer further; keep the max.
     if (m_return_type_context != nullptr) {
-      const int64_t persisted = m_return_type_context->persisted_length();
-      if (persisted > 0 &&
-          static_cast<size_t>(persisted) > m_result_buffer_size) {
-        m_result_buffer_size = static_cast<size_t>(persisted);
+      const int64_t buffer_len = m_return_type_context->field_buffer_length();
+      assert(buffer_len > 0);
+      if (static_cast<size_t>(buffer_len) > m_result_buffer_size) {
+        m_result_buffer_size = static_cast<size_t>(buffer_len);
         m_result_buffer =
             pointer_cast<char *>((*THR_MALLOC)->Alloc(m_result_buffer_size));
         if (!m_result_buffer) return true;

--- a/villagesql/veb/veb_register_type_v3.cc
+++ b/villagesql/veb/veb_register_type_v3.cc
@@ -235,11 +235,15 @@ std::optional<TypeDescriptor> build_type_descriptor_v3(
   }
 
   if (td->persisted_length == -1) {
-    // Variable-length type: max_persisted_length bounds the field and
-    // is always required. resolve_params is required only for parameterized
-    // variants (those that also expose int_to_params, validated below); a bare
-    // variable-length type whose length is decided per value needs only
-    // max_persisted_length.
+    // Variable-length / parameterized type: resolve_params_vdf_name and
+    // max_persisted_length are both required.
+    if (td->resolve_params_vdf_name == nullptr) {
+      LogVSQL(ERROR_LEVEL,
+              "Type '%s' in extension '%s' has persisted_length=-1 "
+              "(variable-length) but does not set resolve_params_vdf_name",
+              type_name.c_str(), extension_name.c_str());
+      return std::nullopt;
+    }
     if (td->max_persisted_length <= 0) {
       LogVSQL(ERROR_LEVEL,
               "Type '%s' in extension '%s' has persisted_length=-1 "

--- a/villagesql/veb/veb_register_type_v3.cc
+++ b/villagesql/veb/veb_register_type_v3.cc
@@ -235,15 +235,11 @@ std::optional<TypeDescriptor> build_type_descriptor_v3(
   }
 
   if (td->persisted_length == -1) {
-    // Variable-length / parameterized type: resolve_params_vdf_name and
-    // max_persisted_length are both required.
-    if (td->resolve_params_vdf_name == nullptr) {
-      LogVSQL(ERROR_LEVEL,
-              "Type '%s' in extension '%s' has persisted_length=-1 "
-              "(variable-length) but does not set resolve_params_vdf_name",
-              type_name.c_str(), extension_name.c_str());
-      return std::nullopt;
-    }
+    // Variable-length type: max_persisted_length bounds the field and
+    // is always required. resolve_params is required only for parameterized
+    // variants (those that also expose int_to_params, validated below); a bare
+    // variable-length type whose length is decided per value needs only
+    // max_persisted_length.
     if (td->max_persisted_length <= 0) {
       LogVSQL(ERROR_LEVEL,
               "Type '%s' in extension '%s' has persisted_length=-1 "


### PR DESCRIPTION
A custom type marks a column as variadic-size by declaring persisted_length = -1: the stored length is decided per value rather than fixed by the type. The type also declares max_persisted_length, an upper bound on a single value.

The backing field is a VARBINARY sized to max_persisted_length, so the in-memory record image reserves that many bytes for the column. A VARBINARY, however, stores only the bytes a value actually uses -- a 1- or 2-byte length prefix plus the written bytes -- so the persisted row keeps only the bytes each value needs, never the full max_persisted_length. Every value's encode reports its true length via out.set_length(), which becomes the VARBINARY length; values of different sizes coexist in one column.

Implementation:
- TypeContext::field_buffer_length() centralizes the rule: persisted_length when it is >= 0 (fixed-length), otherwise max_persisted_length (variadic).
- Registration accepts a persisted_length = -1 type as long as max_persisted_length > 0; int_to_params/resolve_params are required only for parameterized variants.

Test fixtures (mysql-test/suite/villagesql/extension):
- BITFIELD (vsql_bitfield_test): a variadic type declared with NO max size and no other specification -- CREATE TABLE t (b BITFIELD). Each value is a bit field of its own length, packed 8 bits per byte; the byte length is decided per value.
- TARRAY (vsql_tarray_test): a variadic type WITH a max size -- TARRAY(N) or TARRAY('max_size=N,type=...'). int_to_params maps the integer to max_size and resolve_params enforces max_size * element_size <= max_persisted_length, while persisted_length stays -1 (the count is still per value, just capped at max_size).

Fixes #535
