### PR TITLE
buf_size assert fix

### DIFF
--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -273,9 +273,10 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
     // keep the max.
     if (m_return_type_context != nullptr) {
       const int64_t buffer_len = m_return_type_context->field_buffer_length();
-      assert(buffer_len > 0);
+      assert(!m_return_type_context->is_variable_length() || buffer_len > 0);
       // TODO(villagesql): refactor to MaybeResizeBuffer()
-      if (static_cast<size_t>(buffer_len) > m_result_buffer_size) {
+      if (buffer_len > 0 &&
+          static_cast<size_t>(buffer_len) > m_result_buffer_size) {
         m_result_buffer_size = static_cast<size_t>(buffer_len);
         m_result_buffer =
             pointer_cast<char *>((*THR_MALLOC)->Alloc(m_result_buffer_size));


### PR DESCRIPTION
It is possible for persisted_length to be -1 for a parameterized type. If we call a VDF before resolve_params has had a chance to run, we rely on the VDF’s buffer_size() when allocating the result buffer. This is why m_return_type_context->field_buffer_length() == -1 should not trigger the assert.