### PR TITLE
Revise Semver so codebase add is easier

### DIFF
--- a/unittest/gunit/villagesql/semver-t.cc
+++ b/unittest/gunit/villagesql/semver-t.cc
@@ -25,6 +25,18 @@ using namespace villagesql;
 
 class SemverTest : public ::testing::Test {};
 
+// Local helper to construct a Semver from components and return it.  Tests do a
+// lot of this, otherwise its uses are mostly one-offs. The result is invalid
+// (is_valid() == false) if any component fails validation.
+Semver from_components(unsigned long major, unsigned long minor,
+                       unsigned long patch,
+                       const std::vector<std::string> &prerelease = {},
+                       const std::vector<std::string> &build_metadata = {}) {
+  Semver v;
+  v.from_components(major, minor, patch, prerelease, build_metadata);
+  return v;
+}
+
 // Test basic parsing of valid semver strings
 TEST_F(SemverTest, ParseValidVersions) {
   Semver v1;
@@ -462,7 +474,7 @@ TEST_F(SemverTest, ReuseObject) {
 // Test from_components factory method
 TEST_F(SemverTest, FromComponents) {
   // Basic version without pre-release or build metadata
-  Semver v1 = Semver::from_components(1, 2, 3);
+  Semver v1 = from_components(1, 2, 3);
   EXPECT_TRUE(v1.is_valid());
   EXPECT_EQ(1u, v1.major());
   EXPECT_EQ(2u, v1.minor());
@@ -472,14 +484,14 @@ TEST_F(SemverTest, FromComponents) {
   EXPECT_EQ("1.2.3", v1.to_string());
 
   // Version with pre-release
-  Semver v2 = Semver::from_components(1, 0, 0, {"alpha"});
+  Semver v2 = from_components(1, 0, 0, {"alpha"});
   EXPECT_TRUE(v2.is_valid());
   EXPECT_EQ(1u, v2.prerelease().size());
   EXPECT_EQ("alpha", v2.prerelease()[0]);
   EXPECT_EQ("1.0.0-alpha", v2.to_string());
 
   // Version with pre-release and build metadata
-  Semver v3 = Semver::from_components(2, 1, 0, {"beta", "1"}, {"build", "123"});
+  Semver v3 = from_components(2, 1, 0, {"beta", "1"}, {"build", "123"});
   EXPECT_TRUE(v3.is_valid());
   EXPECT_TRUE(v3.has_prerelease());
   EXPECT_TRUE(v3.has_build_metadata());
@@ -492,14 +504,14 @@ TEST_F(SemverTest, FromComponents) {
   EXPECT_EQ("2.1.0-beta.1+build.123", v3.to_string());
 
   // Version with only build metadata
-  Semver v4 = Semver::from_components(3, 0, 0, {}, {"sha", "abc123"});
+  Semver v4 = from_components(3, 0, 0, {}, {"sha", "abc123"});
   EXPECT_TRUE(v4.is_valid());
   EXPECT_FALSE(v4.has_prerelease());
   EXPECT_TRUE(v4.has_build_metadata());
   EXPECT_EQ("3.0.0+sha.abc123", v4.to_string());
 
   // Zero version
-  Semver v5 = Semver::from_components(0, 0, 0);
+  Semver v5 = from_components(0, 0, 0);
   EXPECT_TRUE(v5.is_valid());
   EXPECT_EQ("0.0.0", v5.to_string());
 }
@@ -507,37 +519,37 @@ TEST_F(SemverTest, FromComponents) {
 // Test from_components with invalid identifiers
 TEST_F(SemverTest, FromComponentsInvalid) {
   // Invalid character in pre-release
-  Semver v1 = Semver::from_components(1, 0, 0, {"alpha@beta"});
+  Semver v1 = from_components(1, 0, 0, {"alpha@beta"});
   EXPECT_FALSE(v1.is_valid());
 
   // Leading zero in numeric pre-release identifier
-  Semver v2 = Semver::from_components(1, 0, 0, {"01"});
+  Semver v2 = from_components(1, 0, 0, {"01"});
   EXPECT_FALSE(v2.is_valid());
 
   // Empty identifier in pre-release
-  Semver v3 = Semver::from_components(1, 0, 0, {""});
+  Semver v3 = from_components(1, 0, 0, {""});
   EXPECT_FALSE(v3.is_valid());
 
   // Invalid character in build metadata
-  Semver v4 = Semver::from_components(1, 0, 0, {}, {"build$123"});
+  Semver v4 = from_components(1, 0, 0, {}, {"build$123"});
   EXPECT_FALSE(v4.is_valid());
 
   // Empty identifier in build metadata
-  Semver v5 = Semver::from_components(1, 0, 0, {}, {""});
+  Semver v5 = from_components(1, 0, 0, {}, {""});
   EXPECT_FALSE(v5.is_valid());
 
   // Valid numeric identifier with leading zero is OK if it's actually "0"
-  Semver v6 = Semver::from_components(1, 0, 0, {"0", "alpha"});
+  Semver v6 = from_components(1, 0, 0, {"0", "alpha"});
   EXPECT_TRUE(v6.is_valid());
   EXPECT_EQ("1.0.0-0.alpha", v6.to_string());
 }
 
 // Test comparison with versions created from components
 TEST_F(SemverTest, FromComponentsComparison) {
-  Semver v1 = Semver::from_components(1, 2, 3);
-  Semver v2 = Semver::from_components(1, 2, 3);
-  Semver v3 = Semver::from_components(1, 2, 4);
-  Semver v4 = Semver::from_components(1, 2, 3, {"alpha"});
+  Semver v1 = from_components(1, 2, 3);
+  Semver v2 = from_components(1, 2, 3);
+  Semver v3 = from_components(1, 2, 4);
+  Semver v4 = from_components(1, 2, 3, {"alpha"});
 
   EXPECT_TRUE(v1 == v2);
   EXPECT_TRUE(v1 < v3);
@@ -547,8 +559,7 @@ TEST_F(SemverTest, FromComponentsComparison) {
 
 // Test that from_components and parse produce equivalent results
 TEST_F(SemverTest, FromComponentsEquivalentToParse) {
-  Semver v1 =
-      Semver::from_components(1, 2, 3, {"alpha", "1"}, {"build", "123"});
+  Semver v1 = from_components(1, 2, 3, {"alpha", "1"}, {"build", "123"});
   Semver v2;
   v2.parse("1.2.3-alpha.1+build.123");
 

--- a/unittest/gunit/villagesql/semver-t.cc
+++ b/unittest/gunit/villagesql/semver-t.cc
@@ -200,6 +200,19 @@ TEST_F(SemverTest, ParseInvalidVersions) {
   EXPECT_FALSE(v.parse("1.2.03", &error));
   EXPECT_FALSE(error.empty());
 
+  // Version numbers exceeding their per-position bounds
+  error.clear();
+  EXPECT_FALSE(v.parse("11.0.0", &error));
+  EXPECT_FALSE(error.empty());
+
+  error.clear();
+  EXPECT_FALSE(v.parse("0.101.0", &error));
+  EXPECT_FALSE(error.empty());
+
+  error.clear();
+  EXPECT_FALSE(v.parse("0.0.1001", &error));
+  EXPECT_FALSE(error.empty());
+
   // Leading zeros in numeric pre-release identifiers
   error.clear();
   EXPECT_FALSE(v.parse("1.0.0-01", &error));
@@ -405,11 +418,11 @@ TEST_F(SemverTest, NumericVsAlphanumericPrerelease) {
 TEST_F(SemverTest, EdgeCases) {
   Semver v;
 
-  // Large version numbers
-  EXPECT_TRUE(v.parse("999999.999999.999999"));
-  EXPECT_EQ(999999u, v.major());
-  EXPECT_EQ(999999u, v.minor());
-  EXPECT_EQ(999999u, v.patch());
+  // Maximum allowed version numbers (bounds are inclusive)
+  EXPECT_TRUE(v.parse("10.100.1000"));
+  EXPECT_EQ(10u, v.major());
+  EXPECT_EQ(100u, v.minor());
+  EXPECT_EQ(1000u, v.patch());
 
   // Single character identifiers
   EXPECT_TRUE(v.parse("1.0.0-a"));

--- a/unittest/gunit/villagesql/semver-t.cc
+++ b/unittest/gunit/villagesql/semver-t.cc
@@ -139,21 +139,6 @@ TEST_F(SemverTest, ToString) {
   EXPECT_EQ("1.0.0-beta+exp.sha.5114f85", v5.to_string());
 }
 
-// Test from_string factory method
-TEST_F(SemverTest, FromString) {
-  std::string error;
-  Semver v1 = Semver::from_string("1.2.3", &error);
-  EXPECT_TRUE(v1.is_valid());
-  EXPECT_TRUE(error.empty());
-  EXPECT_EQ(1u, v1.major());
-  EXPECT_EQ(2u, v1.minor());
-  EXPECT_EQ(3u, v1.patch());
-
-  Semver v2 = Semver::from_string("invalid", &error);
-  EXPECT_FALSE(v2.is_valid());
-  EXPECT_FALSE(error.empty());
-}
-
 // Test invalid version strings
 TEST_F(SemverTest, ParseInvalidVersions) {
   std::string error;
@@ -560,11 +545,12 @@ TEST_F(SemverTest, FromComponentsComparison) {
   EXPECT_FALSE(v1 < v2);
 }
 
-// Test that from_components and from_string produce equivalent results
-TEST_F(SemverTest, FromComponentsEquivalentToFromString) {
+// Test that from_components and parse produce equivalent results
+TEST_F(SemverTest, FromComponentsEquivalentToParse) {
   Semver v1 =
       Semver::from_components(1, 2, 3, {"alpha", "1"}, {"build", "123"});
-  Semver v2 = Semver::from_string("1.2.3-alpha.1+build.123");
+  Semver v2;
+  v2.parse("1.2.3-alpha.1+build.123");
 
   EXPECT_TRUE(v1.is_valid());
   EXPECT_TRUE(v2.is_valid());

--- a/villagesql/common/semver.cc
+++ b/villagesql/common/semver.cc
@@ -228,8 +228,8 @@ Semver Semver::from_components(unsigned long major, unsigned long minor,
   ver.valid_ = false;
 
   if (!check_version_bound(major, kMajorMax, "MAJOR", nullptr)) return ver;
-  if (!check_version_bound(major, kMinorMax, "MINOR", nullptr)) return ver;
-  if (!check_version_bound(major, kPatchMax, "PATCH", nullptr)) return ver;
+  if (!check_version_bound(minor, kMinorMax, "MINOR", nullptr)) return ver;
+  if (!check_version_bound(patch, kPatchMax, "PATCH", nullptr)) return ver;
 
   // Validate identifiers if provided
   for (const auto &id : prerelease) {

--- a/villagesql/common/semver.cc
+++ b/villagesql/common/semver.cc
@@ -22,28 +22,109 @@
 
 namespace villagesql {
 
-Semver::Semver() : major_(0), minor_(0), patch_(0), valid_(false) {}
+namespace {
 
-bool Semver::is_numeric(std::string_view str) {
+// Check if a string contains only digits.
+bool is_numeric(std::string_view str) {
   if (str.empty()) return false;
   return std::all_of(str.begin(), str.end(),
                      [](unsigned char c) { return std::isdigit(c); });
 }
 
-bool Semver::has_leading_zero(std::string_view str) {
+// Check if a numeric identifier has a disallowed leading zero, i.e. it is
+// more than one digit long and starts with '0'. Per the semver spec, numeric
+// identifiers must not include leading zeros.
+bool has_leading_zero(std::string_view str) {
   return str.length() > 1 && str[0] == '0';
 }
 
-bool Semver::is_valid_identifier(std::string_view id) {
+// Check if a string is a valid identifier (alphanumeric + hyphen).
+bool is_valid_identifier(std::string_view id) {
   if (id.empty()) return false;
   return std::all_of(id.begin(), id.end(), [](unsigned char c) {
     return std::isalnum(c) || c == '-';
   });
 }
 
-bool Semver::parse_core_component(std::string_view version_str,
-                                  unsigned long version_max, const char *name,
-                                  unsigned long *out, std::string *error) {
+// Check that a parsed core version value is within its allowed bound.
+//
+// @param version_val The parsed value to check
+// @param version_max Inclusive maximum value allowed for this position
+// @param name Position name used in the error message (e.g. "MAJOR")
+// @param[out] error Optional error message if the value exceeds the bound
+// @return true if version_val <= version_max, false otherwise
+bool check_version_bound(unsigned long version_val, unsigned long version_max,
+                         const char *name, std::string *error) {
+  // Easy case if things are valid
+  if (version_val <= version_max) return true;
+
+  // It must be too big
+  if (error)
+    *error = std::string(name) + " version value(" +
+             std::to_string(version_val) + ") must not exceed " +
+             std::to_string(version_max);
+  return false;
+}
+
+// Maximum number of source characters reproduced by safe_for_output().
+constexpr size_t kMaxOutputChars = 10;
+
+// Sanitize an arbitrary string for safe inclusion in output such as error
+// messages. At most kMaxOutputChars source characters are reproduced; any
+// unprintable character is rendered as a readable escape sequence (e.g.
+// "\n", "\x1b"); if the input is longer than kMaxOutputChars an ellipsis is
+// appended.
+//
+// @param str The string to sanitize
+// @return A printable, length-limited representation of str
+std::string safe_for_output(std::string_view str) {
+  std::string result;
+  size_t limit = std::min(str.size(), kMaxOutputChars);
+  for (size_t i = 0; i < limit; ++i) {
+    unsigned char c = static_cast<unsigned char>(str[i]);
+    switch (c) {
+      case '\t':
+        result += "\\t";
+        break;
+      case '\n':
+        result += "\\n";
+        break;
+      case '\r':
+        result += "\\r";
+        break;
+      case '\\':  // Keep out safe with backslash.
+        result += "\\\\";
+        break;
+      default:
+        if (std::isprint(c)) {
+          result += static_cast<char>(c);
+        } else {
+          char buf[5];
+          snprintf(buf, sizeof(buf), "\\x%02X", c);
+          result += buf;
+        }
+    }
+  }
+  // Truncated strings get an unicode ellipsis appended at the end
+  if (str.size() > kMaxOutputChars) result += "\u2026";
+  return result;
+}
+
+// Parse and validate a single core version component.
+//
+// Validates that the component is numeric with no leading zeros, converts it,
+// and range-checks the result, rejecting values that overflow or exceed the
+// (inclusive) maximum allowed for this position.
+//
+// @param version_str Component string
+// @param version_max Inclusive maximum value allowed for this position
+// @param name Position name used in error messages (e.g. "MAJOR")
+// @param[out] out Parsed value
+// @param[out] error Optional error message if validation fails
+// @return true on success, false otherwise
+bool parse_core_component(std::string_view version_str,
+                          unsigned long version_max, const char *name,
+                          unsigned long *out, std::string *error) {
   if (!is_numeric(version_str)) {
     if (error)
       *error = std::string(name) + " must be numeric, not " +
@@ -75,23 +156,17 @@ bool Semver::parse_core_component(std::string_view version_str,
   return true;
 }
 
-bool Semver::check_version_bound(unsigned long version_val,
-                                 unsigned long version_max, const char *name,
-                                 std::string *error) {
-  // Easy case if things are valid
-  if (version_val <= version_max) return true;
-
-  // It must be too big
-  if (error)
-    *error = std::string(name) + " version value(" +
-             std::to_string(version_val) + ") must not exceed " +
-             std::to_string(version_max);
-  return false;
-}
-
-bool Semver::parse_core(std::string_view core, unsigned long *major,
-                        unsigned long *minor, unsigned long *patch,
-                        std::string *error) {
+// Parse and validate the core "MAJOR.MINOR.PATCH" segment.
+//
+// @param core The core segment, with no pre-release or build metadata
+// @param[out] major Parsed MAJOR number
+// @param[out] minor Parsed MINOR number
+// @param[out] patch Parsed PATCH number
+// @param[out] error Optional error message if validation fails
+// @return true on success, false otherwise
+bool parse_core(std::string_view core, unsigned long *major,
+                unsigned long *minor, unsigned long *patch,
+                std::string *error) {
   if (std::count(core.begin(), core.end(), '.') != 2) {
     if (error)
       *error = "Invalid core version format, expected MAJOR.MINOR.PATCH";
@@ -106,14 +181,22 @@ bool Semver::parse_core(std::string_view core, unsigned long *major,
   std::string_view patch_str = core.substr(patch_pos + 1);
 
   // Parse each position into its own bounds.
-  return parse_core_component(major_str, kMajorMax, "MAJOR", major, error) &&
-         parse_core_component(minor_str, kMinorMax, "MINOR", minor, error) &&
-         parse_core_component(patch_str, kPatchMax, "PATCH", patch, error);
+  return parse_core_component(major_str, Semver::kMajorMax, "MAJOR", major,
+                              error) &&
+         parse_core_component(minor_str, Semver::kMinorMax, "MINOR", minor,
+                              error) &&
+         parse_core_component(patch_str, Semver::kPatchMax, "PATCH", patch,
+                              error);
 }
 
-bool Semver::parse_prerelease(std::string_view segment,
-                              std::vector<std::string> *out,
-                              std::string *error) {
+// Parse and validate the dot-separated pre-release segment.
+//
+// @param segment Pre-release identifiers, without the leading '-'
+// @param[out] out Parsed pre-release identifiers
+// @param[out] error Optional error message if validation fails
+// @return true on success, false otherwise
+bool parse_prerelease(std::string_view segment, std::vector<std::string> *out,
+                      std::string *error) {
   // Split by dots
   while (true) {
     size_t dot = segment.find('.');
@@ -137,9 +220,14 @@ bool Semver::parse_prerelease(std::string_view segment,
   return true;
 }
 
-bool Semver::parse_build_metadata(std::string_view segment,
-                                  std::vector<std::string> *out,
-                                  std::string *error) {
+// Parse and validate the dot-separated build metadata segment.
+//
+// @param segment Build metadata identifiers, without the leading '+'
+// @param[out] out Parsed build metadata identifiers
+// @param[out] error Optional error message if validation fails
+// @return true on success, false otherwise
+bool parse_build_metadata(std::string_view segment,
+                          std::vector<std::string> *out, std::string *error) {
   // Split by dots
   while (true) {
     size_t dot = segment.find('.');
@@ -156,6 +244,53 @@ bool Semver::parse_build_metadata(std::string_view segment,
   }
   return true;
 }
+
+// Compare two pre-release identifier lists according to semver rules.
+// @return -1 if lhs < rhs, 0 if equal, 1 if lhs > rhs
+int compare_prerelease(const std::vector<std::string> &lhs,
+                       const std::vector<std::string> &rhs) {
+  // No pre-release > has pre-release
+  if (lhs.empty() && !rhs.empty()) return 1;
+  if (!lhs.empty() && rhs.empty()) return -1;
+  if (lhs.empty() && rhs.empty()) return 0;
+
+  // Compare identifier by identifier
+  size_t min_size = std::min(lhs.size(), rhs.size());
+  for (size_t i = 0; i < min_size; ++i) {
+    const std::string &l = lhs[i];
+    const std::string &r = rhs[i];
+
+    bool l_numeric = is_numeric(l);
+    bool r_numeric = is_numeric(r);
+
+    if (l_numeric && r_numeric) {
+      // Both numeric - compare numerically
+      unsigned long l_val = std::stoul(l);
+      unsigned long r_val = std::stoul(r);
+      if (l_val < r_val) return -1;
+      if (l_val > r_val) return 1;
+    } else if (l_numeric && !r_numeric) {
+      // Numeric < alphanumeric
+      return -1;
+    } else if (!l_numeric && r_numeric) {
+      // Alphanumeric > numeric
+      return 1;
+    } else {
+      // Both alphanumeric - compare lexically
+      if (l < r) return -1;
+      if (l > r) return 1;
+    }
+  }
+
+  // All compared identifiers are equal, check length
+  if (lhs.size() < rhs.size()) return -1;
+  if (lhs.size() > rhs.size()) return 1;
+  return 0;
+}
+
+}  // namespace
+
+Semver::Semver() : major_(0), minor_(0), patch_(0), valid_(false) {}
 
 bool Semver::parse(std::string_view s, std::string *error) {
   // Reset state
@@ -211,12 +346,6 @@ bool Semver::parse(std::string_view s, std::string *error) {
   build_metadata_.swap(build_metadata_tmp);
   valid_ = true;
   return true;
-}
-
-Semver Semver::from_string(std::string_view version_str, std::string *error) {
-  Semver ver;
-  ver.parse(version_str, error);
-  return ver;
 }
 
 Semver Semver::from_components(unsigned long major, unsigned long minor,
@@ -286,79 +415,6 @@ std::string Semver::to_string() const {
   return r;
 }
 
-std::string Semver::safe_for_output(std::string_view str) {
-  std::string result;
-  size_t limit = std::min(str.size(), kMaxOutputChars);
-  for (size_t i = 0; i < limit; ++i) {
-    unsigned char c = static_cast<unsigned char>(str[i]);
-    switch (c) {
-      case '\t':
-        result += "\\t";
-        break;
-      case '\n':
-        result += "\\n";
-        break;
-      case '\r':
-        result += "\\r";
-        break;
-      case '\\':  // Keep out safe with backslash.
-        result += "\\\\";
-        break;
-      default:
-        if (std::isprint(c)) {
-          result += static_cast<char>(c);
-        } else {
-          char buf[5];
-          snprintf(buf, sizeof(buf), "\\x%02X", c);
-          result += buf;
-        }
-    }
-  }
-  // Truncated strings get an unicode ellipsis appended at the end
-  if (str.size() > kMaxOutputChars) result += "\u2026";
-  return result;
-}
-
-int Semver::compare_prerelease(const Semver &other) const {
-  // No pre-release > has pre-release
-  if (prerelease_.empty() && !other.prerelease_.empty()) return 1;
-  if (!prerelease_.empty() && other.prerelease_.empty()) return -1;
-  if (prerelease_.empty() && other.prerelease_.empty()) return 0;
-
-  // Compare identifier by identifier
-  size_t min_size = std::min(prerelease_.size(), other.prerelease_.size());
-  for (size_t i = 0; i < min_size; ++i) {
-    const std::string &l = prerelease_[i];
-    const std::string &r = other.prerelease_[i];
-
-    bool l_numeric = is_numeric(l);
-    bool r_numeric = is_numeric(r);
-
-    if (l_numeric && r_numeric) {
-      // Both numeric - compare numerically
-      unsigned long l_val = std::stoul(l);
-      unsigned long r_val = std::stoul(r);
-      if (l_val < r_val) return -1;
-      if (l_val > r_val) return 1;
-    } else if (l_numeric && !r_numeric) {
-      // Numeric < alphanumeric
-      return -1;
-    } else if (!l_numeric && r_numeric) {
-      // Alphanumeric > numeric
-      return 1;
-    } else {
-      // Both alphanumeric - compare lexically
-      if (l < r) return -1;
-      if (l > r) return 1;
-    }
-  }
-
-  // All compared identifiers are equal, check length
-  if (prerelease_.size() < other.prerelease_.size()) return -1;
-  if (prerelease_.size() > other.prerelease_.size()) return 1;
-  return 0;
-}
-
 bool Semver::operator==(const Semver &other) const {
   if (!valid_ || !other.valid_) return false;
   return major_ == other.major_ && minor_ == other.minor_ &&
@@ -377,7 +433,7 @@ bool Semver::operator<(const Semver &other) const {
   if (patch_ != other.patch_) return patch_ < other.patch_;
 
   // Core versions are equal, compare pre-release
-  return compare_prerelease(other) < 0;
+  return compare_prerelease(prerelease_, other.prerelease_) < 0;
 }
 
 bool Semver::operator<=(const Semver &other) const {

--- a/villagesql/common/semver.cc
+++ b/villagesql/common/semver.cc
@@ -18,7 +18,7 @@
 
 #include <algorithm>
 #include <cctype>
-#include <climits>
+#include <cerrno>
 #include <cstdlib>
 
 namespace villagesql {
@@ -31,11 +31,132 @@ bool Semver::is_numeric(std::string_view str) {
                      [](unsigned char c) { return std::isdigit(c); });
 }
 
+bool Semver::has_leading_zero(std::string_view str) {
+  return str.length() > 1 && str[0] == '0';
+}
+
 bool Semver::is_valid_identifier(std::string_view id) {
   if (id.empty()) return false;
   return std::all_of(id.begin(), id.end(), [](unsigned char c) {
     return std::isalnum(c) || c == '-';
   });
+}
+
+bool Semver::parse_core_component(const std::string &version_str, unsigned long version_max,
+                                  const char *name, unsigned long *out,
+                                  std::string *error) {
+  if (!is_numeric(version_str)) {
+    if (error)
+      *error = std::string(name) + " must be numeric, not " +
+               safe_for_output(version_str);
+    return false;
+  }
+
+  // Check for leading zeros
+  if (has_leading_zero(version_str)) {
+    if (error)
+      *error = std::string(name) + " version numbers ("
+               + safe_for_output(version_str)
+               + ") must not have leading zeros";
+    return false;
+  }
+
+  errno = 0;
+  unsigned long value = strtoul(version_str.c_str(), nullptr, 10);
+  if (errno == ERANGE ) {
+    if (error)
+      *error = std::string(name) + " version ("
+               + safe_for_output(version_str)
+               + ") is out of range";
+    return false;
+  }
+
+  if (!check_version_bound(value, version_max, name, error)) return false;
+
+  *out = value;
+  return true;
+}
+
+bool Semver::check_version_bound(unsigned long version_val, unsigned long version_max,
+                                 const char *name, std::string *error) {
+
+  // Easy case if things are valid
+  if (version_val <= version_max) return true;
+
+  // It must be too big
+  if (error)
+    *error = std::string(name) + " version value("
+              + std::to_string(version_val)
+              + ") must not exceed " +
+              std::to_string(version_max);
+  return false;
+}
+
+bool Semver::parse_core(std::string_view core, unsigned long *major,
+                        unsigned long *minor, unsigned long *patch,
+                        std::string *error) {
+  if (std::count(core.begin(), core.end(), '.') != 2) {
+    if (error)
+      *error = "Invalid core version format, expected MAJOR.MINOR.PATCH";
+    return false;
+  }
+
+  size_t minor_pos = core.find('.');
+  size_t patch_pos = core.find('.', minor_pos + 1);
+  std::string major_str(core.substr(0, minor_pos));
+  std::string minor_str(core.substr(minor_pos + 1, patch_pos - minor_pos - 1));
+  std::string patch_str(core.substr(patch_pos + 1));
+
+  // Parse each position into its own bounds.
+  return parse_core_component(major_str, kMajorMax, "MAJOR", major, error) &&
+         parse_core_component(minor_str, kMinorMax, "MINOR", minor, error) &&
+         parse_core_component(patch_str, kPatchMax, "PATCH", patch, error);
+}
+
+bool Semver::parse_prerelease(std::string_view segment,
+                              std::vector<std::string> *out,
+                              std::string *error) {
+  // Split by dots
+  while (true) {
+    size_t dot = segment.find('.');
+    std::string_view identifier = segment.substr(0, dot);
+
+    if (!is_valid_identifier(identifier)) {
+      if (error) *error = "Invalid pre-release identifier";
+      return false;
+    }
+    // Check for leading zeros in numeric identifiers
+    if (is_numeric(identifier) && has_leading_zero(identifier)) {
+      if (error)
+        *error = "Numeric pre-release identifiers must not have leading zeros";
+      return false;
+    }
+
+    out->push_back(std::string(identifier));
+    if (dot == std::string_view::npos) break;
+    segment.remove_prefix(dot + 1);
+  }
+  return true;
+}
+
+bool Semver::parse_build_metadata(std::string_view segment,
+                                  std::vector<std::string> *out,
+                                  std::string *error) {
+  // Split by dots
+  while (true) {
+    size_t dot = segment.find('.');
+    std::string_view identifier = segment.substr(0, dot);
+
+    if (!is_valid_identifier(identifier)) {
+      if (error) *error = "Invalid build metadata identifier";
+      return false;
+    }
+
+    out->push_back(std::string(identifier));
+    if (dot == std::string_view::npos) break;
+    segment.remove_prefix(dot + 1);
+  }
+  return true;
 }
 
 bool Semver::parse(std::string_view s, std::string *error) {
@@ -47,113 +168,42 @@ bool Semver::parse(std::string_view s, std::string *error) {
     return false;
   }
 
-  // Separate core version (MAJOR.MINOR.PATCH)
-  std::string_view core_version =
-      s.substr(0, std::min(s.find("+"), s.find("-")));
-  s.remove_prefix(core_version.size());
+  // Split into core[-prerelease][+build_metadata] segments. The core segment
+  // ends at the first '-' or '+'; any pre-release runs up to a trailing '+'.
+  std::string_view core = s.substr(0, std::min(s.find('+'), s.find('-')));
+  s.remove_prefix(core.size());
 
-  // Parse MAJOR.MINOR.PATCH
-  if (std::count(core_version.begin(), core_version.end(), '.') != 2) {
-    if (error)
-      *error = "Invalid core version format, expected MAJOR.MINOR.PATCH";
-    return false;
+  bool has_prerelease = !s.empty() && s[0] == '-';
+  std::string_view prerelease_seg;
+  if (has_prerelease) {
+    std::string_view seg = s.substr(0, s.find('+'));
+    s.remove_prefix(seg.size());
+    prerelease_seg = seg.substr(1);  // skip leading '-'
   }
 
-  size_t minor_pos = core_version.find('.');
-  size_t patch_pos = core_version.find('.', minor_pos + 1);
-  std::string major_str = std::string(core_version.substr(0, minor_pos));
-  std::string minor_str = std::string(
-      core_version.substr(minor_pos + 1, patch_pos - minor_pos - 1));
-  std::string patch_str = std::string(core_version.substr(patch_pos + 1));
-
-  // Validate and parse major, minor, patch
-  if (!is_numeric(major_str) || !is_numeric(minor_str) ||
-      !is_numeric(patch_str)) {
-    if (error) *error = "MAJOR, MINOR, and PATCH must be numeric";
-    return false;
+  bool has_build_metadata = !s.empty() && s[0] == '+';
+  std::string_view build_seg;
+  if (has_build_metadata) {
+    build_seg = s.substr(1);  // skip leading '+'
   }
 
-  // Check for leading zeros
-  if ((major_str.length() > 1 && major_str[0] == '0') ||
-      (minor_str.length() > 1 && minor_str[0] == '0') ||
-      (patch_str.length() > 1 && patch_str[0] == '0')) {
-    if (error) *error = "Version numbers must not have leading zeros";
-    return false;
-  }
-
-  // Parse the numbers. Use the C routines to avoid exceptions
-  unsigned long major_tmp = strtoul(major_str.data(), nullptr, 10);
-  unsigned long minor_tmp = strtoul(minor_str.data(), nullptr, 10);
-  unsigned long patch_tmp = strtoul(patch_str.data(), nullptr, 10);
-  if (major_tmp == ULONG_MAX || minor_tmp == ULONG_MAX ||
-      patch_tmp == ULONG_MAX) {
-    if (error) *error = "Version number out of range";
+  // Parse each component into temporaries so that a failure partway through
+  // leaves the existing object state untouched.
+  unsigned long major_tmp = 0, minor_tmp = 0, patch_tmp = 0;
+  if (!parse_core(core, &major_tmp, &minor_tmp, &patch_tmp, error)) {
     return false;
   }
 
   std::vector<std::string> prerelease_tmp;
-  // Parse pre-release if present
-  if (!s.empty() && s[0] == '-') {
-    std::string_view prerelease_str = s.substr(0, s.find('+'));
-    s.remove_prefix(prerelease_str.size());
-
-    // Split by dots
-    while (!prerelease_str.empty()) {
-      // Remove '-' or '.'
-      prerelease_str.remove_prefix(1);
-
-      size_t dot = prerelease_str.find('.');
-      std::string_view identifier = prerelease_str.substr(0, dot);
-
-      if (!is_valid_identifier(identifier)) {
-        if (error) *error = "Invalid pre-release identifier";
-        return false;
-      }
-      // Check for leading zeros in numeric identifiers
-      if (is_numeric(identifier) && identifier.length() > 1 &&
-          identifier[0] == '0') {
-        if (error)
-          *error =
-              "Numeric pre-release identifiers must not have leading zeros";
-        return false;
-      }
-
-      prerelease_tmp.push_back(std::string(identifier));
-      prerelease_str.remove_prefix(identifier.size());
-    }
-
-    if (prerelease_tmp.empty()) {
-      if (error) *error = "Pre-release section cannot be empty";
-      return false;
-    }
+  if (has_prerelease &&
+      !parse_prerelease(prerelease_seg, &prerelease_tmp, error)) {
+    return false;
   }
 
   std::vector<std::string> build_metadata_tmp;
-  // Parse build metadata if present
-  if (!s.empty() && s[0] == '+') {
-    std::string_view build_str = s;
-
-    // Split by dots
-    while (!build_str.empty()) {
-      // Remove '+' or '.'
-      build_str.remove_prefix(1);
-
-      size_t dot = build_str.find('.');
-      std::string_view identifier = build_str.substr(0, dot);
-
-      if (!is_valid_identifier(identifier)) {
-        if (error) *error = "Invalid build metadata identifier";
-        return false;
-      }
-
-      build_metadata_tmp.push_back(std::string(identifier));
-      build_str.remove_prefix(identifier.size());
-    }
-
-    if (build_metadata_tmp.empty()) {
-      if (error) *error = "Build metadata section cannot be empty";
-      return false;
-    }
+  if (has_build_metadata &&
+      !parse_build_metadata(build_seg, &build_metadata_tmp, error)) {
+    return false;
   }
 
   major_ = major_tmp;
@@ -177,26 +227,26 @@ Semver Semver::from_components(unsigned long major, unsigned long minor,
                                const std::vector<std::string> &build_metadata) {
   Semver ver;
 
+  // Assume failure unless everything succeeds
+  ver.valid_ = false;
+
+  if (!check_version_bound(major, kMajorMax, "MAJOR", nullptr)) return ver;
+  if (!check_version_bound(major, kMinorMax, "MINOR", nullptr)) return ver;
+  if (!check_version_bound(major, kPatchMax, "PATCH", nullptr)) return ver;
+
   // Validate identifiers if provided
   for (const auto &id : prerelease) {
-    if (!is_valid_identifier(id)) {
-      ver.valid_ = false;
-      return ver;
-    }
+    if (!is_valid_identifier(id))  return ver;
+
     // Check for leading zeros in numeric identifiers
-    if (is_numeric(id) && id.length() > 1 && id[0] == '0') {
-      ver.valid_ = false;
-      return ver;
-    }
+    if (is_numeric(id) && has_leading_zero(id)) return ver;
   }
 
   for (const auto &id : build_metadata) {
-    if (!is_valid_identifier(id)) {
-      ver.valid_ = false;
-      return ver;
-    }
+    if (!is_valid_identifier(id)) return ver;
   }
 
+  // All of the components are valid
   ver.major_ = major;
   ver.minor_ = minor;
   ver.patch_ = patch;
@@ -236,6 +286,39 @@ std::string Semver::to_string() const {
   }
 
   return r;
+}
+
+std::string Semver::safe_for_output(std::string_view str) {
+  std::string result;
+  size_t limit = std::min(str.size(), kMaxOutputChars);
+  for (size_t i = 0; i < limit; ++i) {
+    unsigned char c = static_cast<unsigned char>(str[i]);
+    switch (c) {
+      case '\t':
+        result += "\\t";
+        break;
+      case '\n':
+        result += "\\n";
+        break;
+      case '\r':
+        result += "\\r";
+        break;
+      case '\\':  // Keep out safe with backslash.
+        result += "\\\\";
+        break;
+      default:
+        if (std::isprint(c)) {
+          result += static_cast<char>(c);
+        } else {
+          char buf[5];
+          snprintf(buf, sizeof(buf), "\\x%02X", c);
+          result += buf;
+        }
+    }
+  }
+  // Truncated strings get an unicode ellipsis appended at the end
+  if (str.size() > kMaxOutputChars) result += "\u2026";
+  return result;
 }
 
 int Semver::compare_prerelease(const Semver &other) const {

--- a/villagesql/common/semver.cc
+++ b/villagesql/common/semver.cc
@@ -42,9 +42,9 @@ bool Semver::is_valid_identifier(std::string_view id) {
   });
 }
 
-bool Semver::parse_core_component(const std::string &version_str, unsigned long version_max,
-                                  const char *name, unsigned long *out,
-                                  std::string *error) {
+bool Semver::parse_core_component(const std::string &version_str,
+                                  unsigned long version_max, const char *name,
+                                  unsigned long *out, std::string *error) {
   if (!is_numeric(version_str)) {
     if (error)
       *error = std::string(name) + " must be numeric, not " +
@@ -55,19 +55,17 @@ bool Semver::parse_core_component(const std::string &version_str, unsigned long 
   // Check for leading zeros
   if (has_leading_zero(version_str)) {
     if (error)
-      *error = std::string(name) + " version numbers ("
-               + safe_for_output(version_str)
-               + ") must not have leading zeros";
+      *error = std::string(name) + " version numbers (" +
+               safe_for_output(version_str) + ") must not have leading zeros";
     return false;
   }
 
   errno = 0;
   unsigned long value = strtoul(version_str.c_str(), nullptr, 10);
-  if (errno == ERANGE ) {
+  if (errno == ERANGE) {
     if (error)
-      *error = std::string(name) + " version ("
-               + safe_for_output(version_str)
-               + ") is out of range";
+      *error = std::string(name) + " version (" + safe_for_output(version_str) +
+               ") is out of range";
     return false;
   }
 
@@ -77,18 +75,17 @@ bool Semver::parse_core_component(const std::string &version_str, unsigned long 
   return true;
 }
 
-bool Semver::check_version_bound(unsigned long version_val, unsigned long version_max,
-                                 const char *name, std::string *error) {
-
+bool Semver::check_version_bound(unsigned long version_val,
+                                 unsigned long version_max, const char *name,
+                                 std::string *error) {
   // Easy case if things are valid
   if (version_val <= version_max) return true;
 
   // It must be too big
   if (error)
-    *error = std::string(name) + " version value("
-              + std::to_string(version_val)
-              + ") must not exceed " +
-              std::to_string(version_max);
+    *error = std::string(name) + " version value(" +
+             std::to_string(version_val) + ") must not exceed " +
+             std::to_string(version_max);
   return false;
 }
 
@@ -236,7 +233,7 @@ Semver Semver::from_components(unsigned long major, unsigned long minor,
 
   // Validate identifiers if provided
   for (const auto &id : prerelease) {
-    if (!is_valid_identifier(id))  return ver;
+    if (!is_valid_identifier(id)) return ver;
 
     // Check for leading zeros in numeric identifiers
     if (is_numeric(id) && has_leading_zero(id)) return ver;

--- a/villagesql/common/semver.cc
+++ b/villagesql/common/semver.cc
@@ -320,68 +320,55 @@ bool Semver::parse(std::string_view s, std::string *error) {
     build_seg = s.substr(1);  // skip leading '+'
   }
 
-  // Parse each component into temporaries so that a failure partway through
-  // leaves the existing object state untouched.
-  unsigned long major_tmp = 0, minor_tmp = 0, patch_tmp = 0;
-  if (!parse_core(core, &major_tmp, &minor_tmp, &patch_tmp, error)) {
+  // Parse each component value.
+  unsigned long major = 0, minor = 0, patch = 0;
+  if (!parse_core(core, &major, &minor, &patch, error)) {
     return false;
   }
 
-  std::vector<std::string> prerelease_tmp;
-  if (has_prerelease &&
-      !parse_prerelease(prerelease_seg, &prerelease_tmp, error)) {
+  std::vector<std::string> prerelease;
+  if (has_prerelease && !parse_prerelease(prerelease_seg, &prerelease, error)) {
     return false;
   }
 
-  std::vector<std::string> build_metadata_tmp;
+  std::vector<std::string> build_metadata;
   if (has_build_metadata &&
-      !parse_build_metadata(build_seg, &build_metadata_tmp, error)) {
+      !parse_build_metadata(build_seg, &build_metadata, error)) {
     return false;
   }
 
-  major_ = major_tmp;
-  minor_ = minor_tmp;
-  patch_ = patch_tmp;
-  prerelease_.swap(prerelease_tmp);
-  build_metadata_.swap(build_metadata_tmp);
-  valid_ = true;
-  return true;
+  // Accept a small amount of duplicate validation for consistency in behavior.
+  return from_components(major, minor, patch, prerelease, build_metadata);
 }
 
-Semver Semver::from_components(unsigned long major, unsigned long minor,
-                               unsigned long patch,
-                               const std::vector<std::string> &prerelease,
-                               const std::vector<std::string> &build_metadata) {
-  Semver ver;
-
-  // Assume failure unless everything succeeds
-  ver.valid_ = false;
-
-  if (!check_version_bound(major, kMajorMax, "MAJOR", nullptr)) return ver;
-  if (!check_version_bound(minor, kMinorMax, "MINOR", nullptr)) return ver;
-  if (!check_version_bound(patch, kPatchMax, "PATCH", nullptr)) return ver;
+bool Semver::from_components(unsigned long major, unsigned long minor,
+                             unsigned long patch,
+                             const std::vector<std::string> &prerelease,
+                             const std::vector<std::string> &build_metadata) {
+  if (!check_version_bound(major, kMajorMax, "MAJOR", nullptr)) return false;
+  if (!check_version_bound(minor, kMinorMax, "MINOR", nullptr)) return false;
+  if (!check_version_bound(patch, kPatchMax, "PATCH", nullptr)) return false;
 
   // Validate identifiers if provided
   for (const auto &id : prerelease) {
-    if (!is_valid_identifier(id)) return ver;
+    if (!is_valid_identifier(id)) return false;
 
     // Check for leading zeros in numeric identifiers
-    if (is_numeric(id) && has_leading_zero(id)) return ver;
+    if (is_numeric(id) && has_leading_zero(id)) return false;
   }
 
   for (const auto &id : build_metadata) {
-    if (!is_valid_identifier(id)) return ver;
+    if (!is_valid_identifier(id)) return false;
   }
 
   // All of the components are valid
-  ver.major_ = major;
-  ver.minor_ = minor;
-  ver.patch_ = patch;
-  ver.prerelease_ = prerelease;
-  ver.build_metadata_ = build_metadata;
-  ver.valid_ = true;
-
-  return ver;
+  major_ = major;
+  minor_ = minor;
+  patch_ = patch;
+  prerelease_ = prerelease;
+  build_metadata_ = build_metadata;
+  valid_ = true;
+  return true;
 }
 
 std::string Semver::to_string() const {

--- a/villagesql/common/semver.cc
+++ b/villagesql/common/semver.cc
@@ -18,8 +18,7 @@
 
 #include <algorithm>
 #include <cctype>
-#include <cerrno>
-#include <cstdlib>
+#include <charconv>
 
 namespace villagesql {
 
@@ -42,7 +41,7 @@ bool Semver::is_valid_identifier(std::string_view id) {
   });
 }
 
-bool Semver::parse_core_component(const std::string &version_str,
+bool Semver::parse_core_component(std::string_view version_str,
                                   unsigned long version_max, const char *name,
                                   unsigned long *out, std::string *error) {
   if (!is_numeric(version_str)) {
@@ -60,9 +59,10 @@ bool Semver::parse_core_component(const std::string &version_str,
     return false;
   }
 
-  errno = 0;
-  unsigned long value = strtoul(version_str.c_str(), nullptr, 10);
-  if (errno == ERANGE) {
+  unsigned long value = 0;
+  auto [ptr, ec] = std::from_chars(
+      version_str.data(), version_str.data() + version_str.size(), value);
+  if (ec != std::errc()) {
     if (error)
       *error = std::string(name) + " version (" + safe_for_output(version_str) +
                ") is out of range";
@@ -100,9 +100,10 @@ bool Semver::parse_core(std::string_view core, unsigned long *major,
 
   size_t minor_pos = core.find('.');
   size_t patch_pos = core.find('.', minor_pos + 1);
-  std::string major_str(core.substr(0, minor_pos));
-  std::string minor_str(core.substr(minor_pos + 1, patch_pos - minor_pos - 1));
-  std::string patch_str(core.substr(patch_pos + 1));
+  std::string_view major_str = core.substr(0, minor_pos);
+  std::string_view minor_str =
+      core.substr(minor_pos + 1, patch_pos - minor_pos - 1);
+  std::string_view patch_str = core.substr(patch_pos + 1);
 
   // Parse each position into its own bounds.
   return parse_core_component(major_str, kMajorMax, "MAJOR", major, error) &&

--- a/villagesql/include/semver.h
+++ b/villagesql/include/semver.h
@@ -42,9 +42,6 @@ class Semver {
   static constexpr unsigned long kMinorMax = 100;
   static constexpr unsigned long kPatchMax = 1000;
 
-  // Maximum number of source characters reproduced by safe_for_output().
-  static constexpr size_t kMaxOutputChars = 10;
-
   /**
    * Default constructor creates an invalid semver (0.0.0)
    */
@@ -59,16 +56,6 @@ class Semver {
    * NOTE this is the opposite of mysql normal.
    */
   bool parse(std::string_view version_str, std::string *error = nullptr);
-
-  /**
-   * Static factory method to parse and create a Semver.
-   *
-   * @param version_str String in semver format
-   * @param[out] error Optional error message if parsing fails
-   * @return Semver object, check is_valid() to see if parsing succeeded
-   */
-  static Semver from_string(std::string_view version_str,
-                            std::string *error = nullptr);
 
   /**
    * Static factory method to create a Semver from components.
@@ -135,18 +122,6 @@ class Semver {
   std::string to_string() const;
 
   /**
-   * Sanitize an arbitrary string for safe inclusion in output such as error
-   * messages. At most kMaxOutputChars source characters are reproduced; any
-   * unprintable character is rendered as a readable escape sequence (e.g.
-   * "\n", "\x1b"); if the input is longer than kMaxOutputChars an ellipsis is
-   * appended.
-   *
-   * @param str The string to sanitize
-   * @return A printable, length-limited representation of str
-   */
-  static std::string safe_for_output(std::string_view str);
-
-  /**
    * Comparison operators.
    * Note: Build metadata is ignored for precedence comparison per semver spec.
    * Pre-release versions have lower precedence than normal versions.
@@ -159,98 +134,6 @@ class Semver {
   bool operator>=(const Semver &other) const;
 
  private:
-  /**
-   * Compare pre-release identifiers according to semver rules.
-   * @return -1 if this < other, 0 if equal, 1 if this > other
-   */
-  int compare_prerelease(const Semver &other) const;
-
-  /**
-   * Parse and validate a single core version component.
-   *
-   * Validates that the component is numeric with no leading zeros, converts it,
-   * and range-checks the result, rejecting values that overflow or exceed the
-   * (inclusive) maximum allowed for this position.
-   *
-   * @param version_str Component string
-   * @param version_max Inclusive maximum value allowed for this position
-   * @param name Position name used in error messages (e.g. "MAJOR")
-   * @param[out] out Parsed value
-   * @param[out] error Optional error message if validation fails
-   * @return true on success, false otherwise
-   */
-  static bool parse_core_component(std::string_view version_str,
-                                   unsigned long version_max, const char *name,
-                                   unsigned long *out, std::string *error);
-
-  /**
-   * Check that a parsed core version value is within its allowed bound.
-   *
-   * @param version_val The parsed value to check
-   * @param version_max Inclusive maximum value allowed for this position
-   * @param name Position name used in the error message (e.g. "MAJOR")
-   * @param[out] error Optional error message if the value exceeds the bound
-   * @return true if version_val <= version_max, false otherwise
-   */
-  static bool check_version_bound(unsigned long version_val,
-                                  unsigned long version_max, const char *name,
-                                  std::string *error);
-
-  /**
-   * Parse and validate the core "MAJOR.MINOR.PATCH" segment.
-   *
-   * @param core The core segment, with no pre-release or build metadata
-   * @param[out] major Parsed MAJOR number
-   * @param[out] minor Parsed MINOR number
-   * @param[out] patch Parsed PATCH number
-   * @param[out] error Optional error message if validation fails
-   * @return true on success, false otherwise
-   */
-  static bool parse_core(std::string_view core, unsigned long *major,
-                         unsigned long *minor, unsigned long *patch,
-                         std::string *error);
-
-  /**
-   * Parse and validate the dot-separated pre-release segment.
-   *
-   * @param segment Pre-release identifiers, without the leading '-'
-   * @param[out] out Parsed pre-release identifiers
-   * @param[out] error Optional error message if validation fails
-   * @return true on success, false otherwise
-   */
-  static bool parse_prerelease(std::string_view segment,
-                               std::vector<std::string> *out,
-                               std::string *error);
-
-  /**
-   * Parse and validate the dot-separated build metadata segment.
-   *
-   * @param segment Build metadata identifiers, without the leading '+'
-   * @param[out] out Parsed build metadata identifiers
-   * @param[out] error Optional error message if validation fails
-   * @return true on success, false otherwise
-   */
-  static bool parse_build_metadata(std::string_view segment,
-                                   std::vector<std::string> *out,
-                                   std::string *error);
-
-  /**
-   * Check if a string is a valid identifier (alphanumeric + hyphen)
-   */
-  static bool is_valid_identifier(std::string_view id);
-
-  /**
-   * Check if a string contains only digits
-   */
-  static bool is_numeric(std::string_view str);
-
-  /**
-   * Check if a numeric identifier has a disallowed leading zero, i.e. it is
-   * more than one digit long and starts with '0'. Per the semver spec, numeric
-   * identifiers must not include leading zeros.
-   */
-  static bool has_leading_zero(std::string_view str);
-
   unsigned long major_;
   unsigned long minor_;
   unsigned long patch_;

--- a/villagesql/include/semver.h
+++ b/villagesql/include/semver.h
@@ -180,9 +180,8 @@ class Semver {
    * @return true on success, false otherwise
    */
   static bool parse_core_component(const std::string &version_str,
-                                      unsigned long version_max,
-                                      const char *name, unsigned long *out,
-                                      std::string *error);
+                                   unsigned long version_max, const char *name,
+                                   unsigned long *out, std::string *error);
 
   /**
    * Check that a parsed core version value is within its allowed bound.

--- a/villagesql/include/semver.h
+++ b/villagesql/include/semver.h
@@ -36,6 +36,15 @@ namespace villagesql {
  */
 class Semver {
  public:
+  // Inclusive upper bounds for each core version position. The bounds differ
+  // by position so that, for example, the patch number has the widest range.
+  static constexpr unsigned long kMajorMax = 10;
+  static constexpr unsigned long kMinorMax = 100;
+  static constexpr unsigned long kPatchMax = 1000;
+
+  // Maximum number of source characters reproduced by safe_for_output().
+  static constexpr size_t kMaxOutputChars = 10;
+
   /**
    * Default constructor creates an invalid semver (0.0.0)
    */
@@ -126,6 +135,18 @@ class Semver {
   std::string to_string() const;
 
   /**
+   * Sanitize an arbitrary string for safe inclusion in output such as error
+   * messages. At most kMaxOutputChars source characters are reproduced; any
+   * unprintable character is rendered as a readable escape sequence (e.g.
+   * "\n", "\x1b"); if the input is longer than kMaxOutputChars an ellipsis is
+   * appended.
+   *
+   * @param str The string to sanitize
+   * @return A printable, length-limited representation of str
+   */
+  static std::string safe_for_output(std::string_view str);
+
+  /**
    * Comparison operators.
    * Note: Build metadata is ignored for precedence comparison per semver spec.
    * Pre-release versions have lower precedence than normal versions.
@@ -145,6 +166,76 @@ class Semver {
   int compare_prerelease(const Semver &other) const;
 
   /**
+   * Parse and validate a single core version component.
+   *
+   * Validates that the component is numeric with no leading zeros, converts it,
+   * and range-checks the result, rejecting values that overflow or exceed the
+   * (inclusive) maximum allowed for this position.
+   *
+   * @param version_str Component string
+   * @param version_max Inclusive maximum value allowed for this position
+   * @param name Position name used in error messages (e.g. "MAJOR")
+   * @param[out] out Parsed value
+   * @param[out] error Optional error message if validation fails
+   * @return true on success, false otherwise
+   */
+  static bool parse_core_component(const std::string &version_str,
+                                      unsigned long version_max,
+                                      const char *name, unsigned long *out,
+                                      std::string *error);
+
+  /**
+   * Check that a parsed core version value is within its allowed bound.
+   *
+   * @param version_val The parsed value to check
+   * @param version_max Inclusive maximum value allowed for this position
+   * @param name Position name used in the error message (e.g. "MAJOR")
+   * @param[out] error Optional error message if the value exceeds the bound
+   * @return true if version_val <= version_max, false otherwise
+   */
+  static bool check_version_bound(unsigned long version_val,
+                                  unsigned long version_max, const char *name,
+                                  std::string *error);
+
+  /**
+   * Parse and validate the core "MAJOR.MINOR.PATCH" segment.
+   *
+   * @param core The core segment, with no pre-release or build metadata
+   * @param[out] major Parsed MAJOR number
+   * @param[out] minor Parsed MINOR number
+   * @param[out] patch Parsed PATCH number
+   * @param[out] error Optional error message if validation fails
+   * @return true on success, false otherwise
+   */
+  static bool parse_core(std::string_view core, unsigned long *major,
+                         unsigned long *minor, unsigned long *patch,
+                         std::string *error);
+
+  /**
+   * Parse and validate the dot-separated pre-release segment.
+   *
+   * @param segment Pre-release identifiers, without the leading '-'
+   * @param[out] out Parsed pre-release identifiers
+   * @param[out] error Optional error message if validation fails
+   * @return true on success, false otherwise
+   */
+  static bool parse_prerelease(std::string_view segment,
+                               std::vector<std::string> *out,
+                               std::string *error);
+
+  /**
+   * Parse and validate the dot-separated build metadata segment.
+   *
+   * @param segment Build metadata identifiers, without the leading '+'
+   * @param[out] out Parsed build metadata identifiers
+   * @param[out] error Optional error message if validation fails
+   * @return true on success, false otherwise
+   */
+  static bool parse_build_metadata(std::string_view segment,
+                                   std::vector<std::string> *out,
+                                   std::string *error);
+
+  /**
    * Check if a string is a valid identifier (alphanumeric + hyphen)
    */
   static bool is_valid_identifier(std::string_view id);
@@ -153,6 +244,13 @@ class Semver {
    * Check if a string contains only digits
    */
   static bool is_numeric(std::string_view str);
+
+  /**
+   * Check if a numeric identifier has a disallowed leading zero, i.e. it is
+   * more than one digit long and starts with '0'. Per the semver spec, numeric
+   * identifiers must not include leading zeros.
+   */
+  static bool has_leading_zero(std::string_view str);
 
   unsigned long major_;
   unsigned long minor_;

--- a/villagesql/include/semver.h
+++ b/villagesql/include/semver.h
@@ -179,7 +179,7 @@ class Semver {
    * @param[out] error Optional error message if validation fails
    * @return true on success, false otherwise
    */
-  static bool parse_core_component(const std::string &version_str,
+  static bool parse_core_component(std::string_view version_str,
                                    unsigned long version_max, const char *name,
                                    unsigned long *out, std::string *error);
 

--- a/villagesql/include/semver.h
+++ b/villagesql/include/semver.h
@@ -58,19 +58,20 @@ class Semver {
   bool parse(std::string_view version_str, std::string *error = nullptr);
 
   /**
-   * Static factory method to create a Semver from components.
+   * Populate a Semver from components.  If any component fails validation,
+   * the result is false and this Semver is unchanged.
    *
    * @param major Major version number
    * @param minor Minor version number
    * @param patch Patch version number
    * @param prerelease Optional pre-release identifiers (e.g., {"alpha", "1"})
    * @param build_metadata Optional build metadata identifiers
-   * @return Semver object, always valid if component validation passes
+   * @return true if component validation passes
    */
-  static Semver from_components(
-      unsigned long major, unsigned long minor, unsigned long patch,
-      const std::vector<std::string> &prerelease = {},
-      const std::vector<std::string> &build_metadata = {});
+  bool from_components(unsigned long major, unsigned long minor,
+                       unsigned long patch,
+                       const std::vector<std::string> &prerelease = {},
+                       const std::vector<std::string> &build_metadata = {});
 
   /**
    * Check if this is a valid semver

--- a/villagesql/include/version.h.in
+++ b/villagesql/include/version.h.in
@@ -38,11 +38,10 @@ inline Semver GetBuildVersion() {
   if (std::string_view(VSQL_PRE_RELEASE_VERSION).size() > 0) {
     prerelease.push_back(VSQL_PRE_RELEASE_VERSION);
   }
-  return Semver::from_components(
-    VSQL_MAJOR_VERSION,
-    VSQL_MINOR_VERSION,
-    VSQL_PATCH_VERSION,
-    prerelease);
+  Semver v;
+  v.from_components(VSQL_MAJOR_VERSION, VSQL_MINOR_VERSION,
+                    VSQL_PATCH_VERSION, prerelease);
+  return v;
 }
 
 }  // namespace villagesql

--- a/villagesql/schema/schema_manager.cc
+++ b/villagesql/schema/schema_manager.cc
@@ -368,7 +368,9 @@ static bool validate_villagesql_tables(THD *thd) {
 // villagesql/schema/upgrade.h.
 bool run_villagesql_version_upgrades(THD *thd, Semver from_version) {
   // Upgrade from 0.0.1 to 0.0.3: add type_parameters column to custom_columns
-  if (from_version < Semver::from_components(0, 0, 3)) {
+  Semver version_003;
+  version_003.from_components(0, 0, 3);
+  if (from_version < version_003) {
     if (upgrade::upgrade_villagesql_from_0_0_1_to_0_0_3(thd)) return true;
   }
   // Future versions would be added here


### PR DESCRIPTION
## Description

Refactors Semver parse in order to isolate the various semantic version components into their own validation function.  This makes it much easier to add codebase as a prefix component.

<!-- What does this PR do? Briefly describe the change. -->

Provides component specific validation functions to parse and validate different semantic version components.  This also allows for more specific error messages when validation failures occur.

<!-- Link the GitHub issue this PR addresses, e.g. Fixes #123 -->
An early step toward #595 - Cleanup release process

## How was this tested?

The semantic version regression tests passed:

```make -j14 villagesql-unit-tests && ctest -L villagesql```

