### PR TITLE
descriptor lookup from TypeContext create

### DIFF
--- a/villagesql/schema/victionary_client.h
+++ b/villagesql/schema/victionary_client.h
@@ -841,6 +841,13 @@ class VictionaryClient {
            "Write lock not held - able to acquire read lock");
   }
 
+  // Assert that read or write lock is held (for debugging)
+  void assert_read_or_write_lock_held() const {
+    // Try to acquire write lock - should fail if we have any lock
+    assert(mysql_rwlock_trywrlock(&m_lock) != 0 &&
+           "No lock held - able to acquire write lock");
+  }
+
  private:
   VictionaryClient()
       : m_properties(&m_lock),  // Pass lock pointer to map

--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -156,8 +156,14 @@ class PT_custom_type : public PT_type {
 
     const TypeContext *type_context = nullptr;
 
-    // Handle types that accept a length/parameter spec
+    // Handle types that accept a length spec. Note that this create function
+    // only handles TYPE(N) syntax and unparameterized types. Parameterized types with
+    // TYPE('key=value,...') syntax are handled by the other create() overload.
     if (descriptor->is_parameterized()) {
+      // type provides resolve_params, check if also provides int_to_params for TYPE(N) syntax.
+      // In case it does, and length is provided, we will convert the length to parameters and
+      // resolve the TypeContext.
+      // In case it does, and length is not provided -> this is an error.
       if (length != nullptr) {
         // TYPE(N) syntax used - convert N to parameters via callbacks
         if (!descriptor->int_to_params_fn().has_value()) {
@@ -194,6 +200,7 @@ class PT_custom_type : public PT_type {
           return nullptr;
         }
 
+        // resolve_params_and_context will call AcquireOrCreateTypeContext after resolving the parameters
         if (resolve_params_and_context(pos, thd, descriptor, canonical.str(),
                                        type_context)) {
           return nullptr;
@@ -202,20 +209,25 @@ class PT_custom_type : public PT_type {
         // length is now consumed - pass nullptr to constructor
         length = nullptr;
       } else {
-        // No length provided for a parameterized type
+        // No length provided for TYPE(N)
         if (descriptor->int_to_params_fn().has_value()) {
           thd->syntax_error_at(pos, "Type '%s' requires a length specification",
                                descriptor->qualified_base_name().c_str());
           return nullptr;
         }
       }
-    }
-
-    // Populate type_context for non parameterized (no length) types.
-    if (type_context == nullptr &&
-        AcquireOrCreateTypeContext(descriptor, TypeParameters(), *thd->mem_root,
-                                   type_context)) {
-      return nullptr;
+    } else {
+      // non parameterized type
+      if (length != nullptr) {
+        if (!current_thd->is_error())
+          villagesql_error(
+              "Length provided for non-parameterized type '%s'",
+              MYF(0), descriptor->qualified_base_name().c_str());
+        return nullptr;
+      }
+      if (AcquireOrCreateTypeContext(descriptor, TypeParameters(), *thd->mem_root,
+                                     type_context)) 
+        return nullptr;
     }
 
     PT_custom_type *ret = new (pt_mem_root)

--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -108,13 +108,12 @@ class PT_custom_type : public PT_type {
   // (extension_name.type_name), pass extension_name; for unqualified names,
   // pass empty LEX_STRING {} for extension_name.
 
-  // Resolve params via resolve_params callback and re-resolve TypeContext.
-  // Shared by both TYPE(N) and TYPE('key=value,...') paths.
-  // params_str must be in canonical form ("key=value,key=value,...").
+  // Resolve params via the resolve_params callback and acquire the concrete
+  // TypeContext for the given descriptor. Shared by both TYPE(N) and
+  // TYPE('key=value,...') paths. params_str must be in canonical form
+  // ("key=value,key=value,...").
   static bool resolve_params_and_context(const POS &pos, THD *thd,
                                          const TypeDescriptor *descriptor,
-                                         const LEX_STRING &extension_name,
-                                         const LEX_STRING &type_name,
                                          const std::string &params_str,
                                          const TypeContext *&type_context) {
     char error_msg[VEF_MAX_ERROR_LEN] = {0};
@@ -128,9 +127,8 @@ class PT_custom_type : public PT_type {
     TypeParameters params(params_str);
 
     type_context = nullptr;
-    if (ResolveTypeToContext(to_string_view(extension_name),
-                             to_string_view(type_name), params, *thd->mem_root,
-                             type_context)) {
+    if (AcquireOrCreateTypeContext(descriptor, params, *thd->mem_root,
+                                   type_context)) {
       return true;
     }
     return false;
@@ -141,24 +139,31 @@ class PT_custom_type : public PT_type {
                                 const LEX_STRING &extension_name,
                                 const LEX_STRING &type_name,
                                 const char *length) {
-    const TypeContext *type_context = nullptr;
-    TypeParameters empty_params;
-    if (ResolveTypeToContext(to_string_view(extension_name),
-                             to_string_view(type_name), empty_params,
-                             *thd->mem_root, type_context)) {
+    // Resolve the descriptor first so we can inspect the type's
+    // characteristics. We defer creating the TypeContext until
+    // the concrete parameters are known.
+    const TypeDescriptor *descriptor = nullptr;
+    if (ResolveTypeDescriptor(to_string_view(extension_name),
+                              to_string_view(type_name), descriptor)) {
       return nullptr;
     }
 
+    if (descriptor == nullptr) {
+      // Type not found - constructor records the error.
+      return new (pt_mem_root)
+          PT_custom_type(pos, thd, type_name, nullptr, nullptr);
+    }
+
+    const TypeContext *type_context = nullptr;
+
     // Handle types that accept a length/parameter spec
-    if (type_context != nullptr && type_context->is_parameterized()) {
-      auto *descriptor = type_context->descriptor();
+    if (descriptor->is_parameterized()) {
       if (length != nullptr) {
         // TYPE(N) syntax used - convert N to parameters via callbacks
         if (!descriptor->int_to_params_fn().has_value()) {
-          std::string qname = type_context->qualified_name();
           thd->syntax_error_at(
               pos, "Type '%s' does not accept a length specification",
-              qname.c_str());
+              descriptor->qualified_base_name().c_str());
           return nullptr;
         }
 
@@ -166,9 +171,8 @@ class PT_custom_type : public PT_type {
         char *endptr = nullptr;
         int64_t int_value = strtoll(length, &endptr, 10);
         if (endptr == length || *endptr != '\0' || int_value <= 0) {
-          std::string qname = type_context->qualified_name();
           thd->syntax_error_at(pos, "Invalid length '%s' for type '%s'", length,
-                               qname.c_str());
+                               descriptor->qualified_base_name().c_str());
           return nullptr;
         }
 
@@ -186,12 +190,11 @@ class PT_custom_type : public PT_type {
         TypeParameters canonical = TypeParameters::from_raw(params_str);
         if (canonical.empty()) {
           thd->syntax_error_at(pos, "Invalid parameter string for type '%s'",
-                               type_context->qualified_name().c_str());
+                               descriptor->qualified_base_name().c_str());
           return nullptr;
         }
 
-        if (resolve_params_and_context(pos, thd, descriptor, extension_name,
-                                       type_name, canonical.str(),
+        if (resolve_params_and_context(pos, thd, descriptor, canonical.str(),
                                        type_context)) {
           return nullptr;
         }
@@ -201,12 +204,18 @@ class PT_custom_type : public PT_type {
       } else {
         // No length provided for a parameterized type
         if (descriptor->int_to_params_fn().has_value()) {
-          std::string qname = type_context->qualified_name();
           thd->syntax_error_at(pos, "Type '%s' requires a length specification",
-                               qname.c_str());
+                               descriptor->qualified_base_name().c_str());
           return nullptr;
         }
       }
+    }
+
+    // Populate type_context for non parameterized (no length) types.
+    if (type_context == nullptr &&
+        AcquireOrCreateTypeContext(descriptor, TypeParameters(), *thd->mem_root,
+                                   type_context)) {
+      return nullptr;
     }
 
     PT_custom_type *ret = new (pt_mem_root)
@@ -224,45 +233,42 @@ class PT_custom_type : public PT_type {
       return create(pt_mem_root, pos, thd, extension_name, type_name, length);
     }
 
-    const TypeContext *type_context = nullptr;
-    TypeParameters empty_params;
-    if (ResolveTypeToContext(to_string_view(extension_name),
-                             to_string_view(type_name), empty_params,
-                             *thd->mem_root, type_context)) {
+    // Resolve the descriptor first
+    const TypeDescriptor *descriptor = nullptr;
+    if (ResolveTypeDescriptor(to_string_view(extension_name),
+                              to_string_view(type_name), descriptor)) {
       return nullptr;
     }
 
-    if (type_context == nullptr) {
+    if (descriptor == nullptr) {
       return new (pt_mem_root)
           PT_custom_type(pos, thd, type_name, nullptr, nullptr);
     }
 
-    auto *descriptor = type_context->descriptor();
     if (!descriptor->resolve_params_fn().has_value()) {
-      std::string qname = type_context->qualified_name();
       thd->syntax_error_at(pos, "Type '%s' does not accept parameters",
-                           qname.c_str());
+                           descriptor->qualified_base_name().c_str());
       return nullptr;
     }
 
     // Normalize the raw parameter string to canonical form
     std::string input(params_str, params_str_len);
     if (input.empty()) {
-      std::string qname = type_context->qualified_name();
       thd->syntax_error_at(pos, "Empty parameter string for type '%s'",
-                           qname.c_str());
+                           descriptor->qualified_base_name().c_str());
       return nullptr;
     }
 
     TypeParameters canonical = TypeParameters::from_raw(input);
     if (canonical.empty()) {
       thd->syntax_error_at(pos, "Invalid parameter string for type '%s'",
-                           type_context->qualified_name().c_str());
+                           descriptor->qualified_base_name().c_str());
       return nullptr;
     }
 
-    if (resolve_params_and_context(pos, thd, descriptor, extension_name,
-                                   type_name, canonical.str(), type_context)) {
+    const TypeContext *type_context = nullptr;
+    if (resolve_params_and_context(pos, thd, descriptor, canonical.str(),
+                                   type_context)) {
       return nullptr;
     }
 

--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -72,17 +72,6 @@ class PT_custom_type : public PT_type {
       return;
     }
 
-    // Validate length specification against type characteristics
-    if (nullptr != length_spec && !type_context->is_parameterized()) {
-      // Non parameterized type with length specification - this is an error
-      std::string qname = type_context->qualified_name();
-      thd->syntax_error_at(pos,
-                           "Type '%s' is not parameterized and cannot have a "
-                           "length specification",
-                           qname.c_str());
-      return;
-    }
-
     // If no length_spec provided, generate it from the TypeContext's storage
     // length. For fixed-length types this comes from the descriptor; for
     // variable-length types it is the descriptor's max_persisted_length
@@ -171,6 +160,8 @@ class PT_custom_type : public PT_type {
           thd->syntax_error_at(
               pos, "Type '%s' does not accept a length specification",
               descriptor->qualified_base_name().c_str());
+          // it's OK to return nullptr only if an error has already been set in
+          // THD
           return nullptr;
         }
 
@@ -221,9 +212,10 @@ class PT_custom_type : public PT_type {
     } else {
       // non parameterized type
       if (length != nullptr) {
-        if (!current_thd->is_error())
-          villagesql_error("Length provided for non-parameterized type '%s'",
-                           MYF(0), descriptor->qualified_base_name().c_str());
+        thd->syntax_error_at(pos,
+                             "Type '%s' is not parameterized and cannot have a "
+                             "length specification",
+                             descriptor->qualified_base_name().c_str());
         return nullptr;
       }
       if (AcquireOrCreateTypeContext(descriptor, TypeParameters(),
@@ -231,6 +223,8 @@ class PT_custom_type : public PT_type {
         return nullptr;
     }
 
+    // in case type_context is still nullptr - PT_custom_type constructor will
+    // record the error
     PT_custom_type *ret = new (pt_mem_root)
         PT_custom_type(pos, thd, type_name, length, type_context);
     return ret;

--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -157,13 +157,14 @@ class PT_custom_type : public PT_type {
     const TypeContext *type_context = nullptr;
 
     // Handle types that accept a length spec. Note that this create function
-    // only handles TYPE(N) syntax and unparameterized types. Parameterized types with
-    // TYPE('key=value,...') syntax are handled by the other create() overload.
+    // only handles TYPE(N) syntax and unparameterized types. Parameterized
+    // types with TYPE('key=value,...') syntax are handled by the other create()
+    // overload.
     if (descriptor->is_parameterized()) {
-      // type provides resolve_params, check if also provides int_to_params for TYPE(N) syntax.
-      // In case it does, and length is provided, we will convert the length to parameters and
-      // resolve the TypeContext.
-      // In case it does, and length is not provided -> this is an error.
+      // type provides resolve_params, check if also provides int_to_params for
+      // TYPE(N) syntax. In case it does, and length is provided, we will
+      // convert the length to parameters and resolve the TypeContext. In case
+      // it does, and length is not provided -> this is an error.
       if (length != nullptr) {
         // TYPE(N) syntax used - convert N to parameters via callbacks
         if (!descriptor->int_to_params_fn().has_value()) {
@@ -200,7 +201,8 @@ class PT_custom_type : public PT_type {
           return nullptr;
         }
 
-        // resolve_params_and_context will call AcquireOrCreateTypeContext after resolving the parameters
+        // resolve_params_and_context will call AcquireOrCreateTypeContext after
+        // resolving the parameters
         if (resolve_params_and_context(pos, thd, descriptor, canonical.str(),
                                        type_context)) {
           return nullptr;
@@ -220,13 +222,12 @@ class PT_custom_type : public PT_type {
       // non parameterized type
       if (length != nullptr) {
         if (!current_thd->is_error())
-          villagesql_error(
-              "Length provided for non-parameterized type '%s'",
-              MYF(0), descriptor->qualified_base_name().c_str());
+          villagesql_error("Length provided for non-parameterized type '%s'",
+                           MYF(0), descriptor->qualified_base_name().c_str());
         return nullptr;
       }
-      if (AcquireOrCreateTypeContext(descriptor, TypeParameters(), *thd->mem_root,
-                                     type_context)) 
+      if (AcquireOrCreateTypeContext(descriptor, TypeParameters(),
+                                     *thd->mem_root, type_context))
         return nullptr;
     }
 

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -293,13 +293,20 @@ bool MaybeInjectCustomIndex(THD *thd, TABLE_SHARE &share, KEY *keyinfo) {
   return false;
 }
 
-bool ResolveTypeToContext(std::string_view extension_name,
-                          std::string_view type_name,
-                          const TypeParameters &parameters, MEM_ROOT &mem_root,
-                          const TypeContext *&result) {
+namespace {
+
+// Look up the TypeDescriptor for a (possibly extension-qualified) type name.
+// REQUIRES: caller holds the victionary read or write lock.
+// Returns true on internal failure. A type that simply isn't found returns
+// false with result set to nullptr.
+bool resolve_type_descriptor_locked(VictionaryClient &vclient,
+                                    std::string_view extension_name,
+                                    std::string_view type_name,
+                                    const TypeDescriptor *&result) {
   result = nullptr;
 
-  auto &vclient = VictionaryClient::instance();
+  vclient.assert_read_or_write_lock_held();
+
   if (should_assert_if_false(vclient.is_initialized())) {
     LogVSQL(ERROR_LEVEL,
             "Failed to resolve type %.*s; VictionaryClient not initialized",
@@ -309,8 +316,6 @@ bool ResolveTypeToContext(std::string_view extension_name,
 
   TypeDescriptorKeyPrefix prefix{std::string(type_name),
                                  std::string(extension_name)};
-
-  auto guard = vclient.get_write_lock();
   std::vector<const TypeDescriptor *> results =
       vclient.type_descriptors().get_prefix_committed(prefix);
 
@@ -320,30 +325,98 @@ bool ResolveTypeToContext(std::string_view extension_name,
     return true;
   }
 
-  // The type didn't resolve, which isn't a failure here. It probably is to the
-  // caller, but they will see result is nullptr.
   if (results.empty()) return false;
+  result = results[0];
+  return false;
+}
 
-  const TypeDescriptor *type_descriptor = results[0];
-  TypeDescriptorKey type_descriptor_key(type_descriptor->type_name(),
-                                        type_descriptor->extension_name(),
-                                        type_descriptor->extension_version());
+// Acquire (create if necessary) the cached TypeContext for a descriptor and
+// its parameters. REQUIRES: caller holds the victionary write lock.
+// Returns true on error (and sets the SQL error).
+bool acquire_or_create_type_context_locked(VictionaryClient &vclient,
+                                           const TypeDescriptor *descriptor,
+                                           const TypeParameters &parameters,
+                                           MEM_ROOT &mem_root,
+                                           const TypeContext *&result) {
+  vclient.assert_write_lock_held();
+
+  if (should_assert_if_null(descriptor)) {
+    LogVSQL(ERROR_LEVEL,
+            "Cannot acquire or create TypeContext for null descriptor");
+    return true;
+  }
+
+  TypeDescriptorKey type_descriptor_key(descriptor->type_name(),
+                                        descriptor->extension_name(),
+                                        descriptor->extension_version());
   TypeContextKey type_context_key(type_descriptor_key, parameters);
 
   result = vclient.type_contexts().acquire_or_create(type_context_key, mem_root,
-                                                     type_descriptor);
+                                                     descriptor);
   if (result == nullptr) {
     // nullptr means OOM (SQL error already set) or TypeContext initialization
     // failure (only logged to error log). Set the SQL error if not already set.
     if (!current_thd->is_error()) {
       villagesql_error(
           "Type '%s' failed to initialize; check the error log for details",
-          MYF(0), type_descriptor->qualified_base_name().c_str());
+          MYF(0), descriptor->qualified_base_name().c_str());
     }
     return true;
   }
-
   return false;
+}
+
+}  // namespace
+
+bool ResolveTypeDescriptor(std::string_view extension_name,
+                           std::string_view type_name,
+                           const TypeDescriptor *&result) {
+  auto &vclient = VictionaryClient::instance();
+  auto guard = vclient.get_read_lock();
+  return resolve_type_descriptor_locked(vclient, extension_name, type_name,
+                                        result);
+}
+
+bool AcquireOrCreateTypeContext(const TypeDescriptor *descriptor,
+                                const TypeParameters &parameters,
+                                MEM_ROOT &mem_root,
+                                const TypeContext *&result) {
+  result = nullptr;
+  assert(descriptor != nullptr);
+  auto &vclient = VictionaryClient::instance();
+  auto guard = vclient.get_write_lock();
+  return acquire_or_create_type_context_locked(vclient, descriptor, parameters,
+                                               mem_root, result);
+}
+
+// Fills *result with a TypeContext based on the type_name given. If
+// extension_name is non-empty, filters results to match that extension
+// (for qualified names like extension_name.type_name).
+// Returns false on success and true on failure. If the type isn't known the
+// function will return false (success), but the result will be nullptr. The
+// mem_root is used to scope the cleanup of the TypeContext.
+static bool ResolveTypeToContext(std::string_view extension_name,
+                                 std::string_view type_name,
+                                 const TypeParameters &parameters,
+                                 MEM_ROOT &mem_root,
+                                 const TypeContext *&result) {
+  result = nullptr;
+
+  auto &vclient = VictionaryClient::instance();
+  auto guard = vclient.get_write_lock();
+
+  const TypeDescriptor *type_descriptor = nullptr;
+  if (resolve_type_descriptor_locked(vclient, extension_name, type_name,
+                                     type_descriptor)) {
+    return true;
+  }
+
+  // The type didn't resolve, which isn't a failure here. It probably is to the
+  // caller, but they will see result is nullptr.
+  if (type_descriptor == nullptr) return false;
+
+  return acquire_or_create_type_context_locked(vclient, type_descriptor,
+                                               parameters, mem_root, result);
 }
 
 bool HasCustomTypeColumns(const List<Create_field> &create_list) {
@@ -1334,7 +1407,6 @@ void RemoveTmpTableMetadata(THD *thd, TABLE *table) {
   if (!table) return;
   RemoveTmpTableMetadata(thd, table->s->db.str, table->s->table_name.str);
 }
-
 
 void PrepareAlterCustomFields(THD *thd, const List<Create_field> &create_list) {
   thd->villagesql_alter_custom_fields.clear();

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -308,9 +308,11 @@ bool resolve_type_descriptor_locked(VictionaryClient &vclient,
   vclient.assert_read_or_write_lock_held();
 
   if (should_assert_if_false(vclient.is_initialized())) {
-    LogVSQL(ERROR_LEVEL,
-            "Failed to resolve type %.*s; VictionaryClient not initialized",
-            static_cast<int>(type_name.size()), type_name.data());
+    if (!current_thd->is_error()) {
+      villagesql_error(
+          "Failed to resolve type %.*s; VictionaryClient not initialized",
+          MYF(0), static_cast<int>(type_name.size()), type_name.data());
+    }
     return true;
   }
 
@@ -320,8 +322,11 @@ bool resolve_type_descriptor_locked(VictionaryClient &vclient,
       vclient.type_descriptors().get_prefix_committed(prefix);
 
   if (should_assert_if_true(results.size() > 1)) {
-    LogVSQL(ERROR_LEVEL, "Found more than one entry for type %.*s",
-            static_cast<int>(type_name.size()), type_name.data());
+    if (!current_thd->is_error()) {
+      villagesql_error(
+          "Failed to resolve type %.*s; VictionaryClient not initialized",
+          MYF(0), static_cast<int>(type_name.size()), type_name.data());
+    }
     return true;
   }
 
@@ -341,8 +346,11 @@ bool acquire_or_create_type_context_locked(VictionaryClient &vclient,
   vclient.assert_write_lock_held();
 
   if (should_assert_if_null(descriptor)) {
-    LogVSQL(ERROR_LEVEL,
-            "Cannot acquire or create TypeContext for null descriptor");
+    if (!current_thd->is_error()) {
+      villagesql_error(
+          "Type '%s' failed to initialize; cannot acquire or create TypeContext for null descriptor",
+          MYF(0), descriptor->qualified_base_name().c_str());
+    }
     return true;
   }
 
@@ -403,9 +411,9 @@ static bool ResolveTypeToContext(std::string_view extension_name,
   result = nullptr;
 
   auto &vclient = VictionaryClient::instance();
+  const TypeDescriptor *type_descriptor = nullptr;
   auto guard = vclient.get_write_lock();
 
-  const TypeDescriptor *type_descriptor = nullptr;
   if (resolve_type_descriptor_locked(vclient, extension_name, type_name,
                                      type_descriptor)) {
     return true;

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -348,7 +348,8 @@ bool acquire_or_create_type_context_locked(VictionaryClient &vclient,
   if (should_assert_if_null(descriptor)) {
     if (!current_thd->is_error()) {
       villagesql_error(
-          "Type '%s' failed to initialize; cannot acquire or create TypeContext for null descriptor",
+          "Type '%s' failed to initialize; cannot acquire or create "
+          "TypeContext for null descriptor",
           MYF(0), descriptor->qualified_base_name().c_str());
     }
     return true;

--- a/villagesql/types/util.h
+++ b/villagesql/types/util.h
@@ -96,17 +96,22 @@ extern void BuildQualifiedParamsString(THD *thd, enum_sp_type sp_type,
                                        const sp_pcontext *root_ctx,
                                        LEX_STRING *out);
 
-// Fills *result with a TypeContext based on the type_name given. If
-// extension_name is non-empty, filters results to match that extension
-// (for qualified names like extension_name.type_name).
-// Returns false on success and true on failure. If the type isn't known the
-// function will return false (success), but the result will be nullptr. The
-// mem_root is used to scope the cleanup of the TypeContext.
-extern bool ResolveTypeToContext(std::string_view extension_name,
-                                 std::string_view type_name,
-                                 const TypeParameters &parameters,
-                                 MEM_ROOT &mem_root,
-                                 const TypeContext *&result);
+// Looks up just the TypeDescriptor for a (possibly extension-qualified) type
+// name. Returns false on success and true on internal failure.
+// If the type isn't known the function returns false (success) with result
+// nullptr.
+extern bool ResolveTypeDescriptor(std::string_view extension_name,
+                                  std::string_view type_name,
+                                  const TypeDescriptor *&result);
+
+// Acquires (create if necessary) the cached TypeContext for an already
+// resolved TypeDescriptor and its concrete parameters. The descriptor must be
+// non-null (typically obtained from ResolveTypeDescriptor). The mem_root scopes
+// the cleanup of the TypeContext. Returns false on success and true on failure.
+extern bool AcquireOrCreateTypeContext(const TypeDescriptor *descriptor,
+                                       const TypeParameters &parameters,
+                                       MEM_ROOT &mem_root,
+                                       const TypeContext *&result);
 
 // Pre-populate session-local temporary metadata from Create_field list so that
 // MaybeInjectCustomType can inject type contexts during open_table_from_share


### PR DESCRIPTION
PT_custom_type::create() resolved the type by calling ResolveTypeToContext with empty parameters before it knew the concrete parameters. Because ResolveTypeToContext both looks up the TypeDescriptor and acquire_or_creates (and caches) a TypeContext, this populated the victionary with a spurious empty-params TypeContext for every parameterized type, only to create the correctly-keyed parameterized TypeContext moments later.

Split the two responsibilities so the descriptor can be inspected before a TypeContext is materialized:

- Add ResolveTypeDescriptor() (read-locked descriptor lookup, no context) and AcquireOrCreateTypeContext() (acquire/create a context for a descriptor + params). ResolveTypeToContext() is reimplemented on top of two file-local *_locked helpers, keeping its single write-lock acquisition unchanged for existing callers.
- Both create() factories now resolve the descriptor first, branch on its characteristics (fixed- vs variable-length, int_to_params/resolve_params), and create the TypeContext exactly once with the resolved parameters. The parameterized path no longer caches an empty-params context.
- resolve_params_and_context() takes the descriptor in hand and calls AcquireOrCreateTypeContext() directly, dropping a redundant descriptor lookup.

Behavior is preserved: unknown type names still construct a PT_custom_type with a null context so the constructor records the syntax error, and the unknown-params (bare parameterized type) case still resolves to an empty-params TypeContext.

No functional change to error messages: the create() paths previously read TypeContext::qualified_name() of the empty-params context, which equals the descriptor's qualified_base_name().

