### PR TITLE
ci: post PR comments via issues endpoint

### DIFF
--- a/.github/workflows/extension-compat-suite.yml
+++ b/.github/workflows/extension-compat-suite.yml
@@ -314,8 +314,11 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BODY="$(./scripts/ci_helpers/villagesql_ext_compat_summary.sh \
             extresults '${{ needs.build-server.result }}' "$RUN_URL")"
-          gh pr comment "${{ inputs.pr_number }}" \
-            --repo "${{ github.repository }}" --body "$BODY"
+          # REST issues-comments endpoint works with issues:write (gh pr comment
+          # uses GraphQL addComment, which needs pull-requests:write).
+          gh api --method POST \
+            "repos/${{ github.repository }}/issues/${{ inputs.pr_number }}/comments" \
+            -f body="$BODY" >/dev/null
 
   # Sends a Slack summary after all test jobs complete (nightly / dispatch).
   slack_notify:

--- a/.github/workflows/extension-compat-suite.yml
+++ b/.github/workflows/extension-compat-suite.yml
@@ -314,8 +314,7 @@ jobs:
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           BODY="$(./scripts/ci_helpers/villagesql_ext_compat_summary.sh \
             extresults '${{ needs.build-server.result }}' "$RUN_URL")"
-          # REST issues-comments endpoint works with issues:write (gh pr comment
-          # uses GraphQL addComment, which needs pull-requests:write).
+          # Cf. slash-commands.yml; grep for "issues-comments endpoint".
           gh api --method POST \
             "repos/${{ github.repository }}/issues/${{ inputs.pr_number }}/comments" \
             -f body="$BODY" >/dev/null

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -123,5 +123,8 @@ jobs:
         RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         BODY="$(printf '## %s \`/testall\` %s\n\nFull test suite (unit + big + all suites) finished with result \`%s\`.\n\n[View run](%s)' \
           "$ICON" "$RESULT" "$RESULT" "$RUN_URL")"
-        gh pr comment "${{ inputs.pr_number }}" \
-          --repo "${{ github.repository }}" --body "$BODY"
+        # REST issues-comments endpoint works with issues:write (gh pr comment
+        # uses GraphQL addComment, which needs pull-requests:write).
+        gh api --method POST \
+          "repos/${{ github.repository }}/issues/${{ inputs.pr_number }}/comments" \
+          -f body="$BODY" >/dev/null

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -123,8 +123,7 @@ jobs:
         RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
         BODY="$(printf '## %s \`/testall\` %s\n\nFull test suite (unit + big + all suites) finished with result \`%s\`.\n\n[View run](%s)' \
           "$ICON" "$RESULT" "$RESULT" "$RUN_URL")"
-        # REST issues-comments endpoint works with issues:write (gh pr comment
-        # uses GraphQL addComment, which needs pull-requests:write).
+        # Cf. slash-commands.yml; grep for "issues-comments endpoint".
         gh api --method POST \
           "repos/${{ github.repository }}/issues/${{ inputs.pr_number }}/comments" \
           -f body="$BODY" >/dev/null

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -66,7 +66,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          post() { gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$1"; }
+          # Post via the REST issues-comments endpoint (works with
+          # issues:write); gh pr comment uses GraphQL addComment, which would
+          # require pull-requests:write.
+          post() {
+            gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" \
+              -f body="$1" >/dev/null
+          }
           stop() { echo "should_run=false" >> "$GITHUB_OUTPUT"; exit 0; }
           help_text() {
             printf '**Slash commands**\n\n'

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -11,7 +11,9 @@ name: Slash Commands
 # To add a command:
 #   1. Ensure a reusable workflow exists (uses: ./.github/workflows/<x>.yml).
 #   2. Add it to COMMANDS in the parse step (for validation + /help).
-#   3. Add a `run-<command>` caller job below, gated on the command name.
+#   3. Add a contains(...) clause for it to the parse job's `if:` gate, so the
+#      comment provisions a runner (the gate can't read COMMANDS).
+#   4. Add a `run-<command>` caller job below, gated on the command name.
 
 on:
   issue_comment:
@@ -32,13 +34,20 @@ jobs:
   parse:
     name: Parse command
     runs-on: ubuntu-latest
-    # Only provision a runner for PR comments that look like a command. Other
-    # comments still create a (free, skipped) run row — that's inherent to
-    # issue_comment — but they no longer spin up a job. classify() does the
-    # finer-grained parsing (help / unknown / auth) for comments that pass this.
+    # Only provision a runner for PR comments mentioning a configured command
+    # (or /help) anywhere in the body. Other comments still create a (free,
+    # skipped) run row — inherent to issue_comment — but no longer spin up a
+    # job. We use contains() rather than startsWith() so leading whitespace
+    # before the slash still matches; the trade-off is that a comment merely
+    # name-dropping a command also spins up the runner, which then no-ops
+    # because classify() keys on the first token. Keep this list in sync with
+    # COMMANDS in the parse step.
     if: >
-      github.event.issue.pull_request &&
-      startsWith(github.event.comment.body, '/')
+      github.event.issue.pull_request && (
+        contains(github.event.comment.body, '/testall') ||
+        contains(github.event.comment.body, '/testextensions') ||
+        contains(github.event.comment.body, '/help')
+      )
     outputs:
       command: ${{ steps.parse.outputs.command }}
       ref: ${{ steps.parse.outputs.ref }}
@@ -100,9 +109,6 @@ jobs:
           case "$kind" in
             ignore) stop ;;
             help)   post "$(help_text)"; stop ;;
-            unknown)
-              post "$(printf 'Unknown command `/%s`.\n\n%s' "$command" "$(help_text)")"
-              stop ;;
             unauthorized)
               post "🔒 \`/$command\` is restricted to organization members. (Your association: \`$AUTHOR_ASSOCIATION\`.)"
               stop ;;

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -20,7 +20,7 @@ on:
 # run-name embeds the PR number so the parse job's already-running check can
 # associate in-flight runs with a PR (issue_comment runs all report the default
 # branch, so branch filtering is not usable).
-run-name: "PR #${{ github.event.issue.number }}: ${{ github.event.comment.body }}"
+run-name: "${{ github.event.issue.pull_request && 'PR' || 'issue' }} #${{ github.event.issue.number }}: ${{ github.event.comment.body }}"
 
 permissions:
   contents: read
@@ -32,7 +32,13 @@ jobs:
   parse:
     name: Parse command
     runs-on: ubuntu-latest
-    if: github.event.issue.pull_request
+    # Only provision a runner for PR comments that look like a command. Other
+    # comments still create a (free, skipped) run row — that's inherent to
+    # issue_comment — but they no longer spin up a job. classify() does the
+    # finer-grained parsing (help / unknown / auth) for comments that pass this.
+    if: >
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '/')
     outputs:
       command: ${{ steps.parse.outputs.command }}
       ref: ${{ steps.parse.outputs.ref }}
@@ -66,9 +72,15 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Post via the REST issues-comments endpoint (works with
-          # issues:write); gh pr comment uses GraphQL addComment, which would
-          # require pull-requests:write.
+          # Post comments via the REST issues-comments endpoint, which only
+          # needs issues:write. We deliberately avoid `gh pr comment`: it uses
+          # the GraphQL addComment mutation, which requires pull-requests:write.
+          # That scope is broader than this workflow should hold — beyond
+          # commenting, pull-requests:write also lets the token close/reopen
+          # PRs, edit their title/body/base branch, request reviewers, change
+          # labels/assignees/milestones, and toggle auto-merge. This workflow
+          # is triggered by PR comments (org-gated, but still semi-trusted
+          # input), so it stays at the minimum: issues:write to post comments.
           post() {
             gh api --method POST "repos/$REPO/issues/$PR_NUMBER/comments" \
               -f body="$1" >/dev/null

--- a/scripts/ci_helpers/regtest_workflow_scripts.sh
+++ b/scripts/ci_helpers/regtest_workflow_scripts.sh
@@ -30,15 +30,18 @@ check() {
 # --- classify ---------------------------------------------------------------
 out() { BODY="$1" AUTHOR_ASSOCIATION="$2" "$CLASSIFY" | tr '\n' ',' ; }
 
-check "classify: member /testall"        "kind=run,command=testall,"        "$(out '/testall' MEMBER)"
-check "classify: owner /testextensions"  "kind=run,command=testextensions," "$(out '/testextensions' OWNER)"
-check "classify: non-member /testall"    "kind=unauthorized,command=testall," "$(out '/testall' NONE)"
-check "classify: unknown command"        "kind=unknown,command=deploy,"     "$(out '/deploy' MEMBER)"
-check "classify: help"                   "kind=help,"                       "$(out '/help' NONE)"
-check "classify: not a command"          "kind=ignore,"                     "$(out 'looks good to me' MEMBER)"
-check "classify: trailing args ignored"  "kind=run,command=testall,"        "$(out '/testall please' MEMBER)"
-check "classify: case-insensitive"       "kind=run,command=testall,"        "$(out '/TestAll' MEMBER)"
-check "classify: empty body"             "kind=ignore,"                     "$(out '' MEMBER)"
+check "classify: member /testall"         "kind=run,command=testall,"          "$(out '/testall' MEMBER)"
+check "classify: owner /testextensions"   "kind=run,command=testextensions,"   "$(out '/testextensions' OWNER)"
+check "classify: non-member /testall"     "kind=unauthorized,command=testall," "$(out '/testall' NONE)"
+check "classify: unknown slash ignored"   "kind=ignore,"                       "$(out '/deploy' MEMBER)"
+check "classify: help"                    "kind=help,"                         "$(out '/help' NONE)"
+check "classify: not a command"           "kind=ignore,"                       "$(out 'looks good to me' MEMBER)"
+check "classify: command anywhere"        "kind=run,command=testall,"          "$(out 'lgtm, please /testall now' MEMBER)"
+check "classify: cmd after unknown slash" "kind=run,command=testextensions,"   "$(out '/foo then /testextensions' MEMBER)"
+check "classify: leading whitespace"      "kind=run,command=testall,"          "$(out '  /testall' MEMBER)"
+check "classify: trailing args"           "kind=run,command=testall,"          "$(out '/testall please' MEMBER)"
+check "classify: case-insensitive"        "kind=run,command=testall,"          "$(out '/TestAll' MEMBER)"
+check "classify: empty body"              "kind=ignore,"                       "$(out '' MEMBER)"
 
 # --- find_running -----------------------------------------------------------
 RUNS='{"workflow_runs":[

--- a/scripts/ci_helpers/villagesql_slash_classify.sh
+++ b/scripts/ci_helpers/villagesql_slash_classify.sh
@@ -2,7 +2,12 @@
 # Classifies a PR slash-command comment for slash-commands.yml.
 #
 # Pure decision logic (no GitHub API calls) so it can be tested locally:
-#   BODY='/testall' AUTHOR_ASSOCIATION=MEMBER ./scripts/villagesql_slash_classify.sh
+#   BODY='please /testall' AUTHOR_ASSOCIATION=MEMBER \
+#     ./scripts/ci_helpers/villagesql_slash_classify.sh
+#
+# A command is recognized ANYWHERE in the comment: the first whitespace-
+# delimited token that is /<known-command> (or /help) wins, so "lgtm, /testall"
+# triggers a run. Unknown slash words (e.g. /foo) are ignored, not reported.
 #
 # Inputs (environment variables):
 #   BODY                The comment body.
@@ -11,51 +16,41 @@
 #                       (default: "testall testextensions")
 #
 # Output (key=value lines on stdout, suitable for appending to $GITHUB_OUTPUT):
-#   kind=ignore        Not a slash command — do nothing.
+#   kind=ignore        No known command found — do nothing.
 #   kind=help          /help or /commands — show the command list.
-#   kind=unknown       A /command we don't recognize.
 #   kind=unauthorized  Known command, but commenter lacks repo access.
 #   kind=run           Known command from an authorized commenter.
 #   command=<name>     The command name (omitted for ignore/help).
 
 set -euo pipefail
+set -f  # no globbing while word-splitting the (untrusted) comment body
 
 BODY="${BODY:-}"
 AUTHOR_ASSOCIATION="${AUTHOR_ASSOCIATION:-}"
 COMMANDS="${COMMANDS:-testall testextensions}"
 ALLOWED="OWNER MEMBER COLLABORATOR"
 
-# First whitespace-delimited token of the comment.
-first_tok=$(printf '%s' "$BODY" | awk 'NF {print $1; exit}')
+# Scan tokens for the first known /command (or /help), anywhere in the body.
+name=""
+for tok in $BODY; do
+  [ "${tok#/}" = "$tok" ] && continue  # not slash-prefixed
+  cand=$(printf '%s' "${tok#/}" | tr '[:upper:]' '[:lower:]')
+  if [ "$cand" = "help" ] || [ "$cand" = "commands" ]; then
+    echo "kind=help"
+    exit 0
+  fi
+  case " $COMMANDS " in
+    *" $cand "*) name="$cand"; break ;;
+  esac
+done
 
-if [ "${first_tok#/}" = "$first_tok" ]; then
+if [ -z "$name" ]; then
   echo "kind=ignore"
   exit 0
 fi
 
-# Strip leading slash, lowercase (tr for bash 3.2 / macOS portability).
-name=$(printf '%s' "${first_tok#/}" | tr '[:upper:]' '[:lower:]')
-
-if [ "$name" = "help" ] || [ "$name" = "commands" ]; then
-  echo "kind=help"
-  exit 0
-fi
-
-case " $COMMANDS " in
-  *" $name "*) ;;
-  *)
-    echo "kind=unknown"
-    echo "command=$name"
-    exit 0
-    ;;
-esac
-
 case " $ALLOWED " in
-  *" $AUTHOR_ASSOCIATION "*)
-    echo "kind=run"
-    ;;
-  *)
-    echo "kind=unauthorized"
-    ;;
+  *" $AUTHOR_ASSOCIATION "*) echo "kind=run" ;;
+  *) echo "kind=unauthorized" ;;
 esac
 echo "command=$name"


### PR DESCRIPTION
gh pr comment uses the GraphQL addComment mutation, which GitHub authorizes against pull-requests:write. The slash-command workflows only grant issues:write (+ pull-requests:read), so /testall failed at the started comment with 'Resource not accessible by integration'. Post via the REST issues-comments endpoint (gh api), which works with issues:write — matching the original github-script behavior.
