### PR TITLE
fix: replace hardcoded my_charset_utf8mb4_0900_ai_ci with system_charset_info

### DIFF
--- a/villagesql/schema/systable/helpers.cc
+++ b/villagesql/schema/systable/helpers.cc
@@ -164,7 +164,7 @@ const CHARSET_INFO *get_identifier_charset() {
   if (::lower_case_table_names == 0) {
     return &my_charset_utf8mb4_bin;  // Case-sensitive
   }
-  return &my_charset_utf8mb4_0900_ai_ci;  // Case-insensitive
+  return system_charset_info;  // Case-insensitive
 }
 
 std::string normalize_database_name(const std::string &name) {
@@ -185,7 +185,7 @@ std::string normalize_table_name(const std::string &name) {
 
 std::string normalize_column_name(const std::string &name) {
   // Column names are always case-insensitive in MySQL
-  return casedn(&my_charset_utf8mb4_0900_ai_ci, name);
+  return casedn(system_charset_info, name);
 }
 
 std::string normalize_extension_name(const std::string &name) {
@@ -197,13 +197,13 @@ std::string normalize_extension_name(const std::string &name) {
 
 std::string normalize_type_name(const std::string &name) {
   // Type names should be case-insensitive (like SQL type names)
-  return casedn(&my_charset_utf8mb4_0900_ai_ci, name);
+  return casedn(system_charset_info, name);
 }
 
 std::string normalize_index_name(const std::string &name) {
   // Index names are always case-insensitive in MySQL, regardless of
   // lower_case_table_names (which only governs table/database identifiers).
-  return casedn(&my_charset_utf8mb4_0900_ai_ci, name);
+  return casedn(system_charset_info, name);
 }
 
 // ===== Test utilities =====


### PR DESCRIPTION

**Remove hardcoded `my_charset_utf8mb4_0900_ai_ci` in identifier normalization functions**

Closes #353 | Internal tracker: 130

## What

Replaces three remaining hardcded `&my_charset_utf8mb4_0900_ai_ci` references in `villagesql/schema/systable/helpers.cc` with `system_charset_info`:

- `get_identifier_charset()` — case-insensitive branch
- `normalize_column_name()`
- `normalize_type_name()`
- `normalize_index_name()`

`normalize_extension_name()` was already corrected in a prior change and includes a TODO pointing at these remaining sites.

## Why

These functions normalize VEF identifiers (extension names, type names, column names, index names) for case-insensitive comparison and storage. Identifiers are metadata, not user data, so they should use `system_charset_info` — the same charset MySQL uses internally for all DD identifier handling — rather than a hardcoded collation.

Hardcoding `my_charset_utf8mb4_0900_ai_ci` is fragile because it bypasses the server's charset infrastructure and creates an invisible assumption that the server will always use that specific collation for identifier folding. Using `system_charset_info` is consistent with how `normalize_extension_name()` already works and with MySQL's own convention for identifier normalization.

## Testing

Existing unit tests in `unittest/gunit/villagesql/victionary_client-t.cc` cover basic case folding for all affected functions. Run with:

```bash
make -j $(($(nproc) - 2)) villagesql-unit-tests && ctest -L villagesql -R victionary_client -V
```

## Checklist

- [x] I have signed the CLA
- [X] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [X] I have added or updated tests as appropriate
- [X] My changes maintain compatibility with upstream MySQL 8.4
