### PR TITLE
Restore working regtest_villint.py

### DIFF
--- a/scripts/regtest_villint_data/allowlist_nonstandard_copyrights.txt
+++ b/scripts/regtest_villint_data/allowlist_nonstandard_copyrights.txt
@@ -2,5 +2,5 @@
 # Add one file path per line (relative to repository root)
 # Example:
 # extra/some_third_party/file.cc
-extra/libbacktrace/sha9ae4f4a/internal.h
+extra/libbacktrace/sha793921876c981/internal.h
 extra/libarchive/

--- a/scripts/regtest_villint_test_cases/vsql_copyright_allowlisted_edit.sh
+++ b/scripts/regtest_villint_test_cases/vsql_copyright_allowlisted_edit.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-FILE="extra/libbacktrace/sha9ae4f4a/internal.h"
+FILE="extra/libbacktrace/sha793921876c981/internal.h"
 
 echo "Modifying allowlisted file: $FILE"
 

--- a/scripts/regtest_villint_test_cases/vsql_copyright_allowlisted_verify.sh
+++ b/scripts/regtest_villint_test_cases/vsql_copyright_allowlisted_verify.sh
@@ -3,7 +3,7 @@
 # For allowlisted files, we just verify the file exists and was modified
 # We don't require VillageSQL copyright for allowlisted third-party files
 
-FILE="extra/libbacktrace/sha9ae4f4a/internal.h"
+FILE="extra/libbacktrace/sha793921876c981/internal.h"
 
 # Check if file exists
 if [ ! -f "$FILE" ]; then


### PR DESCRIPTION
## Description

Curiously, the merge of mysql-8.4.8 broke the regression tests for villint.

In SHA 0a7963059 (a.k.a. dbentley/merge_848_bak, “Merge 8.4.8 from upstream Oracle”), one of the known files used for testing is relocated to a different directory.  Broadly speaking, `extra/libbacktrace/sha9ae4f4a` is renamed to `extra/libbacktrace/sha793921876c981`.  As a result, the test for non-conforming copyrights fails due to a non-existent test file.  The targeted file `extra/libbacktrace/sha9ae4f4a/internal.h` has moved to  `extra/libbacktrace/sha793921876c981/internal.h`.

These git commands indicate the deletion of the `sha9ae4f4a` directory, with 15 of the original files renamed into the new `sha793921876c981` directory.
```
git show 0a796305970950cf0ab5ecf7c300497f52668c1f --name-status | grep ^D
git show 0a796305970950cf0ab5ecf7c300497f52668c1f --name-status | grep ^R | grep sha
```
Who woulda figured you pick a renamed file for test artifact?

## Related Issue

Part of the effort to Cleanup release-dev-server #595

## How was this tested?

Multiple local runs of the regression test harness.
