### PR TITLE
fix: rename back to extension-compat.yml

### DIFF
--- a/.github/workflows/extension-compat.yml
+++ b/.github/workflows/extension-compat.yml
@@ -9,6 +9,14 @@ name: Extension SDK Compatibility
 #
 # For on-demand testing against a PR's commit, see /testextensions in
 # slash-commands.yml, which calls the same reusable workflow.
+#
+# DO NOT RENAME THIS FILE. The filename `extension-compat.yml` is a public
+# contract: https://github.com/villagesql/extension-actions looks up the
+# latest successful nightly run by filename via
+#     gh run list --workflow extension-compat.yml
+# to download the `devserver-*` and `sdk-*` artifacts. That action is consumed
+# by every extension repo (vsql-ai, etc.), so renaming this file silently
+# breaks nightly CI across all of them. See cpp/action.yml in extension-actions.
 
 on:
   workflow_run:


### PR DESCRIPTION
All the CI actions for testing extensions lookup the nightly build based on the workflow yml file name.  It is easier to rename this back, than fix all the workflows.

This reverts the change in #685.