### PR TITLE
create per-syntax factories

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_resolve_only_create_table.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_resolve_only_create_table.result
@@ -4,13 +4,14 @@ SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS
 WHERE extension_name = 'vsql_resolve_only_test';
 EXTENSION_NAME	EXTENSION_VERSION
 vsql_resolve_only_test	0.0.1
-# The bare form is rejected at parse time (it used to crash the server).
+# The bare form routes through resolve_params with empty parameters,
+# which rejects the missing 'len' at parse time.
 CREATE TABLE t_bare (id INT, v vsql_resolve_only_test.RPARAM);
-ERROR 42000: Fixed-length type 'vsql_resolve_only_test.RPARAM' requires parameters near 'vsql_resolve_only_test.RPARAM)' at line 1
+ERROR 42000: RPARAM requires a 'len' parameter near 'vsql_resolve_only_test.RPARAM)' at line 1
 # The integer-length form is rejected too: it needs int_to_params, which
 # this type does not provide.
 CREATE TABLE t_int (id INT, v vsql_resolve_only_test.RPARAM(8));
-ERROR 42000: Fixed-length type 'vsql_resolve_only_test.RPARAM' requires parameters near 'vsql_resolve_only_test.RPARAM(8))' at line 1
+ERROR 42000: Type 'vsql_resolve_only_test.RPARAM' does not accept a length specification near 'vsql_resolve_only_test.RPARAM(8))' at line 1
 # The explicit-parameter form is accepted: resolve_params resolves the
 # width, so the type is otherwise valid -- only the bare form is rejected.
 CREATE TABLE t_param (id INT, v vsql_resolve_only_test.RPARAM('len=8'));

--- a/mysql-test/suite/villagesql/extension/t/extension_resolve_only_create_table.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_resolve_only_create_table.test
@@ -1,12 +1,6 @@
 # Regression check for a fixed-length parameterized custom type that provides
 # resolve_params but NOT int_to_params.
 #
-# RPARAM has persisted_length(-1) (its width is resolved from the 'len'
-# parameter) and provides resolve_params, so it is parameterized. With no
-# int_to_params, a bare declaration has no way to obtain a width: resolve_params
-# is never invoked (no parameters) and persisted_length stays -1. It must now
-# be rejected at parse time instead.
-#
 # Fixture: vsql_resolve_only_test exposes RPARAM.
 
 --echo # Install the fixture.
@@ -15,7 +9,8 @@ INSTALL EXTENSION vsql_resolve_only_test;
 SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS
 WHERE extension_name = 'vsql_resolve_only_test';
 
---echo # The bare form is rejected at parse time (it used to crash the server).
+--echo # The bare form routes through resolve_params with empty parameters,
+--echo # which rejects the missing 'len' at parse time.
 --error ER_PARSE_ERROR
 CREATE TABLE t_bare (id INT, v vsql_resolve_only_test.RPARAM);
 

--- a/sql/sql_yacc.yy
+++ b/sql/sql_yacc.yy
@@ -7121,25 +7121,35 @@ type:
           {
             $$= NEW_PTN PT_json_type(@$);
           }
-        | IDENT_sys opt_field_length
+        | IDENT_sys %prec PREFER_PARENTHESES
           {
-            // Custom data type, potentially - we will find out when constructing.
-            $$= villagesql::PT_custom_type::create(YYMEM_ROOT, @$, Lex->thd, {}, $1, $2);
+            // Custom data type with no length or parameters: TYPE
+            $$= villagesql::PT_custom_type::create(YYMEM_ROOT, @$, Lex->thd, {}, $1);
           }
-        | IDENT_sys '.' IDENT_sys opt_field_length
+        | IDENT_sys field_length
+          {
+            // Custom type with an integer length: TYPE(N)
+            $$= villagesql::PT_custom_type::create_with_length(YYMEM_ROOT, @$, Lex->thd, {}, $1, $2);
+          }
+        | IDENT_sys '.' IDENT_sys %prec PREFER_PARENTHESES
           {
             // Qualified custom type: extension_name.type_name
-            $$= villagesql::PT_custom_type::create(YYMEM_ROOT, @$, Lex->thd, $1, $3, $4);
+            $$= villagesql::PT_custom_type::create(YYMEM_ROOT, @$, Lex->thd, $1, $3);
+          }
+        | IDENT_sys '.' IDENT_sys field_length
+          {
+            // Qualified custom type with an integer length: extension_name.type_name(N)
+            $$= villagesql::PT_custom_type::create_with_length(YYMEM_ROOT, @$, Lex->thd, $1, $3, $4);
           }
         | IDENT_sys '(' TEXT_STRING_literal ')'
           {
             // Custom type with string parameters: TYPE('key=value,...')
-            $$= villagesql::PT_custom_type::create(YYMEM_ROOT, @$, Lex->thd, {}, $1, nullptr, $3.str, $3.length);
+            $$= villagesql::PT_custom_type::create_with_params(YYMEM_ROOT, @$, Lex->thd, {}, $1, $3.str, $3.length);
           }
         | IDENT_sys '.' IDENT_sys '(' TEXT_STRING_literal ')'
           {
             // Qualified custom type with string parameters
-            $$= villagesql::PT_custom_type::create(YYMEM_ROOT, @$, Lex->thd, $1, $3, nullptr, $5.str, $5.length);
+            $$= villagesql::PT_custom_type::create_with_params(YYMEM_ROOT, @$, Lex->thd, $1, $3, $5.str, $5.length);
           }
         ;
 

--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -84,6 +84,18 @@ class PT_custom_type : public PT_type {
     }
   }
 
+  // Resolve the type descriptor for the given (extension_name, type_name). On
+  // success, sets descriptor (which may be nullptr if the type was not found)
+  // and returns false. Returns true if descriptor resolution itself failed
+  // with an error already recorded.
+  static bool resolve_descriptor(const LEX_STRING &extension_name,
+                                 const LEX_STRING &type_name,
+                                 const TypeDescriptor *&descriptor) {
+    descriptor = nullptr;
+    return ResolveTypeDescriptor(to_string_view(extension_name),
+                                 to_string_view(type_name), descriptor);
+  }
+
  public:
   // During parsing, type_name is not yet validated. However, when we construct
   // this object, we could find out there actually was an error in specifying
@@ -113,6 +125,32 @@ class PT_custom_type : public PT_type {
       return true;
     }
 
+    // Validate the resolved persisted_length against the type's declared
+    // length kind. Fixed-length types must resolve to a concrete positive
+    // footprint; variable-length types size their storage per value, so
+    // they must not report a fixed persisted_length here.
+    if (descriptor->is_variable_length()) {
+      if (resolved.persisted_length > 0) {
+        thd->syntax_error_at(
+            pos,
+            "Variable-length type '%s' resolved an unexpected fixed "
+            "persisted_length (%" PRId64
+            "); variable-length types size storage per value, so "
+            "persisted_length should be <= 0 (stay unset)",
+            descriptor->qualified_base_name().c_str(),
+            resolved.persisted_length);
+        return true;
+      }
+    } else if (resolved.persisted_length <= 0) {
+      thd->syntax_error_at(
+          pos,
+          "Type '%s' resolved an invalid persisted_length (%" PRId64
+          "); fixed-length types must resolve to a concrete footprint, so "
+          "persisted_length should be > 0",
+          descriptor->qualified_base_name().c_str(), resolved.persisted_length);
+      return true;
+    }
+
     TypeParameters params(params_str);
 
     type_context = nullptr;
@@ -123,17 +161,15 @@ class PT_custom_type : public PT_type {
     return false;
   }
 
-  // Factory for TYPE(N) and unparameterized syntax.
+  // Factory for the bare, unparameterized custom type syntax: TYPE (no length,
+  // no parameters).
   static PT_custom_type *create(MEM_ROOT *pt_mem_root, const POS &pos, THD *thd,
                                 const LEX_STRING &extension_name,
-                                const LEX_STRING &type_name,
-                                const char *length) {
+                                const LEX_STRING &type_name) {
     // Resolve the descriptor first so we can inspect the type's
-    // characteristics. We defer creating the TypeContext until
-    // the concrete parameters are known.
+    // characteristics.
     const TypeDescriptor *descriptor = nullptr;
-    if (ResolveTypeDescriptor(to_string_view(extension_name),
-                              to_string_view(type_name), descriptor)) {
+    if (resolve_descriptor(extension_name, type_name, descriptor)) {
       return nullptr;
     }
 
@@ -143,115 +179,123 @@ class PT_custom_type : public PT_type {
           PT_custom_type(pos, thd, type_name, nullptr, nullptr);
     }
 
-    // Note, this create function is called when params string is empty.
-    if (!descriptor->is_variable_length() && descriptor->is_parameterized() &&
-        !descriptor->int_to_params_fn().has_value()) {
-      thd->syntax_error_at(pos, "Fixed-length type '%s' requires parameters",
-                           descriptor->qualified_base_name().c_str());
-      return nullptr;
-    }
-
     const TypeContext *type_context = nullptr;
 
-    // Handle types that accept a length spec. Note that this create function
-    // only handles TYPE(N) syntax and unparameterized types. Parameterized
-    // types with TYPE('key=value,...') syntax are handled by the other create()
-    // overload.
     if (descriptor->is_parameterized()) {
-      // type provides resolve_params, check if also provides int_to_params for
-      // TYPE(N) syntax. In case it does, and length is provided, we will
-      // convert the length to parameters and resolve the TypeContext. In case
-      // it does, and length is not provided -> this is an error.
-      if (length != nullptr) {
-        // TYPE(N) syntax used - convert N to parameters via callbacks
-        if (!descriptor->int_to_params_fn().has_value()) {
-          thd->syntax_error_at(
-              pos, "Type '%s' does not accept a length specification",
-              descriptor->qualified_base_name().c_str());
-          // it's OK to return nullptr only if an error has already been set in
-          // THD
-          return nullptr;
-        }
-
-        // Parse the length string to int64_t
-        char *endptr = nullptr;
-        int64_t int_value = strtoll(length, &endptr, 10);
-        if (endptr == length || *endptr != '\0' || int_value <= 0) {
-          thd->syntax_error_at(pos, "Invalid length '%s' for type '%s'", length,
-                               descriptor->qualified_base_name().c_str());
-          return nullptr;
-        }
-
-        // Call int_to_params to convert integer to canonical parameter string
-        std::string params_str;
-        char error_msg[VEF_MAX_ERROR_LEN] = {0};
-        if (descriptor->int_to_params_fn()->invoke(int_value, &params_str,
-                                                   error_msg)) {
-          thd->syntax_error_at(pos, "%s", error_msg);
-          return nullptr;
-        }
-
-        // Normalize to canonical form (lowercase, sorted) just like the
-        // TYPE('k=v,...') path does via from_raw.
-        TypeParameters canonical = TypeParameters::from_raw(params_str);
-        if (canonical.empty()) {
-          thd->syntax_error_at(pos, "Invalid parameter string for type '%s'",
-                               descriptor->qualified_base_name().c_str());
-          return nullptr;
-        }
-
-        // resolve_params_and_context will call AcquireOrCreateTypeContext after
-        // resolving the parameters
-        if (resolve_params_and_context(pos, thd, descriptor, canonical.str(),
-                                       type_context)) {
-          return nullptr;
-        }
-
-        // length is now consumed - pass nullptr to constructor
-        length = nullptr;
-      } else {
+      if (descriptor->int_to_params_fn().has_value()) {
         // No length provided for TYPE(N)
-        if (descriptor->int_to_params_fn().has_value()) {
-          thd->syntax_error_at(pos, "Type '%s' requires a length specification",
-                               descriptor->qualified_base_name().c_str());
-          return nullptr;
-        }
-      }
-    } else {
-      // non parameterized type
-      if (length != nullptr) {
-        thd->syntax_error_at(pos,
-                             "Type '%s' is not parameterized and cannot have a "
-                             "length specification",
+        thd->syntax_error_at(pos, "Type '%s' requires a length specification",
                              descriptor->qualified_base_name().c_str());
         return nullptr;
       }
+
+      // resolve_params is the single validation gate for parameterized types
+      // (fixed- or variable-length). Invoke it with empty parameters so the
+      // type can either resolve its defaults or report that parameters are
+      // required.
+      if (resolve_params_and_context(pos, thd, descriptor, std::string(),
+                                     type_context))
+        return nullptr;
+    } else {
+      // Non-parameterized type - acquire the context with empty parameters.
       if (AcquireOrCreateTypeContext(descriptor, TypeParameters(),
                                      *thd->mem_root, type_context))
         return nullptr;
     }
 
-    // in case type_context is still nullptr - PT_custom_type constructor will
-    // record the error
-    PT_custom_type *ret = new (pt_mem_root)
-        PT_custom_type(pos, thd, type_name, length, type_context);
-    return ret;
+    return new (pt_mem_root)
+        PT_custom_type(pos, thd, type_name, nullptr, type_context);
   }
 
-  // Factory for TYPE('key=value,...') string parameter syntax.
-  static PT_custom_type *create(MEM_ROOT *pt_mem_root, const POS &pos, THD *thd,
-                                const LEX_STRING &extension_name,
-                                const LEX_STRING &type_name, const char *length,
-                                const char *params_str, size_t params_str_len) {
-    // If no string params provided, fall through to the normal path
-    if (params_str == nullptr) {
-      return create(pt_mem_root, pos, thd, extension_name, type_name, length);
+  // Factory for the TYPE(N) integer length syntax. length is guaranteed to be
+  // a non-null numeric string by the grammar (field_length).
+  static PT_custom_type *create_with_length(MEM_ROOT *pt_mem_root,
+                                            const POS &pos, THD *thd,
+                                            const LEX_STRING &extension_name,
+                                            const LEX_STRING &type_name,
+                                            const char *length) {
+    assert(length != nullptr);
+
+    const TypeDescriptor *descriptor = nullptr;
+    if (resolve_descriptor(extension_name, type_name, descriptor)) {
+      return nullptr;
     }
+
+    if (descriptor == nullptr) {
+      // Type not found - constructor records the error.
+      return new (pt_mem_root)
+          PT_custom_type(pos, thd, type_name, nullptr, nullptr);
+    }
+
+    if (!descriptor->is_parameterized()) {
+      thd->syntax_error_at(pos,
+                           "Type '%s' is not parameterized and cannot have a "
+                           "length specification",
+                           descriptor->qualified_base_name().c_str());
+      return nullptr;
+    }
+
+    // type provides resolve_params; it must also provide int_to_params to
+    // support the TYPE(N) syntax.
+    if (!descriptor->int_to_params_fn().has_value()) {
+      thd->syntax_error_at(pos,
+                           "Type '%s' does not accept a length specification",
+                           descriptor->qualified_base_name().c_str());
+      return nullptr;
+    }
+
+    // Parse the length string to int64_t
+    char *endptr = nullptr;
+    int64_t int_value = strtoll(length, &endptr, 10);
+    if (endptr == length || *endptr != '\0' || int_value <= 0) {
+      thd->syntax_error_at(pos, "Invalid length '%s' for type '%s'", length,
+                           descriptor->qualified_base_name().c_str());
+      return nullptr;
+    }
+
+    // Call int_to_params to convert integer to canonical parameter string
+    std::string params_str;
+    char error_msg[VEF_MAX_ERROR_LEN] = {0};
+    if (descriptor->int_to_params_fn()->invoke(int_value, &params_str,
+                                               error_msg)) {
+      thd->syntax_error_at(pos, "%s", error_msg);
+      return nullptr;
+    }
+
+    // Normalize to canonical form (lowercase, sorted) just like the
+    // TYPE('k=v,...') path does via from_raw.
+    TypeParameters canonical = TypeParameters::from_raw(params_str);
+    if (canonical.empty()) {
+      thd->syntax_error_at(pos, "Invalid parameter string for type '%s'",
+                           descriptor->qualified_base_name().c_str());
+      return nullptr;
+    }
+
+    // resolve_params_and_context will call AcquireOrCreateTypeContext after
+    // resolving the parameters
+    const TypeContext *type_context = nullptr;
+    if (resolve_params_and_context(pos, thd, descriptor, canonical.str(),
+                                   type_context)) {
+      return nullptr;
+    }
+
+    return new (pt_mem_root)
+        PT_custom_type(pos, thd, type_name, nullptr, type_context);
+  }
+
+  // Factory for TYPE('key=value,...') string parameter syntax. params_str is
+  // guaranteed non-null by the grammar (TEXT_STRING_literal).
+  static PT_custom_type *create_with_params(MEM_ROOT *pt_mem_root,
+                                            const POS &pos, THD *thd,
+                                            const LEX_STRING &extension_name,
+                                            const LEX_STRING &type_name,
+                                            const char *params_str,
+                                            size_t params_str_len) {
+    assert(params_str != nullptr);
 
     // Resolve the descriptor first
     const TypeDescriptor *descriptor = nullptr;
-    if (ResolveTypeDescriptor(to_string_view(extension_name),
-                              to_string_view(type_name), descriptor)) {
+    if (resolve_descriptor(extension_name, type_name, descriptor)) {
       return nullptr;
     }
 


### PR DESCRIPTION
The custom-type grammar previously funneled every form through a single overloaded create() that took an optional length and optional parameter string, then branched internally to figure out which syntax was actually used. This made the control flow hard to follow and forced the bare declaration (TYPE) and the integer-length form (TYPE(N)) to share a code path that guessed intent from null checks.

Split the grammar's `IDENT_sys opt_field_length` alternative into three explicit productions, each calling a dedicated factory:

  - TYPE                 -> create()             (no length, no params)
  - TYPE(N)              -> create_with_length()  (integer length)
  - TYPE('key=value')    -> create_with_params()  (string parameters)
