### PR TITLE
Add build time information to the binary

### DIFF
--- a/mysql-test/suite/sys_vars/r/villagesql_build_info_basic.result
+++ b/mysql-test/suite/sys_vars/r/villagesql_build_info_basic.result
@@ -1,0 +1,14 @@
+# Test VillageSQL Build Info System Variable
+# This test verifies that the villagesql_build_info system variable works correctly
+# Test 1: Check that the variable exists and is readable
+SHOW VARIABLES LIKE 'villagesql_build_info';
+Variable_name	Value
+villagesql_build_info	{"git_sha":"SHA","files_added":N,"files_deleted":N,"files_modified":N,"build_timestamp":"TS","build_host":"HOST","build_os":"OS","build_arch":"ARCH"}
+SELECT @@GLOBAL.villagesql_build_info AS build_info;
+build_info
+{"git_sha":"SHA","files_added":N,"files_deleted":N,"files_modified":N,"build_timestamp":"TS","build_host":"HOST","build_os":"OS","build_arch":"ARCH"}
+# Test 2: Verify the variable is READ_ONLY
+SET GLOBAL villagesql_build_info = '999';
+ERROR HY000: Variable 'villagesql_build_info' is a read only variable
+SET SESSION villagesql_build_info = '999';
+ERROR HY000: Variable 'villagesql_build_info' is a read only variable

--- a/mysql-test/suite/sys_vars/t/villagesql_build_info_basic.test
+++ b/mysql-test/suite/sys_vars/t/villagesql_build_info_basic.test
@@ -1,0 +1,21 @@
+# Test VillageSQL build info system variable
+
+--echo # Test VillageSQL Build Info System Variable
+--echo # This test verifies that the villagesql_build_info system variable works correctly
+
+--echo # Test 1: Check that the variable exists and is readable
+# The value is build/machine specific (git SHA, file counts, timestamp, host,
+# OS, arch), so redact every field to a placeholder and assert only the JSON
+# structure and keys.
+--replace_regex /"git_sha":"[^"]*"/"git_sha":"SHA"/ /"files_added":[0-9]+/"files_added":N/ /"files_deleted":[0-9]+/"files_deleted":N/ /"files_modified":[0-9]+/"files_modified":N/ /"build_timestamp":"[^"]*"/"build_timestamp":"TS"/ /"build_host":"[^"]*"/"build_host":"HOST"/ /"build_os":"[^"]*"/"build_os":"OS"/ /"build_arch":"[^"]*"/"build_arch":"ARCH"/
+SHOW VARIABLES LIKE 'villagesql_build_info';
+
+--replace_regex /"git_sha":"[^"]*"/"git_sha":"SHA"/ /"files_added":[0-9]+/"files_added":N/ /"files_deleted":[0-9]+/"files_deleted":N/ /"files_modified":[0-9]+/"files_modified":N/ /"build_timestamp":"[^"]*"/"build_timestamp":"TS"/ /"build_host":"[^"]*"/"build_host":"HOST"/ /"build_os":"[^"]*"/"build_os":"OS"/ /"build_arch":"[^"]*"/"build_arch":"ARCH"/
+SELECT @@GLOBAL.villagesql_build_info AS build_info;
+
+--echo # Test 2: Verify the variable is READ_ONLY
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET GLOBAL villagesql_build_info = '999';
+
+--error ER_INCORRECT_GLOBAL_LOCAL_VAR
+SET SESSION villagesql_build_info = '999';

--- a/villagesql/cmake/gen_build_info.cmake
+++ b/villagesql/cmake/gen_build_info.cmake
@@ -19,11 +19,13 @@
 #
 # Volatile values (git SHA, work-tree file counts, timestamp, host) are
 # computed here. Stable values are passed in via -D by the caller:
-#   IN_FILE    - path to build_info.cc.in
-#   OUT_FILE   - path to the generated build_info.cc
-#   SRC_DIR    - source tree to inspect with git
-#   BUILD_OS   - host OS string (CMAKE_HOST_SYSTEM)
-#   BUILD_ARCH - host architecture (CMAKE_HOST_SYSTEM_PROCESSOR)
+#   IN_FILE          - path to build_info.cc.in
+#   OUT_FILE         - path to the generated build_info.cc
+#   SRC_DIR          - source tree to inspect with git
+#   BUILD_OS         - host OS string (CMAKE_HOST_SYSTEM)
+#   BUILD_ARCH       - host architecture (CMAKE_HOST_SYSTEM_PROCESSOR)
+#   PRODUCTION_BUILD - if true, blank the volatile, non-reproducible fields
+#                      (build timestamp and host) for reproducible releases
 
 find_package(Git QUIET)
 
@@ -69,5 +71,18 @@ endif()
 string(TIMESTAMP BUILD_TIMESTAMP "%Y-%m-%dT%H:%M:%SZ" UTC)
 
 cmake_host_system_information(RESULT BUILD_HOST QUERY HOSTNAME)
+
+# Production releases blank the volatile, non-reproducible fields so identical
+# sources yield identical binaries (and incremental builds stop relinking just
+# to refresh the timestamp). The work-tree counts are forced to zero so a
+# release always reports clean (is_dirty() == false); git_sha, OS and arch stay
+# populated.
+if(PRODUCTION_BUILD)
+  set(GIT_FILES_ADDED 0)
+  set(GIT_FILES_DELETED 0)
+  set(GIT_FILES_MODIFIED 0)
+  set(BUILD_TIMESTAMP "")
+  set(BUILD_HOST "")
+endif()
 
 configure_file("${IN_FILE}" "${OUT_FILE}" @ONLY)

--- a/villagesql/cmake/gen_build_info.cmake
+++ b/villagesql/cmake/gen_build_info.cmake
@@ -1,0 +1,73 @@
+# Copyright (c) 2026 VillageSQL Contributors
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+# Generates villagesql/common/build_info.cc from build_info.cc.in with fresh
+# build metadata. Run at build time via `cmake -P` (not at configure time) so
+# the git state and timestamp reflect the moment of the build.
+#
+# Volatile values (git SHA, work-tree file counts, timestamp, host) are
+# computed here. Stable values are passed in via -D by the caller:
+#   IN_FILE    - path to build_info.cc.in
+#   OUT_FILE   - path to the generated build_info.cc
+#   SRC_DIR    - source tree to inspect with git
+#   BUILD_OS   - host OS string (CMAKE_HOST_SYSTEM)
+#   BUILD_ARCH - host architecture (CMAKE_HOST_SYSTEM_PROCESSOR)
+
+find_package(Git QUIET)
+
+set(GIT_SHA "unknown")
+set(GIT_FILES_ADDED 0)
+set(GIT_FILES_DELETED 0)
+set(GIT_FILES_MODIFIED 0)
+
+if(GIT_EXECUTABLE)
+  execute_process(COMMAND ${GIT_EXECUTABLE} -C "${SRC_DIR}" rev-parse HEAD
+    OUTPUT_VARIABLE GIT_SHA OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+  if(NOT GIT_SHA)
+    set(GIT_SHA "unknown")
+  endif()
+
+  # Count work-tree divergence from HEAD by status code, one bucket per file.
+  # Untracked ("??") files count as added alongside staged adds ("A"); a clean
+  # tree leaves all three counts at zero.
+  execute_process(COMMAND ${GIT_EXECUTABLE} -C "${SRC_DIR}" status --porcelain
+    OUTPUT_VARIABLE _status OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET)
+  if(_status)
+    string(REPLACE "\n" ";" _lines "${_status}")
+    foreach(_line IN LISTS _lines)
+      string(SUBSTRING "${_line}" 0 2 _xy)
+      if(_xy STREQUAL "??")
+        math(EXPR GIT_FILES_ADDED "${GIT_FILES_ADDED} + 1")
+      else()
+        string(SUBSTRING "${_xy}" 0 1 _x)
+        string(SUBSTRING "${_xy}" 1 1 _y)
+        if(_x STREQUAL "A" OR _y STREQUAL "A")
+          math(EXPR GIT_FILES_ADDED "${GIT_FILES_ADDED} + 1")
+        elseif(_x STREQUAL "D" OR _y STREQUAL "D")
+          math(EXPR GIT_FILES_DELETED "${GIT_FILES_DELETED} + 1")
+        elseif(_x STREQUAL "M" OR _y STREQUAL "M")
+          math(EXPR GIT_FILES_MODIFIED "${GIT_FILES_MODIFIED} + 1")
+        endif()
+      endif()
+    endforeach()
+  endif()
+endif()
+
+# Honors SOURCE_DATE_EPOCH automatically (CMake >= 3.8) for reproducible builds.
+string(TIMESTAMP BUILD_TIMESTAMP "%Y-%m-%dT%H:%M:%SZ" UTC)
+
+cmake_host_system_information(RESULT BUILD_HOST QUERY HOSTNAME)
+
+configure_file("${IN_FILE}" "${OUT_FILE}" @ONLY)

--- a/villagesql/common/CMakeLists.txt
+++ b/villagesql/common/CMakeLists.txt
@@ -17,9 +17,32 @@ SET(VILLAGESQL_COMMON_SOURCES
   semver.cc
 )
 
+# Generated build metadata (git SHA, work-tree file counts, build timestamp,
+# host). The generator target is always considered out of date, so every build
+# refreshes the timestamp. Only the generated build_info.cc recompiles: callers
+# include the stable, committed build_info.h, so they are unaffected.
+SET(VILLAGESQL_BUILD_INFO_CC ${CMAKE_CURRENT_BINARY_DIR}/build_info.cc)
+
+ADD_CUSTOM_TARGET(villagesql_build_info_gen
+  BYPRODUCTS ${VILLAGESQL_BUILD_INFO_CC}
+  COMMAND ${CMAKE_COMMAND}
+    -DSRC_DIR=${CMAKE_SOURCE_DIR}
+    -DIN_FILE=${CMAKE_CURRENT_SOURCE_DIR}/build_info.cc.in
+    -DOUT_FILE=${VILLAGESQL_BUILD_INFO_CC}
+    -DBUILD_OS=${CMAKE_HOST_SYSTEM}
+    -DBUILD_ARCH=${CMAKE_HOST_SYSTEM_PROCESSOR}
+    -P ${CMAKE_SOURCE_DIR}/villagesql/cmake/gen_build_info.cmake
+  COMMENT "Generating VillageSQL build info"
+  VERBATIM)
+
+SET_SOURCE_FILES_PROPERTIES(${VILLAGESQL_BUILD_INFO_CC} PROPERTIES GENERATED TRUE)
+
 # Object library for compilation into sql_main (avoids circular dependencies)
 ADD_LIBRARY(villagesql_common OBJECT
-  ${VILLAGESQL_COMMON_SOURCES})
+  ${VILLAGESQL_COMMON_SOURCES}
+  ${VILLAGESQL_BUILD_INFO_CC})
+
+ADD_DEPENDENCIES(villagesql_common villagesql_build_info_gen)
 
 TARGET_LINK_LIBRARIES(villagesql_common PRIVATE extra::rapidjson)
 

--- a/villagesql/common/CMakeLists.txt
+++ b/villagesql/common/CMakeLists.txt
@@ -23,6 +23,15 @@ SET(VILLAGESQL_COMMON_SOURCES
 # include the stable, committed build_info.h, so they are unaffected.
 SET(VILLAGESQL_BUILD_INFO_CC ${CMAKE_CURRENT_BINARY_DIR}/build_info.cc)
 
+# Production releases (no pre-release suffix) blank the volatile,
+# non-reproducible fields (build timestamp and host) so release binaries are
+# reproducible; dev builds keep them. The single template is shared by both.
+if(VSQL_HAS_PRE_RELEASE)
+  set(VSQL_BUILD_INFO_PRODUCTION OFF)
+else()
+  set(VSQL_BUILD_INFO_PRODUCTION ON)
+endif()
+
 ADD_CUSTOM_TARGET(villagesql_build_info_gen
   BYPRODUCTS ${VILLAGESQL_BUILD_INFO_CC}
   COMMAND ${CMAKE_COMMAND}
@@ -31,6 +40,7 @@ ADD_CUSTOM_TARGET(villagesql_build_info_gen
     -DOUT_FILE=${VILLAGESQL_BUILD_INFO_CC}
     -DBUILD_OS=${CMAKE_HOST_SYSTEM}
     -DBUILD_ARCH=${CMAKE_HOST_SYSTEM_PROCESSOR}
+    -DPRODUCTION_BUILD=${VSQL_BUILD_INFO_PRODUCTION}
     -P ${CMAKE_SOURCE_DIR}/villagesql/cmake/gen_build_info.cmake
   COMMENT "Generating VillageSQL build info"
   VERBATIM)

--- a/villagesql/common/build_info.cc.in
+++ b/villagesql/common/build_info.cc.in
@@ -35,6 +35,10 @@ constexpr BuildInfo kBuildInfo = {
 
 }  // namespace
 
+bool BuildInfo::is_dirty() const {
+  return files_added != 0 || files_deleted != 0 || files_modified != 0;
+}
+
 const BuildInfo &GetBuildInfo() { return kBuildInfo; }
 
 }  // namespace villagesql

--- a/villagesql/common/build_info.cc.in
+++ b/villagesql/common/build_info.cc.in
@@ -1,0 +1,40 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Generated from build_info.cc.in by cmake/gen_build_info.cmake at build time.
+// Do not edit; edit the template instead.
+
+#include "villagesql/include/build_info.h"
+
+namespace villagesql {
+namespace {
+
+constexpr BuildInfo kBuildInfo = {
+    "@GIT_SHA@",
+    @GIT_FILES_ADDED@,
+    @GIT_FILES_DELETED@,
+    @GIT_FILES_MODIFIED@,
+    "@BUILD_TIMESTAMP@",
+    "@BUILD_HOST@",
+    "@BUILD_OS@",
+    "@BUILD_ARCH@",
+};
+
+}  // namespace
+
+const BuildInfo &GetBuildInfo() { return kBuildInfo; }
+
+}  // namespace villagesql

--- a/villagesql/include/build_info.h
+++ b/villagesql/include/build_info.h
@@ -1,0 +1,52 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef VILLAGESQL_INCLUDE_BUILD_INFO_H_
+#define VILLAGESQL_INCLUDE_BUILD_INFO_H_
+
+namespace villagesql {
+
+// Metadata describing how this server binary was built. The values are baked
+// in at build time by the generated build_info.cc (see common/build_info.cc.in
+// and cmake/gen_build_info.cmake).
+//
+// This API header is hand-written, committed, and stable: it deliberately
+// contains no volatile values, so callers that include it do not recompile
+// when only the build timestamp or git state change. Only the generated
+// build_info.cc is rebuilt on each build.
+//
+// The git_sha pins the source revision; the three counts describe how far the
+// build tree diverged from that revision. A clean (unmodified) tree has
+// files_added == files_deleted == files_modified == 0. Version information is
+// not captured here; use villagesql::GetBuildVersion() (Semver) for that.
+struct BuildInfo {
+  const char *git_sha;          // full 40-char commit SHA, or "unknown"
+  int files_added;              // added + untracked files (git status A, ??)
+  int files_deleted;            // deleted files (git status D)
+  int files_modified;           // modified files (git status M)
+  const char *build_timestamp;  // ISO-8601 UTC, e.g. "2026-06-17T12:34:56Z"
+  const char *build_host;       // hostname of the machine that built it
+  const char *build_os;         // host OS, e.g. "Linux-6.8.0"
+  const char *build_arch;       // host architecture, e.g. "x86_64"
+};
+
+// Returns the build metadata baked into this binary. The reference is to a
+// constexpr instance with static storage duration; it is always valid.
+const BuildInfo &GetBuildInfo();
+
+}  // namespace villagesql
+
+#endif  // VILLAGESQL_INCLUDE_BUILD_INFO_H_

--- a/villagesql/include/build_info.h
+++ b/villagesql/include/build_info.h
@@ -41,6 +41,10 @@ struct BuildInfo {
   const char *build_host;       // hostname of the machine that built it
   const char *build_os;         // host OS, e.g. "Linux-6.8.0"
   const char *build_arch;       // host architecture, e.g. "x86_64"
+
+  // True if the build tree diverged from git_sha, i.e. any of the file-change
+  // counts is non-zero.
+  bool is_dirty() const;
 };
 
 // Returns the build metadata baked into this binary. The reference is to a

--- a/villagesql/sql/initialize.cc
+++ b/villagesql/sql/initialize.cc
@@ -15,12 +15,18 @@
  */
 #include "villagesql/sql/initialize.h"
 
+#include "my_rapidjson_size_t.h"  // IWYU pragma: keep
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
 #include "sql/bootstrap.h"
 #include "sql/dd/cache/dictionary_client.h"
 #include "sql/sd_notify.h"
 #include "sql/sys_vars.h"
 #include "sql/thd_raii.h"
 #include "sql/transaction.h"
+#include "villagesql/include/build_info.h"
 #include "villagesql/include/error.h"
 #include "villagesql/include/version.h"
 #include "villagesql/schema/schema_manager.h"
@@ -81,6 +87,52 @@ const uchar *Sys_var_villagesql_server_version::global_value_ptr(
 
 static Sys_var_villagesql_server_version Sys_villagesql_server_version(
     "villagesql_server_version", "VillageSQL server version.");
+
+class Sys_var_villagesql_build_info : public Sys_var_charptr_func {
+ public:
+  Sys_var_villagesql_build_info(const char *name_arg, const char *comment_arg)
+      : Sys_var_charptr_func(name_arg, comment_arg, GLOBAL) {}
+  const uchar *global_value_ptr(THD *thd, std::string_view) override;
+};
+
+const uchar *Sys_var_villagesql_build_info::global_value_ptr(THD *thd,
+                                                             std::string_view) {
+  const BuildInfo &info = villagesql::GetBuildInfo();
+
+  rapidjson::StringBuffer sb;
+  rapidjson::Writer<rapidjson::StringBuffer> w(sb);
+  w.StartObject();
+  w.Key("git_sha");
+  w.String(info.git_sha);
+  w.Key("files_added");
+  w.Int(info.files_added);
+  w.Key("files_deleted");
+  w.Int(info.files_deleted);
+  w.Key("files_modified");
+  w.Int(info.files_modified);
+  w.Key("build_timestamp");
+  w.String(info.build_timestamp);
+  w.Key("build_host");
+  w.String(info.build_host);
+  w.Key("build_os");
+  w.String(info.build_os);
+  w.Key("build_arch");
+  w.String(info.build_arch);
+  w.EndObject();
+
+  size_t buf_size = sb.GetSize() + 1;
+  char *buf = (char *)thd->alloc(buf_size);
+  if (should_assert_if_null(buf))
+    my_error(ER_OUTOFMEMORY, MYF(ME_FATALERROR), buf_size);
+  else
+    std::copy(sb.GetString(), sb.GetString() + sb.GetSize() + 1, buf);
+  return (uchar *)buf;
+}
+
+static Sys_var_villagesql_build_info Sys_villagesql_build_info(
+    "villagesql_build_info",
+    "VillageSQL build metadata (JSON: git SHA, work-tree file counts, build "
+    "timestamp/host/OS/arch).");
 
 static Sys_var_uint Sys_villagesql_vef_server_protocol(
     "villagesql_vef_server_protocol",

--- a/villagesql/sql/initialize.cc
+++ b/villagesql/sql/initialize.cc
@@ -104,6 +104,8 @@ const uchar *Sys_var_villagesql_build_info::global_value_ptr(THD *thd,
   w.StartObject();
   w.Key("git_sha");
   w.String(info.git_sha);
+  w.Key("is_dirty");
+  w.Bool(info.is_dirty());
   w.Key("files_added");
   w.Int(info.files_added);
   w.Key("files_deleted");


### PR DESCRIPTION
## Description

Adds a variety of easily acquired build time information for binary tracking.

## Related Issue

One increment of the work on Cleanup Release Process #595 

## How was this tested?

Unit tests added as part of submission.

In the mysql client, the "show global variables like 'village%' ;" command shows the villagesql_build_info variable with the full JSON value.

The "SELECT JSON_VALUE(@@global.villagesql_build_info, '$.build_timestamp') AS build_timestamp;" displays the build timestamp as expected.