### PR TITLE
dev_server: add trgm and fuzzystrmatch

### DIFF
--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -18,6 +18,8 @@
 https://github.com/villagesql/vsql-ai main
 https://github.com/villagesql/vsql-boolean main
 https://github.com/villagesql/vsql-crypto main
+https://github.com/villagesql/vsql-fuzzystrmatch main
+https://github.com/villagesql/vsql-trgm main
 https://github.com/villagesql/vsql-cube main
 https://github.com/villagesql/vsql-http main
 https://github.com/villagesql/vsql-network-address main


### PR DESCRIPTION
## Description
Add vsql-fuzzystrmatch and vsql-trgm to extension list

## Related Issue
n/a

## How was this tested?
Passes local MTR tests.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
