### PR TITLE
Session Context: context fields

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-session/r/session_fields.result
+++ b/mysql-test/suite/villagesql/extension/vsql-session/r/session_fields.result
@@ -1,0 +1,50 @@
+# Install extension
+INSTALL EXTENSION vsql_session_test;
+# connection_id matches CONNECTION_ID() of this session
+SELECT vsql_session_test.session_conn_id() = CONNECTION_ID() AS conn_id_matches;
+conn_id_matches
+1
+# priv_user matches CURRENT_USER's user part
+SELECT vsql_session_test.session_priv_user() =
+SUBSTRING_INDEX(CURRENT_USER(), '@', 1) AS priv_user_matches;
+priv_user_matches
+1
+# priv_host matches CURRENT_USER's host part
+SELECT vsql_session_test.session_priv_host() =
+SUBSTRING_INDEX(CURRENT_USER(), '@', -1) AS priv_host_matches;
+priv_host_matches
+1
+# kill_status is NOT_KILLED (0) during normal execution
+SELECT vsql_session_test.session_kill_status() AS kill_status;
+kill_status
+0
+# schema reflects the current default database, fresh per call
+CREATE DATABASE sctx_db1;
+CREATE DATABASE sctx_db2;
+USE sctx_db1;
+SELECT vsql_session_test.session_schema() AS schema_db1;
+schema_db1
+sctx_db1
+USE sctx_db2;
+SELECT vsql_session_test.session_schema() AS schema_db2;
+schema_db2
+sctx_db2
+# priv_user is captured at invocation: a SQL SECURITY DEFINER routine
+# owned by a different account reports that account, not the caller.
+CREATE USER definer_acct@localhost;
+GRANT EXECUTE ON sctx_db2.* TO definer_acct@localhost;
+GRANT EXECUTE ON *.* TO definer_acct@localhost;
+CREATE DEFINER = definer_acct@localhost FUNCTION sctx_db2.who()
+RETURNS VARCHAR(64) SQL SECURITY DEFINER
+RETURN vsql_session_test.session_priv_user();
+# Expect definer_acct, proving capture at invocation time
+SELECT sctx_db2.who() AS definer_priv_user;
+definer_priv_user
+definer_acct
+# Cleanup
+DROP FUNCTION sctx_db2.who;
+DROP USER definer_acct@localhost;
+DROP DATABASE sctx_db1;
+DROP DATABASE sctx_db2;
+USE test;
+UNINSTALL EXTENSION vsql_session_test;

--- a/mysql-test/suite/villagesql/extension/vsql-session/t/session_fields.test
+++ b/mysql-test/suite/villagesql/extension/vsql-session/t/session_fields.test
@@ -1,0 +1,45 @@
+# Tier 1 session context fields, read via vsql::Session in a VDF.
+
+--echo # Install extension
+INSTALL EXTENSION vsql_session_test;
+
+--echo # connection_id matches CONNECTION_ID() of this session
+SELECT vsql_session_test.session_conn_id() = CONNECTION_ID() AS conn_id_matches;
+
+--echo # priv_user matches CURRENT_USER's user part
+SELECT vsql_session_test.session_priv_user() =
+       SUBSTRING_INDEX(CURRENT_USER(), '@', 1) AS priv_user_matches;
+
+--echo # priv_host matches CURRENT_USER's host part
+SELECT vsql_session_test.session_priv_host() =
+       SUBSTRING_INDEX(CURRENT_USER(), '@', -1) AS priv_host_matches;
+
+--echo # kill_status is NOT_KILLED (0) during normal execution
+SELECT vsql_session_test.session_kill_status() AS kill_status;
+
+--echo # schema reflects the current default database, fresh per call
+CREATE DATABASE sctx_db1;
+CREATE DATABASE sctx_db2;
+USE sctx_db1;
+SELECT vsql_session_test.session_schema() AS schema_db1;
+USE sctx_db2;
+SELECT vsql_session_test.session_schema() AS schema_db2;
+
+--echo # priv_user is captured at invocation: a SQL SECURITY DEFINER routine
+--echo # owned by a different account reports that account, not the caller.
+CREATE USER definer_acct@localhost;
+GRANT EXECUTE ON sctx_db2.* TO definer_acct@localhost;
+GRANT EXECUTE ON *.* TO definer_acct@localhost;
+CREATE DEFINER = definer_acct@localhost FUNCTION sctx_db2.who()
+  RETURNS VARCHAR(64) SQL SECURITY DEFINER
+  RETURN vsql_session_test.session_priv_user();
+--echo # Expect definer_acct, proving capture at invocation time
+SELECT sctx_db2.who() AS definer_priv_user;
+
+--echo # Cleanup
+DROP FUNCTION sctx_db2.who;
+DROP USER definer_acct@localhost;
+DROP DATABASE sctx_db1;
+DROP DATABASE sctx_db2;
+USE test;
+UNINSTALL EXTENSION vsql_session_test;

--- a/unittest/gunit/villagesql/CMakeLists.txt
+++ b/unittest/gunit/villagesql/CMakeLists.txt
@@ -23,6 +23,7 @@ SET(VILLAGESQL_UNIT_TESTS
   custom_indexes-t
   identifier_names-t
   semver-t
+  session_context-t
   type_builder-t
   type_context-t
   type_descriptor-t

--- a/unittest/gunit/villagesql/session_context-t.cc
+++ b/unittest/gunit/villagesql/session_context-t.cc
@@ -1,0 +1,128 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <villagesql/abi/types.h>
+#include <villagesql/vsql/func_builder.h>
+#include <villagesql/vsql/func_types.h>
+
+#include "villagesql/vdf/session_context.h"
+
+namespace villagesql_unittest {
+
+class SessionContextAbiTest : public ::testing::Test {};
+
+void session_vdf(vsql::Session, vsql::IntResult) {}
+void regular_vdf(vsql::IntResult) {}
+
+TEST_F(SessionContextAbiTest, KillStatusEnumValues) {
+  EXPECT_EQ(0u, VEF_KILL_NOT_KILLED);
+  EXPECT_EQ(1u, VEF_KILL_CONNECTION);
+  EXPECT_EQ(2u, VEF_KILL_QUERY);
+  EXPECT_EQ(3u, VEF_KILL_TIMEOUT);
+  EXPECT_EQ(255u, VEF_KILL_UNKNOWN);
+}
+
+TEST_F(SessionContextAbiTest, ContextHoldsTier1Fields) {
+  vef_context_t ctx{};
+  ctx.protocol = VEF_PROTOCOL_4;
+  ctx.schema = "mydb";
+  ctx.connection_id = 42;
+  ctx.priv_user = "root";
+  ctx.priv_host = "localhost";
+  ctx.kill_status = VEF_KILL_QUERY;
+
+  EXPECT_STREQ("mydb", ctx.schema);
+  EXPECT_EQ(42u, ctx.connection_id);
+  EXPECT_STREQ("root", ctx.priv_user);
+  EXPECT_STREQ("localhost", ctx.priv_host);
+  EXPECT_EQ(VEF_KILL_QUERY, ctx.kill_status);
+}
+
+TEST_F(SessionContextAbiTest, BuilderOptsInSessionVdfs) {
+  constexpr auto session =
+      vsql::func_builder::make_func<&session_vdf>("session")
+          .returns(vsql::func_builder::INT)
+          .no_params()
+          .build();
+  constexpr auto regular =
+      vsql::func_builder::make_func<&regular_vdf>("regular")
+          .returns(vsql::func_builder::INT)
+          .no_params()
+          .build();
+
+  EXPECT_TRUE(session.uses_session_context());
+  EXPECT_EQ(VEF_PROTOCOL_4, session.required_protocol());
+  EXPECT_FALSE(regular.uses_session_context());
+}
+
+class SessionAccessorTest : public ::testing::Test {};
+
+TEST_F(SessionAccessorTest, ReadsFieldsWhenProtocol4) {
+  vef_context_t ctx{};
+  ctx.protocol = VEF_PROTOCOL_4;
+  ctx.schema = "mydb";
+  ctx.connection_id = 7;
+  ctx.priv_user = "root";
+  ctx.priv_host = "localhost";
+  ctx.kill_status = VEF_KILL_TIMEOUT;
+
+  vsql::Session s(&ctx);
+  EXPECT_TRUE(s.available());
+  EXPECT_EQ("mydb", s.schema());
+  EXPECT_EQ(7u, s.connection_id());
+  EXPECT_EQ("root", s.priv_user());
+  EXPECT_EQ("localhost", s.priv_host());
+  EXPECT_EQ(vsql::KillStatus::Timeout, s.kill_status());
+}
+
+TEST_F(SessionAccessorTest, EmptyWhenProtocolBelow4) {
+  vef_context_t ctx{};
+  ctx.protocol = VEF_PROTOCOL_3;
+  ctx.schema = "should_not_leak";
+
+  vsql::Session s(&ctx);
+  EXPECT_FALSE(s.available());
+  EXPECT_TRUE(s.schema().empty());
+  EXPECT_EQ(0u, s.connection_id());
+  EXPECT_EQ(vsql::KillStatus::NotKilled, s.kill_status());
+}
+
+TEST_F(SessionAccessorTest, EmptyWhenNullPointers) {
+  vef_context_t ctx{};
+  ctx.protocol = VEF_PROTOCOL_4;
+
+  vsql::Session s(&ctx);
+  EXPECT_TRUE(s.available());
+  EXPECT_TRUE(s.schema().empty());
+  EXPECT_TRUE(s.priv_user().empty());
+  EXPECT_TRUE(s.priv_host().empty());
+}
+
+class KillStatusMappingTest : public ::testing::Test {};
+
+TEST_F(KillStatusMappingTest, MapsEachKilledState) {
+  using villagesql::vdf::vef_map_kill_status;
+  EXPECT_EQ(VEF_KILL_NOT_KILLED, vef_map_kill_status(THD::NOT_KILLED));
+  EXPECT_EQ(VEF_KILL_CONNECTION, vef_map_kill_status(THD::KILL_CONNECTION));
+  EXPECT_EQ(VEF_KILL_QUERY, vef_map_kill_status(THD::KILL_QUERY));
+  EXPECT_EQ(VEF_KILL_TIMEOUT, vef_map_kill_status(THD::KILL_TIMEOUT));
+  EXPECT_EQ(VEF_KILL_UNKNOWN, vef_map_kill_status(THD::KILLED_NO_VALUE));
+}
+
+}  // namespace villagesql_unittest

--- a/unittest/gunit/villagesql/type_context-t.cc
+++ b/unittest/gunit/villagesql/type_context-t.cc
@@ -123,7 +123,8 @@ static vef_func_desc_t make_resolve_params_fd(const char *name,
           false,
           nullptr,
           nullptr,
-          0};
+          0,
+          false};
 }
 
 class TypeParametersTest : public ::testing::Test {

--- a/unittest/gunit/villagesql/type_descriptor-t.cc
+++ b/unittest/gunit/villagesql/type_descriptor-t.cc
@@ -242,7 +242,8 @@ TEST_F(TypeDescriptorTest, ConstructionWithParamFunctions) {
                                    false,
                                    nullptr,
                                    nullptr,
-                                   0};
+                                   0,
+                                   false};
 
   static vef_type_t rp_param = {VEF_TYPE_STRING, nullptr};
   static vef_signature_t rp_sig = {1, &rp_param, {VEF_TYPE_STRING, nullptr}};
@@ -256,7 +257,8 @@ TEST_F(TypeDescriptorTest, ConstructionWithParamFunctions) {
                                   false,
                                   nullptr,
                                   nullptr,
-                                  0};
+                                  0,
+                                  false};
 
   villagesql::TypeDescriptor desc(
       villagesql::TypeDescriptorKey("VVECTOR", "test_ext", "1.0.0"),

--- a/villagesql/sdk/README.md
+++ b/villagesql/sdk/README.md
@@ -42,7 +42,7 @@ server.
 | `VEF_PROTOCOL_1` | Stable         | Base protocol (stable as of v0.0.1). Likely to be deprecated before beta.                                                                                                                        |
 | `VEF_PROTOCOL_2` | Deprecated     | Was the unstable development version before being promoted to `VEF_PROTOCOL_3`. The server rejects extensions that declare this version, and no `stable_sdk/v2` snapshot exists.                  |
 | `VEF_PROTOCOL_3` | Stable         | Stable as of v0.0.4. Adds the `deterministic` VDF attribute; VDF-based type operations (encode/decode/compare/hash and int_to_params/resolve_params name fields); a values pointer array; and the preview-capability system. |
-| `VEF_PROTOCOL_4` | In development | Adds `max_result_length` on `vef_func_desc_t` so a STRING result column can be sized to the full value instead of the argument width.                                                             |
+| `VEF_PROTOCOL_4` | In development | Adds `max_result_length` and session-context opt-in on `vef_func_desc_t`, plus session fields (`schema`, `connection_id`, `priv_user`, `priv_host`, `kill_status`) on `vef_context_t`.              |
 
 The enum in `villagesql/sdk/include/villagesql/abi/types.h` is the source of truth
 for protocol status; keep this table in sync with it.

--- a/villagesql/sdk/include/villagesql/abi/types.h
+++ b/villagesql/sdk/include/villagesql/abi/types.h
@@ -188,6 +188,10 @@ typedef enum : unsigned int {
                    //   declare the maximum length of a STRING result so the
                    //   result column is sized to hold the full value instead of
                    //   the argument width (fixes materialization truncation).
+                   // + Session context Tier 1 fields on vef_context_t
+                   //   (schema, connection_id, priv_user, priv_host,
+                   //   kill_status), vef_kill_status_t, and per-function
+                   //   opt-in.
 } vef_protocol_t;
 
 // =============================================================================
@@ -251,13 +255,26 @@ typedef struct {
   const char *extra;
 } vef_version_t;
 
-// Context passed to all function calls (prerun, vdf, postrun)
-//
+// Kill state of the session executing a callback.
+typedef enum : unsigned int {
+  VEF_KILL_NOT_KILLED = 0,
+  VEF_KILL_CONNECTION = 1,
+  VEF_KILL_QUERY = 2,
+  VEF_KILL_TIMEOUT = 3,
+  VEF_KILL_UNKNOWN = 255,
+} vef_kill_status_t;
+
+// Context passed to all function calls (prerun, vdf, postrun).
 typedef struct {
   // protocol version being used
   vef_protocol_t protocol;
 
-  // We foresee adding logger or distributed trace information in this context
+  // protocol >= VEF_PROTOCOL_4
+  const char *schema;
+  uint64_t connection_id;
+  const char *priv_user;
+  const char *priv_host;
+  vef_kill_status_t kill_status;
 } vef_context_t;
 
 typedef struct {
@@ -691,6 +708,9 @@ typedef struct {
   // Distinct from buffer_size, which is only the initial row-time output buffer
   // (it grows on demand); this bounds the column the result is stored into.
   size_t max_result_length;
+
+  // Populate vef_context_t session fields for this function.
+  bool uses_session_context;
 } vef_func_desc_t;
 
 // =============================================================================

--- a/villagesql/sdk/include/villagesql/detail/func_builder.h
+++ b/villagesql/sdk/include/villagesql/detail/func_builder.h
@@ -439,6 +439,8 @@ struct Wrapper {
   static void invoke_impl(vef_context_t *ctx, vef_vdf_args_t *args,
                           vef_vdf_result_t *result,
                           std::index_sequence<Is...>) {
+    (void)ctx;
+    (void)args;
     using Params = typename FuncParamTypes<decltype(Func)>::type;
     std::array<vef_invalue_t, NumParams> vals{
         get_invalue(ctx, args, static_cast<unsigned int>(Is))...};

--- a/villagesql/sdk/include/villagesql/detail/func_builder.h
+++ b/villagesql/sdk/include/villagesql/detail/func_builder.h
@@ -286,6 +286,7 @@ struct FuncWithMetadata {
         num_params(0),
         buffer_size(0),
         max_result_length(0),
+        uses_session_context(false),
         deterministic(false),
         is_varargs(false),
         check_params_cache_bound(nullptr),
@@ -301,6 +302,7 @@ struct FuncWithMetadata {
   size_t num_params;
   size_t buffer_size;
   size_t max_result_length;
+  bool uses_session_context;
   bool deterministic;
   // When true, the function accepts a variable number of arguments. The
   // server skips argument validation and delegates to prerun. num_params
@@ -587,6 +589,42 @@ struct WrapperVoidStarRefState {
     Func(args->user_data,
          make_arg<std::tuple_element_t<1 + Is, Params>>(&vals[Is])...,
          make_result<std::tuple_element_t<1 + NumParams, Params>>(result));
+  }
+
+  template <typename T>
+  static T make_arg(vef_invalue_t *v) {
+    return T(v);
+  }
+  template <typename T>
+  static T make_result(vef_vdf_result_t *r) {
+    return T(r);
+  }
+};
+
+template <typename T>
+struct is_session_param : std::false_type {};
+template <>
+struct is_session_param<::vsql::Session> : std::true_type {};
+
+// Wrapper for VDFs with a leading Session parameter.
+template <auto Func, size_t NumParams>
+struct WrapperWithSession {
+  static void invoke(vef_context_t *ctx, vef_vdf_args_t *args,
+                     vef_vdf_result_t *result) {
+    invoke_impl(ctx, args, result, std::make_index_sequence<NumParams>{});
+  }
+
+ private:
+  template <size_t... Is>
+  static void invoke_impl(vef_context_t *ctx, vef_vdf_args_t *args,
+                          vef_vdf_result_t *result,
+                          std::index_sequence<Is...>) {
+    using Params = typename FuncParamTypes<decltype(Func)>::type;
+    std::array<vef_invalue_t, NumParams> vals{
+        get_invalue(ctx, args, static_cast<unsigned int>(Is))...};
+    Func(::vsql::Session(ctx),
+         make_arg<std::tuple_element_t<1 + Is, Params>>(&vals[Is])...,
+         make_result<std::tuple_element_t<NumParams + 1, Params>>(result));
   }
 
   template <typename T>
@@ -1093,6 +1131,7 @@ struct StaticFuncDesc {
   vef_vdf_accumulate_func_t accumulate_;
   size_t buffer_size_;
   size_t max_result_length_;
+  bool uses_session_context_;
   bool deterministic_;
   bool is_varargs_;
   bool (*check_params_cache_bound_)();
@@ -1110,11 +1149,12 @@ struct StaticFuncDesc {
   // Varargs reads args->values (protocol-3 pointer-array layout) without a
   // protocol-1 fallback, so a varargs VDF cannot run on protocol 1.
   constexpr vef_protocol_t required_protocol() const {
-    if (max_result_length_ > 0) return VEF_PROTOCOL_4;
+    if (max_result_length_ > 0 || uses_session_context_) return VEF_PROTOCOL_4;
     return is_varargs_ ? VEF_PROTOCOL_3 : VEF_PROTOCOL_1;
   }
   constexpr size_t buffer_size() const { return buffer_size_; }
   constexpr size_t max_result_length() const { return max_result_length_; }
+  constexpr bool uses_session_context() const { return uses_session_context_; }
   constexpr bool deterministic() const { return deterministic_; }
   constexpr auto check_params_cache_bound() const -> bool (*)() {
     return check_params_cache_bound_;
@@ -1143,6 +1183,7 @@ struct StaticFuncDesc {
         accumulate_(meta.accumulate),
         buffer_size_(meta.buffer_size),
         max_result_length_(meta.max_result_length),
+        uses_session_context_(meta.uses_session_context),
         deterministic_(meta.deterministic),
         is_varargs_(meta.is_varargs),
         check_params_cache_bound_(meta.check_params_cache_bound),

--- a/villagesql/sdk/include/villagesql/detail/func_builder.h
+++ b/villagesql/sdk/include/villagesql/detail/func_builder.h
@@ -439,13 +439,17 @@ struct Wrapper {
   static void invoke_impl(vef_context_t *ctx, vef_vdf_args_t *args,
                           vef_vdf_result_t *result,
                           std::index_sequence<Is...>) {
-    (void)ctx;
-    (void)args;
     using Params = typename FuncParamTypes<decltype(Func)>::type;
-    std::array<vef_invalue_t, NumParams> vals{
-        get_invalue(ctx, args, static_cast<unsigned int>(Is))...};
-    Func(make_arg<std::tuple_element_t<Is, Params>>(&vals[Is])...,
-         make_result<std::tuple_element_t<NumParams, Params>>(result));
+    if constexpr (NumParams == 0) {
+      (void)ctx;
+      (void)args;
+      Func(make_result<std::tuple_element_t<0, Params>>(result));
+    } else {
+      std::array<vef_invalue_t, NumParams> vals{
+          get_invalue(ctx, args, static_cast<unsigned int>(Is))...};
+      Func(make_arg<std::tuple_element_t<Is, Params>>(&vals[Is])...,
+           make_result<std::tuple_element_t<NumParams, Params>>(result));
+    }
   }
 
   template <typename T>
@@ -622,11 +626,17 @@ struct WrapperWithSession {
                           vef_vdf_result_t *result,
                           std::index_sequence<Is...>) {
     using Params = typename FuncParamTypes<decltype(Func)>::type;
-    std::array<vef_invalue_t, NumParams> vals{
-        get_invalue(ctx, args, static_cast<unsigned int>(Is))...};
-    Func(::vsql::Session(ctx),
-         make_arg<std::tuple_element_t<1 + Is, Params>>(&vals[Is])...,
-         make_result<std::tuple_element_t<NumParams + 1, Params>>(result));
+    if constexpr (NumParams == 0) {
+      (void)args;
+      Func(::vsql::Session(ctx),
+           make_result<std::tuple_element_t<1, Params>>(result));
+    } else {
+      std::array<vef_invalue_t, NumParams> vals{
+          get_invalue(ctx, args, static_cast<unsigned int>(Is))...};
+      Func(::vsql::Session(ctx),
+           make_arg<std::tuple_element_t<1 + Is, Params>>(&vals[Is])...,
+           make_result<std::tuple_element_t<NumParams + 1, Params>>(result));
+    }
   }
 
   template <typename T>

--- a/villagesql/sdk/include/villagesql/detail/vef_register.h
+++ b/villagesql/sdk/include/villagesql/detail/vef_register.h
@@ -51,6 +51,13 @@ struct has_max_result_length<
     T, std::void_t<decltype(std::declval<const T &>().max_result_length())>>
     : std::true_type {};
 
+template <typename T, typename = void>
+struct has_uses_session_context : std::false_type {};
+template <typename T>
+struct has_uses_session_context<
+    T, std::void_t<decltype(std::declval<const T &>().uses_session_context())>>
+    : std::true_type {};
+
 template <typename FuncData, size_t Index>
 __attribute__((visibility("hidden"))) vef_func_desc_t *materialize_func_desc(
     const FuncData &func_data) {
@@ -81,6 +88,11 @@ __attribute__((visibility("hidden"))) vef_func_desc_t *materialize_func_desc(
     desc.max_result_length = func_data.max_result_length();
   } else {
     desc.max_result_length = 0;
+  }
+  if constexpr (has_uses_session_context<FuncData>::value) {
+    desc.uses_session_context = func_data.uses_session_context();
+  } else {
+    desc.uses_session_context = false;
   }
   desc.deterministic = func_data.deterministic();
   desc.clear = func_data.clear();

--- a/villagesql/sdk/include/villagesql/vsql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_builder.h
@@ -328,6 +328,15 @@ class FuncBuilder {
                   "make_func: C++ function must return void and set the SQL "
                   "result through the final typed result wrapper parameter");
 
+    constexpr bool has_session_param = []() constexpr {
+      if constexpr (std::tuple_size_v<AllParams> >= 1) {
+        return detail::is_session_param<
+            std::tuple_element_t<0, AllParams>>::value;
+      } else {
+        return false;
+      }
+    }();
+
     // Detect state-style signatures: first parameter is `void*` or any
     // lvalue reference (State& / const State&). Aggregate result-shape
     // functions also have a `const State&` first parameter but go through
@@ -346,6 +355,12 @@ class FuncBuilder {
     if constexpr (Mode == ParamMode::kVarargs) {
       meta.f = &detail::VarArgsWrapper<Func>::invoke;
       meta.is_varargs = true;
+    } else if constexpr (has_session_param) {
+      static_assert(std::tuple_size_v<AllParams> == NumParams + 2,
+                    "make_func: Session-style VDF must have one Session "
+                    "parameter, then the declared SQL parameters, then a "
+                    "typed result wrapper");
+      meta.f = &detail::WrapperWithSession<Func, NumParams>::invoke;
     } else if constexpr (has_state_param) {
       // Shapes:
       //   void(State&, TypedArgs..., ResultWrapper)     — typed state, mutable
@@ -414,6 +429,7 @@ class FuncBuilder {
     meta.num_params = NumParams;
     meta.buffer_size = buffer_size_;
     meta.max_result_length = max_result_length_;
+    meta.uses_session_context = has_session_param;
     meta.deterministic = deterministic_;
     for (size_t i = 0; i < NumParams; ++i) {
       meta.param_types[i] = detail::to_vef_type(param_types_[i]);

--- a/villagesql/sdk/include/villagesql/vsql/func_types.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_types.h
@@ -321,6 +321,49 @@ class CustomResultWith {
   vef_vdf_result_t *r_;
 };
 
+enum class KillStatus {
+  NotKilled = VEF_KILL_NOT_KILLED,
+  Connection = VEF_KILL_CONNECTION,
+  Query = VEF_KILL_QUERY,
+  Timeout = VEF_KILL_TIMEOUT,
+  Unknown = VEF_KILL_UNKNOWN,
+};
+
+// Read-only session context for a VDF call. Use as the first parameter.
+// Returned string views are valid only for the call.
+class Session {
+ public:
+  explicit Session(const vef_context_t *ctx) : ctx_(ctx) {}
+
+  bool available() const { return ctx_->protocol >= VEF_PROTOCOL_4; }
+
+  std::string_view schema() const {
+    return (available() && ctx_->schema != nullptr)
+               ? std::string_view(ctx_->schema)
+               : std::string_view{};
+  }
+  std::string_view priv_user() const {
+    return (available() && ctx_->priv_user != nullptr)
+               ? std::string_view(ctx_->priv_user)
+               : std::string_view{};
+  }
+  std::string_view priv_host() const {
+    return (available() && ctx_->priv_host != nullptr)
+               ? std::string_view(ctx_->priv_host)
+               : std::string_view{};
+  }
+  uint64_t connection_id() const {
+    return available() ? ctx_->connection_id : 0;
+  }
+  KillStatus kill_status() const {
+    return available() ? static_cast<KillStatus>(ctx_->kill_status)
+                       : KillStatus::NotKilled;
+  }
+
+ private:
+  const vef_context_t *ctx_;
+};
+
 }  // namespace vsql
 
 #endif  // VILLAGESQL_VSQL_FUNC_TYPES_H

--- a/villagesql/test-extensions/CMakeLists.txt
+++ b/villagesql/test-extensions/CMakeLists.txt
@@ -57,6 +57,7 @@ vsql_add_test_extension(vsql-huge-var-test             vsql_huge_var_test)
 vsql_add_test_extension(vsql-bitfield-test             vsql_bitfield_test)
 vsql_add_test_extension(vsql-tarray-test               vsql_tarray_test)
 vsql_add_test_extension(vsql-resolve-only-test         vsql_resolve_only_test)
+vsql_add_test_extension(vsql-session-test              vsql_session_test)
 
 # update_test installable + three target variants exercise the pre-checks
 # of the extension version-update path. The VEB filename is

--- a/villagesql/test-extensions/vsql-session-test/manifest.json
+++ b/villagesql/test-extensions/vsql-session-test/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "vsql_session_test",
+  "version": "0.0.1",
+  "description": "VillageSQL extension exercising Tier 1 session context fields",
+  "author": "VillageSQL Community",
+  "license": "GPL-2.0"
+}

--- a/villagesql/test-extensions/vsql-session-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-session-test/src/extension.cc
@@ -1,0 +1,55 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#include <villagesql/vsql.h>
+
+using namespace vsql;
+
+void session_schema(Session s, StringResult out) { out.set(s.schema()); }
+
+void session_priv_user(Session s, StringResult out) { out.set(s.priv_user()); }
+
+void session_priv_host(Session s, StringResult out) { out.set(s.priv_host()); }
+
+void session_conn_id(Session s, IntResult out) {
+  out.set(static_cast<long long>(s.connection_id()));
+}
+
+void session_kill_status(Session s, IntResult out) {
+  out.set(static_cast<long long>(s.kill_status()));
+}
+
+VEF_GENERATE_ENTRY_POINTS(
+    make_extension()
+        .func(make_func<&session_schema>("session_schema")
+                  .returns(STRING)
+                  .no_params()
+                  .build())
+        .func(make_func<&session_priv_user>("session_priv_user")
+                  .returns(STRING)
+                  .no_params()
+                  .build())
+        .func(make_func<&session_priv_host>("session_priv_host")
+                  .returns(STRING)
+                  .no_params()
+                  .build())
+        .func(make_func<&session_conn_id>("session_conn_id")
+                  .returns(INT)
+                  .no_params()
+                  .build())
+        .func(make_func<&session_kill_status>("session_kill_status")
+                  .returns(INT)
+                  .no_params()
+                  .build()))

--- a/villagesql/vdf/session_context.h
+++ b/villagesql/vdf/session_context.h
@@ -1,0 +1,43 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+#ifndef VILLAGESQL_VDF_SESSION_CONTEXT_H
+#define VILLAGESQL_VDF_SESSION_CONTEXT_H
+
+#include "sql/sql_class.h"
+#include "villagesql/sdk/include/villagesql/abi/types.h"
+
+namespace villagesql::vdf {
+
+// THD::killed_state uses MySQL error-code values, so map instead of casting.
+inline vef_kill_status_t vef_map_kill_status(THD::killed_state k) {
+  switch (k) {
+    case THD::NOT_KILLED:
+      return VEF_KILL_NOT_KILLED;
+    case THD::KILL_CONNECTION:
+      return VEF_KILL_CONNECTION;
+    case THD::KILL_QUERY:
+      return VEF_KILL_QUERY;
+    case THD::KILL_TIMEOUT:
+      return VEF_KILL_TIMEOUT;
+    case THD::KILLED_NO_VALUE:
+      return VEF_KILL_UNKNOWN;
+  }
+  return VEF_KILL_UNKNOWN;
+}
+
+}  // namespace villagesql::vdf
+
+#endif  // VILLAGESQL_VDF_SESSION_CONTEXT_H

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -20,6 +20,7 @@
 #include "lex_string.h"
 #include "my_sys.h"
 #include "mysql/strings/m_ctype.h"
+#include "sql/auth/sql_security_ctx.h"
 #include "sql/current_thd.h"
 #include "sql/derror.h"
 #include "sql/item.h"
@@ -31,6 +32,7 @@
 #include "villagesql/schema/descriptor/type_context.h"
 #include "villagesql/types/from_string_inference.h"
 #include "villagesql/types/util.h"
+#include "villagesql/vdf/session_context.h"
 
 namespace villagesql {
 namespace vdf {
@@ -63,7 +65,12 @@ static size_t RoundUpResultBuffer(size_t needed) {
   return (needed + (kResultBufferQuantum - 1)) & ~(kResultBufferQuantum - 1);
 }
 
-vdf_handler::vdf_handler(udf_func *u_d) : m_udf(u_d) {}
+vdf_handler::vdf_handler(udf_func *u_d)
+    : m_udf(u_d),
+      m_uses_session_context(u_d != nullptr &&
+                             u_d->vdf_protocol >= VEF_PROTOCOL_4 &&
+                             u_d->vdf_func_desc != nullptr &&
+                             u_d->vdf_func_desc->uses_session_context) {}
 
 bool vdf_handler::returns_string() const {
   return m_udf && m_udf->vdf_func_desc &&
@@ -80,13 +87,40 @@ bool vdf_handler::MaybeResizeBuffer(size_t needed) {
   return false;
 }
 
-bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
-                             Item_result_field *func [[maybe_unused]],
+void vdf_handler::initialize_session_context() {
+  if (m_thd == nullptr) {
+    m_context.schema = nullptr;
+    m_context.connection_id = 0;
+    m_context.priv_user = nullptr;
+    m_context.priv_host = nullptr;
+    m_session_context_initialized = true;
+    return;
+  }
+
+  const LEX_CSTRING db = m_thd->db();
+  m_context.schema = (db.str != nullptr && db.length > 0) ? db.str : nullptr;
+  m_context.connection_id = m_thd->thread_id();
+
+  const Security_context *sctx = m_thd->security_context();
+  m_context.priv_user = sctx->priv_user().str;
+  m_context.priv_host = sctx->priv_host().str;
+  m_session_context_initialized = true;
+}
+
+void vdf_handler::prepare_session_context() {
+  if (!m_session_context_initialized) initialize_session_context();
+  m_context.kill_status = m_thd == nullptr
+                              ? VEF_KILL_NOT_KILLED
+                              : vef_map_kill_status(m_thd->killed.load());
+}
+
+bool vdf_handler::fix_fields(THD *thd, Item_result_field *func [[maybe_unused]],
                              uint arg_count, Item **arguments,
                              String *buffers) {
   m_args = arguments;
   m_buffers = buffers;
   m_arg_count = arg_count;
+  m_thd = thd;
 
   // Allocate invalues array for argument marshaling
   if (arg_count > 0) {
@@ -254,6 +288,7 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
     prerun_result.result_buffer_size = 0;
     prerun_result.user_data = nullptr;
 
+    if (m_uses_session_context) prepare_session_context();
     m_udf->vdf_func_desc->prerun(&m_context, &prerun_args, &prerun_result);
 
     if (prerun_result.type == VEF_RESULT_WARNING ||
@@ -304,6 +339,7 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
 }
 
 void vdf_handler::clear() {
+  if (m_uses_session_context) prepare_session_context();
   m_udf->vdf_func_desc->clear(&m_context, &m_vdf_args);
 }
 
@@ -313,6 +349,7 @@ void vdf_handler::accumulate(bool *null_value) {
   result.type = VEF_RESULT_VALUE;
   m_error_msg[0] = '\0';
   result.error_msg = m_error_msg;
+  if (m_uses_session_context) prepare_session_context();
   m_udf->vdf_func_desc->accumulate(&m_context, &m_vdf_args, &result);
   switch (result.type) {
     case VEF_RESULT_VALUE:
@@ -343,9 +380,11 @@ void vdf_handler::cleanup() {
     vef_postrun_args_t postrun_args{};
     postrun_args.user_data = m_vdf_args.user_data;
     vef_postrun_result_t postrun_result{};
+    if (m_uses_session_context) prepare_session_context();
     m_udf->vdf_func_desc->postrun(&m_context, &postrun_args, &postrun_result);
   }
   m_active = false;
+  m_session_context_initialized = false;
 }
 
 template <typename InvalueType>
@@ -459,6 +498,7 @@ bool vdf_handler::invoke_numeric(T *out_value, bool *null_value) {
   result.error_msg = m_error_msg;
 
   // Call the VDF function
+  if (m_uses_session_context) prepare_session_context();
   m_udf->vdf_func_desc->vdf(&m_context, &m_vdf_args, &result);
 
   // Handle result
@@ -565,6 +605,7 @@ String *vdf_handler::val_str(String *str, String *save_str,
       result.alt_str_buf = nullptr;
     }
 
+    if (m_uses_session_context) prepare_session_context();
     m_udf->vdf_func_desc->vdf(&m_context, &m_vdf_args, &result);
 
     if (result.type != VEF_RESULT_VALUE ||

--- a/villagesql/vdf/vdf_handler.h
+++ b/villagesql/vdf/vdf_handler.h
@@ -61,6 +61,9 @@ class vdf_handler {
 
  private:
   udf_func *m_udf;
+  THD *m_thd{nullptr};
+  bool m_uses_session_context{false};
+  bool m_session_context_initialized{false};
   Item **m_args{nullptr};
   String *m_buffers{nullptr};
   uint m_arg_count{0};
@@ -75,6 +78,9 @@ class vdf_handler {
   char *m_error_msg{nullptr};
   bool m_active{false};
   const villagesql::TypeContext *m_return_type_context{nullptr};
+
+  void initialize_session_context();
+  void prepare_session_context();
 
   // Marshal arguments into m_invalues array based on declared parameter types
   void marshal_args();


### PR DESCRIPTION
## Description

Adds Tier 1 read-only session context to the VEF extension ABI: a `vef_kill_status_t` enum and five fields (`schema`, `connection_id`, `priv_user`, `priv_host`, `kill_status`) on `vef_context_t`. The server refreshes them from `current_thd` immediately before every VDF callback (all six dispatch sites in `vdf_handler.cc`), so they reflect the session at invocation time — `SQL SECURITY DEFINER` swaps the security context and the default schema can change between parse and execute. Typed VDFs read them through a new `vsql::Session` parameter (mirroring `vsql::VarArgs`).

Fields are gated under `VEF_PROTOCOL_4` and appended to `vef_context_t`, so extensions built against an older protocol are unaffected.

First of a stacked series for session context (#454); the Tier 2 `vsql::preview::session` capability follows in a PR.

## Related Issue

Part of #454.

## How was this tested?

- Unit (`ctest -L villagesql -R session_context-t`): kill-status mapping across every `THD::killed_state`; `vsql::Session` accessors including protocol gating and null-pointer degradation.
- mysql-test (`--suite=villagesql/extension/vsql-session`): `connection_id`/`priv_user`/`priv_host` against `CONNECTION_ID()`/`CURRENT_USER()`, `schema` freshness across two `USE` statements, and a `SQL SECURITY DEFINER` routine proving `priv_user` is captured at invocation (returns the definer, not the caller).

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4

### Disclosure
AI was used for running tests and commit messages creation.
