### PR TITLE
innodb: custom storage bulk ddl fix

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-storage-test/r/storage_recovery_alter.result
+++ b/mysql-test/suite/villagesql/extension/vsql-storage-test/r/storage_recovery_alter.result
@@ -1,0 +1,52 @@
+SET PERSIST vsql_allow_preview_extensions = ON;
+# Install the column-store test extension (provides STORED_INT)
+INSTALL EXTENSION vsql_storage_test;
+CREATE TABLE t1 (id INT PRIMARY KEY, n STORED_INT) ENGINE=InnoDB;
+INSERT INTO t1 VALUES (1, '111');
+INSERT INTO t1 VALUES (2, '222');
+INSERT INTO t1 VALUES (3, '333');
+# Values before rebuild
+SELECT id, n FROM t1 ORDER BY id;
+id	n
+1	111
+2	222
+3	333
+# Suppress idle background flushing so the column-store pages written by
+# the rebuild stay dirty in the buffer pool until the crash.
+SET GLOBAL innodb_idle_flush_pct = 0;
+# Rebuild the table: clustered bulk load -> insert_direct(no_redo=true)
+ALTER TABLE t1 FORCE, ALGORITHM=INPLACE;
+# Values right after rebuild (in-memory; pages dirty, not yet flushed)
+SELECT id, n FROM t1 ORDER BY id;
+id	n
+1	111
+2	222
+3	333
+# Crash WITHOUT flushing the buffer pool (redo durable only).
+SET GLOBAL innodb_fast_shutdown = 2;
+# Kill and restart
+# ---- after crash recovery ----
+SHOW CREATE TABLE t1;
+Table	Create Table
+t1	CREATE TABLE `t1` (
+  `id` int NOT NULL,
+  `n` vsql_storage_test.STORED_INT DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+CHECK TABLE t1;
+Table	Op	Msg_type	Msg_text
+test.t1	check	status	OK
+# The custom-column values must survive recovery (111, 222, 333).
+SELECT id, n FROM t1 ORDER BY id;
+id	n
+1	111
+2	222
+3	333
+SELECT COUNT(*) AS rows_total FROM t1;
+rows_total
+3
+DROP TABLE t1;
+# Cleanup
+UNINSTALL EXTENSION vsql_storage_test;
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/mysql-test/suite/villagesql/extension/vsql-storage-test/r/storage_recovery_alter.result
+++ b/mysql-test/suite/villagesql/extension/vsql-storage-test/r/storage_recovery_alter.result
@@ -14,7 +14,7 @@ id	n
 # Suppress idle background flushing so the column-store pages written by
 # the rebuild stay dirty in the buffer pool until the crash.
 SET GLOBAL innodb_idle_flush_pct = 0;
-# Rebuild the table: clustered bulk load -> insert_direct(no_redo=true)
+# Rebuild the table: clustered bulk load -> insert_direct() with no redo logging
 ALTER TABLE t1 FORCE, ALGORITHM=INPLACE;
 # Values right after rebuild (in-memory; pages dirty, not yet flushed)
 SELECT id, n FROM t1 ORDER BY id;

--- a/mysql-test/suite/villagesql/extension/vsql-storage-test/t/storage_recovery_alter.test
+++ b/mysql-test/suite/villagesql/extension/vsql-storage-test/t/storage_recovery_alter.test
@@ -1,7 +1,7 @@
 # Crash-recovery test for the column-store (extended storage) bulk-load DDL path.
 #
 # A table-rebuild DDL (ALTER TABLE ... FORCE, ALGORITHM=INPLACE) re-inserts each
-# extended-storage value through Custom_column::insert_direct(..., no_redo=true)
+# extended-storage value through Custom_column::insert_direct()
 # (btr0load.cc Page_load::insert). Those column-store pages are written with
 # MTR_LOG_NO_REDO and are NOT attached to the bulk-load Flush_observer, so they
 # are neither redo-logged nor force-flushed before the DDL commits.
@@ -10,8 +10,6 @@
 # durable, buffer pool NOT flushed) and verifies the STORED_INT values survive
 # recovery. If the durability hole is real, the values are lost/garbage after
 # recovery (RED). A correct implementation preserves them (GREEN).
-#
-# See Docs/CUSTOM_COLUMN_NO_REDO_DURABILITY.md for the full analysis.
 
 SET PERSIST vsql_allow_preview_extensions = ON;
 
@@ -31,7 +29,7 @@ SELECT id, n FROM t1 ORDER BY id;
 --echo # the rebuild stay dirty in the buffer pool until the crash.
 SET GLOBAL innodb_idle_flush_pct = 0;
 
---echo # Rebuild the table: clustered bulk load -> insert_direct(no_redo=true)
+--echo # Rebuild the table: clustered bulk load -> insert_direct() with no redo logging
 ALTER TABLE t1 FORCE, ALGORITHM=INPLACE;
 
 --echo # Values right after rebuild (in-memory; pages dirty, not yet flushed)

--- a/mysql-test/suite/villagesql/extension/vsql-storage-test/t/storage_recovery_alter.test
+++ b/mysql-test/suite/villagesql/extension/vsql-storage-test/t/storage_recovery_alter.test
@@ -1,0 +1,57 @@
+# Crash-recovery test for the column-store (extended storage) bulk-load DDL path.
+#
+# A table-rebuild DDL (ALTER TABLE ... FORCE, ALGORITHM=INPLACE) re-inserts each
+# extended-storage value through Custom_column::insert_direct(..., no_redo=true)
+# (btr0load.cc Page_load::insert). Those column-store pages are written with
+# MTR_LOG_NO_REDO and are NOT attached to the bulk-load Flush_observer, so they
+# are neither redo-logged nor force-flushed before the DDL commits.
+#
+# This test commits the rebuild, then crashes with innodb_fast_shutdown=2 (redo
+# durable, buffer pool NOT flushed) and verifies the STORED_INT values survive
+# recovery. If the durability hole is real, the values are lost/garbage after
+# recovery (RED). A correct implementation preserves them (GREEN).
+#
+# See Docs/CUSTOM_COLUMN_NO_REDO_DURABILITY.md for the full analysis.
+
+SET PERSIST vsql_allow_preview_extensions = ON;
+
+--echo # Install the column-store test extension (provides STORED_INT)
+INSTALL EXTENSION vsql_storage_test;
+
+CREATE TABLE t1 (id INT PRIMARY KEY, n STORED_INT) ENGINE=InnoDB;
+
+INSERT INTO t1 VALUES (1, '111');
+INSERT INTO t1 VALUES (2, '222');
+INSERT INTO t1 VALUES (3, '333');
+
+--echo # Values before rebuild
+SELECT id, n FROM t1 ORDER BY id;
+
+--echo # Suppress idle background flushing so the column-store pages written by
+--echo # the rebuild stay dirty in the buffer pool until the crash.
+SET GLOBAL innodb_idle_flush_pct = 0;
+
+--echo # Rebuild the table: clustered bulk load -> insert_direct(no_redo=true)
+ALTER TABLE t1 FORCE, ALGORITHM=INPLACE;
+
+--echo # Values right after rebuild (in-memory; pages dirty, not yet flushed)
+SELECT id, n FROM t1 ORDER BY id;
+
+--echo # Crash WITHOUT flushing the buffer pool (redo durable only).
+SET GLOBAL innodb_fast_shutdown = 2;
+--source include/kill_and_restart_mysqld.inc
+
+--echo # ---- after crash recovery ----
+SHOW CREATE TABLE t1;
+CHECK TABLE t1;
+
+--echo # The custom-column values must survive recovery (111, 222, 333).
+SELECT id, n FROM t1 ORDER BY id;
+SELECT COUNT(*) AS rows_total FROM t1;
+
+DROP TABLE t1;
+
+--echo # Cleanup
+UNINSTALL EXTENSION vsql_storage_test;
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/storage/innobase/btr/btr0load.cc
+++ b/storage/innobase/btr/btr0load.cc
@@ -490,8 +490,10 @@ dberr_t Page_load::insert(const dtuple_t *tuple, const big_rec_t *big_rec,
     // Insert extended column data before record conversion so that
     // rec_convert_dtuple_to_rec writes the REF directly into the record.
     // const_cast is safe: insert_direct mutates only the extended ref bytes.
+    // The observer force-flushes the no-redo column-store pages before commit.
     auto err = villagesql::innodb::Custom_column::insert_direct(
-        m_index->table, m_trx_id, const_cast<dtuple_t *>(tuple), true);
+        m_index->table, m_trx_id, const_cast<dtuple_t *>(tuple),
+        m_flush_observer);
     if (err != DB_SUCCESS) {
       return err;
     }

--- a/storage/innobase/villagesql/custom_column.cc
+++ b/storage/innobase/villagesql/custom_column.cc
@@ -519,10 +519,14 @@ dberr_t Custom_column::insert(dict_table_t *table, trx_id_t trx_id,
 }
 
 dberr_t Custom_column::insert_direct(dict_table_t *table, trx_id_t trx_id,
-                                     dtuple_t *tuple, bool no_redo) {
+                                     dtuple_t *tuple,
+                                     Flush_observer *observer) {
   if (!table->has_extended_storage) {
     return DB_SUCCESS;
   }
+
+  // Durability of these no-redo pages depends on the observer flush; required.
+  ut_a(observer != nullptr);
 
   dict_index_t *index = table->first_index();
   ut_a(index->is_clustered());
@@ -538,14 +542,12 @@ dberr_t Custom_column::insert_direct(dict_table_t *table, trx_id_t trx_id,
     dict_col_t *col = index->get_field(i)->col;
     ut_a(col->stored_by_extn());
 
-    if (!no_redo) {
-      log_free_check();
-    }
+    // No-redo content writes, force-flushed by the observer before commit
+    // (allocation is redo-logged in the storage ABI). See Page_load::init.
     mtr_t mtr;
     mtr_start(&mtr);
-    if (no_redo) {
-      mtr.set_log_mode(MTR_LOG_NO_REDO);
-    }
+    mtr.set_log_mode(MTR_LOG_NO_REDO);
+    mtr.set_flush_observer(observer);
 
     Custom_column::Ref ref_val = Custom_column::EMPTY_REF;
     auto err =

--- a/storage/innobase/villagesql/custom_column.h
+++ b/storage/innobase/villagesql/custom_column.h
@@ -38,6 +38,8 @@ struct dtuple_t;
 struct upd_t;
 struct TABLE;
 
+class Flush_observer;
+
 class Alter_inplace_info;
 class Field;
 
@@ -163,13 +165,13 @@ class Custom_column {
 
   // Inserts extended column data into the column store before bulk-load record
   // conversion. Updates each extended field in the tuple with the REF in-place.
-  // @param table The table being inserted into.
-  // @param trx_id The transaction ID of the insert.
-  // @param tuple The clustered index tuple
-  // @param no_redo True for bulk-load: skips redo logging for column store mtr.
+  // Writes column-store pages with MTR_LOG_NO_REDO; durability comes from the
+  // bulk-load flush observer (force-flushed before commit) plus redo-logged
+  // page allocation, mirroring Page_load::init in btr0load.cc.
+  // @param observer Bulk-load flush observer; must be non-null.
   // @return DB_SUCCESS or an error code.
   static dberr_t insert_direct(dict_table_t *table, trx_id_t trx_id,
-                               dtuple_t *tuple, bool no_redo);
+                               dtuple_t *tuple, Flush_observer *observer);
 
   // Updates extended column data for an updated row.
   // Marks the old data as deleted and inserts the new data.

--- a/storage/innobase/villagesql/storage_abi.cc
+++ b/storage/innobase/villagesql/storage_abi.cc
@@ -371,8 +371,15 @@ extern "C" int vef_storage_page_allocate_and_load(
 
   mtr_t *mtr = static_cast<mtr_t *>(mtr_ref);
 
-  buf_block_t *buf_block =
-      fseg_alloc_free_page(segment_header, 0, FSP_NO_DIR, mtr);
+  // Allocate in a separate redo-logged mtr, latching/initializing the page in
+  // the caller's content mtr, so allocation is crash-recoverable even when the
+  // contents are written no-redo. Mirrors Page_load::init in btr0load.cc.
+  mtr_t alloc_mtr;
+  alloc_mtr.start();
+  buf_block_t *buf_block = fseg_alloc_free_page_general(
+      segment_header, 0, FSP_NO_DIR, false, &alloc_mtr, mtr);
+  alloc_mtr.commit();
+
   if (buf_block == nullptr) {
     ib::warn(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Failed to allocate page.";


### PR DESCRIPTION
# Fix: durable column-store writes during bulk-load DDL

## Summary

Table-rebuild DDL (`ALTER TABLE ... FORCE`, `OPTIMIZE TABLE`, etc.) on a table with a
column-store-backed custom column could **silently lose committed custom-column values on a crash**.

The bulk-load path wrote the column-store content pages under `MTR_LOG_NO_REDO` but never
force-flushed them before commit and never redo-logged their allocation. A crash after the DDL
committed — but before the page cleaner happened to flush those pages — left the clustered index
pointing at column-store entries that were never made durable.

This PR makes those writes durable the same way InnoDB's own bulk index build does: a `Flush_observer`
force-flushes the no-redo content pages before commit, and page allocation is redo-logged in a
separate mtr.

## Impact

- **Severity:** silent loss of committed data, plus dangling clustered-index references, after a
  *successfully committed* DDL. `CHECK TABLE` reports `OK` (it does not cross-validate column-store
  contents), so the corruption is silent.
- **Affected:** tables with a column using extended/column storage (`has_extended_storage`) that
  undergo a clustered-index rebuild. Ordinary `INSERT`/`UPDATE`/`DELETE` are unaffected — they use the
  redo-logged path (`insert_impl`/`mark_impl`). Tables without extended-storage columns are unaffected
  (`insert_direct` early-returns).
- **Crash window:** after the rebuild commits, before the lazy page cleaner flushes the column-store
  pages and before any sharp checkpoint.

### Reproduction (before this PR)

`ALTER TABLE t FORCE` on a `STORED_INT` table, then crash with `innodb_fast_shutdown=2` (redo durable,
buffer pool not flushed):

```
before rebuild:         1 -> 111, 2 -> 222, 3 -> 333
after ALTER (memory):   1 -> 111, 2 -> 222, 3 -> 333
after crash + recovery: 1 -> 0,   2 -> 0,   3 -> 0     <-- committed values lost
CHECK TABLE t1: OK                                     <-- silent
```

The obvious debug point `innodb_alter_commit_crash_after_commit` does
`log_make_latest_checkpoint()` before crashing, which drains the flush list and masks the bug — likely
why it went unnoticed. A repro must crash *without* a checkpoint.

## Root cause

`Page_load::insert` (clustered bulk load) calls `Custom_column::insert_direct(..., no_redo=true)` from
`btr0load.cc`. `insert_direct` wrote each value in a `MTR_LOG_NO_REDO` mtr that:

- never attached the bulk-load `Flush_observer`, so the pages were **not** force-flushed before commit
  (`Flush_observer::flush` only flushes observer-tagged pages, `buf0lru.cc`; an untagged mtr even
  *resets* the page's observer, `buf0flu.ic`); and
- allocated the pages on that same no-redo mtr (`fseg_alloc_free_page` in
  `vef_storage_page_allocate_and_load`), so the segment/extent bookkeeping was **not** redo-logged
  either.

This diverges from the canonical InnoDB bulk pattern (`Page_load::init`, `btr0load.cc`), which pairs
the no-redo content mtr with an observer flush **and** redo-logs allocation in a separate mtr.

## Background: the established NO_REDO bulk pattern

InnoDB skips redo during bulk page construction for speed and substitutes a fixed, four-part
durability contract. It is not specific to one code path — it recurs across every bulk writer:

1. **No-redo content mtr.** Page contents are written under `mtr->set_log_mode(MTR_LOG_NO_REDO)`.
2. **`Flush_observer` force-flush before commit.** The same mtr gets `mtr->set_flush_observer(observer)`.
   The observer tracks exactly the pages it dirtied and force-flushes them before any redo-logged
   operation can reference the index, so the no-redo pages are on disk by commit. Its stated purpose
   (`buf0flu.h`): *"track flushing of non-redo logged pages in bulk create index ... make sure that
   all dirty pages modified by the index build are flushed to disk before any redo logged operations
   go to the index."* It is created and attached to the trx in `ddl0ctx.cc`
   (`trx_set_flush_observer`) and read back by the bulk loaders.
3. **Redo-logged allocation in a separate mtr.** Page *allocation* is always redo-logged even though
   page *contents* are not — done in a separate default-log-mode `alloc_mtr` with the page latched in
   the content mtr (`btr_page_alloc(..., &alloc_mtr, mtr)`). The rationale is spelled out identically
   in both bulk loaders: *"we will always generate redo log for page allocation, even when creating a
   new tablespace."*
4. **`MLOG_INDEX_LOAD` marker.** After the build, `Builder::write_redo` emits an `MLOG_INDEX_LOAD`
   record for the index. It is **not** replayed in crash recovery — `log0recv.cc` parses and skips it
   (explicitly excluded from the apply hash table). It exists so tooling knows the index pages reached
   disk by other means: hot backup uses it (`index_load_list`) to flag tablespaces that must be
   re-copied. It is a marker, not a reconstruction mechanism — which is *why* legs 2 and 3 are
   mandatory.

Where the pattern is used today:

| Path                               | No-redo + observer | Separate logged alloc |
|------------------------------------|--------------------|-----------------------|
| DDL index build (`btr0load.cc`)    | yes                | yes                   |
| Parallel / LOAD DATA (`btr0mtib.cc`) | yes              | yes                   |
| Out-of-line LOB (`lob0ins.h`)      | yes (blob mtr)     | LOB/btr alloc paths   |

The column-store write was the one bulk writer that adopted leg 1 (no-redo) without legs 2 and 3. This
PR brings it in line with the contract the rest of InnoDB already follows.

## The fix

Mirror `Page_load::init` for the column-store writes — two legs, both required:

1. **Force-flush the no-redo content pages.** `insert_direct` now takes the bulk-load `Flush_observer`
   (threaded from `Page_load::insert`) and sets it on the no-redo mtr, so those pages are flushed
   before the DDL commits.
2. **Redo-log page allocation in a separate mtr.** `vef_storage_page_allocate_and_load` allocates via
   `fseg_alloc_free_page_general(..., &alloc_mtr, mtr)` — allocation logged in `alloc_mtr`, page
   latched/initialized in the caller's content mtr. This makes segment/extent bookkeeping
   crash-recoverable via redo and removes any reliance on observer tagging for shared XDES pages.

### Why not just drop `no_redo`?

`Page_load` holds a page X-latch via `m_mtr` across `Page_load::insert`, so `log_free_check()`
(required before generating redo) cannot be safely called there. That is the original reason for
`no_redo`; the omission was the compensating flush, not the no-redo itself. The observer path keeps
the fast no-redo content writes and supplies the missing durability.

## Files changed

- `storage/innobase/villagesql/custom_column.{h,cc}` — `insert_direct(..., Flush_observer *observer)`;
  set log mode + observer on the content mtr.
- `storage/innobase/btr/btr0load.cc` — pass `m_flush_observer` instead of the `true` literal.
- `storage/innobase/villagesql/storage_abi.cc` — allocate pages in a separate redo-logged mtr.
- `mysql-test/suite/villagesql/extension/vsql-storage-test/t/storage_recovery_alter.test` (+`.result`)
  — crash-recovery regression test.

- **New `storage_recovery_alter`** (suite `villagesql/extension/vsql-storage-test`): RED before the
  fix (`0/0/0` after recovery) → GREEN after (`111/222/333`). The test crashes with
  `innodb_fast_shutdown=2` and sets `innodb_idle_flush_pct=0` to keep the column-store pages dirty in
  the buffer pool through the crash. For a fully deterministic repro on a debug build, additionally
  set `innodb_page_cleaner_disabled_debug=1`.
- **No regressions** on the rebased branch: `villagesql/extension/vsql-storage-test`
  (`storage_basic` + `storage_recovery_alter`), `villagesql/startup.recovery_complex` and its 4
  `_index*` variants (6/6), and the full `villagesql/alter_table` suite (40/40).
- `villint.sh` clean.

## Known limitations / follow-ups

- The separate `alloc_mtr` generates a small amount of redo **per allocated page without a
  `log_free_check()`** (the surrounding bulk page latch precludes calling it). `Page_load::init` has
  the same property, but the column store can allocate one page per row — redo-space pressure on very
  large rebuilds should be evaluated (and whether allocations can be batched).
- Crash matrix not yet exercised for: multi-page custom values, compressed (zip) pages, partitioned
  and virtual-column tables, and concurrent DDL.
- The sibling segment-create / cleanup path in `storage_abi.cc` still carries
  `TODO(villagesql-indexing): ... after DDL logging is implemented`; this PR does not address that
  path's crash-on-failure segment leak.
