### PR TITLE
ci: capture per-worker MTR error logs

### DIFF
--- a/.github/workflows/extension-compat.yml
+++ b/.github/workflows/extension-compat.yml
@@ -241,7 +241,12 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: mtr-results-${{ matrix.extension }}-${{ matrix.platform }}-${{ matrix.abi }}
-          path: ${{ env.PACKAGE_DIR }}/mysql-test/var/log/
+          # var/log/ holds the default error log and per-test save dirs; under
+          # --parallel each worker writes its mysqld.N.err to var/<N>/log/, so
+          # capture both or the server-side failure reason is lost.
+          path: |
+            ${{ env.PACKAGE_DIR }}/mysql-test/var/log/
+            ${{ env.PACKAGE_DIR }}/mysql-test/var/*/log/
 
   # Sends a Slack summary after all test jobs complete.
   # Runs automatically (workflow_run) or when notify is true (workflow_dispatch).


### PR DESCRIPTION
## Description
The extension-compat MTR failure-upload only collected var/log/, but MTR runs with --parallel so each worker writes its mysqld.N.err under var/<N>/log/. Server-side failure reasons (e.g. a listener bind error) never made it into the artifact, leaving intermittent failures like vsql-rest.rest_https undiagnosable. Also collect var/*/log/.
AI=CLAUDE

## Related Issue
nightly extension test run flakiness for vsql-rest

## How was this tested?
YAML validated
 Confirmed against a real `--parallel` MTR run

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
