### PR TITLE
Grow result buffer for VDFs

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_vdf_string_overflow.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_vdf_string_overflow.result
@@ -1,0 +1,40 @@
+call mtr.add_suppression("Orphaned expansion directory found but not removed");
+# restart: --veb-dir=MYSQLTEST_VARDIR/veb
+Creating extension agg_vdf_ext using SDK...
+Created agg_vdf_ext.veb
+INSTALL EXTENSION agg_vdf_ext;
+CREATE TABLE s_data (id INT PRIMARY KEY AUTO_INCREMENT, s VARCHAR(60));
+SELECT LENGTH(agg_vdf_ext.vdf_concat(s)) AS len FROM s_data WHERE id <= 30;
+len
+1529
+SELECT LENGTH(agg_vdf_ext.vdf_concat(s)) AS len FROM s_data;
+len
+5099
+SELECT INSTR(agg_vdf_ext.vdf_concat(s), REPEAT('A', 50)) > 0 AS field_intact
+FROM s_data;
+field_intact
+1
+CREATE TABLE g_data (id INT PRIMARY KEY AUTO_INCREMENT, grp INT, s VARCHAR(60));
+SELECT grp, LENGTH(agg_vdf_ext.vdf_concat(s)) AS len
+FROM g_data
+GROUP BY grp
+ORDER BY grp;
+grp	len
+0	1019
+1	1019
+DROP TABLE g_data;
+SET @old_map = @@global.max_allowed_packet;
+SET GLOBAL max_allowed_packet = 1024;
+Warnings:
+Warning	1708	The value of 'max_allowed_packet' should be no less than the value of 'net_buffer_length'
+SELECT LENGTH(agg_vdf_ext.vdf_concat(s)) AS len FROM s_data;
+len
+NULL
+Warnings:
+Warning	1301	Result of vdf_concat() was larger than max_allowed_packet (1024) - truncated
+SHOW WARNINGS;
+Level	Code	Message
+Warning	1301	Result of vdf_concat() was larger than max_allowed_packet (1024) - truncated
+SET GLOBAL max_allowed_packet = @old_map;
+DROP TABLE s_data;
+UNINSTALL EXTENSION agg_vdf_ext;

--- a/mysql-test/suite/villagesql/extension/t/extension_vdf_string_overflow.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_vdf_string_overflow.test
@@ -1,0 +1,95 @@
+# A STRING-returning VDF writes its result through the SDK StringResult wrapper.
+# The wrapper follows an snprintf-style overflow contract: it copies what
+# fits but reports the full size via actual_len. The server (vdf_handler) sees
+# actual_len > buffer size, grows the buffer (rounded up to a 1 KiB quantum),
+# and re-invokes the VDF so the full value is returned.
+#
+# vdf_concat is an aggregate STRING-returning VDF (out.set(state)) -- the same
+# shape as the STATS_TTEST aggregate in the bug report. By concatenating enough
+# rows we drive its output past the limit, exercising the grow-and-retry path.
+
+# Setup VEB directory for testing
+--let $veb_dir = $MYSQLTEST_VARDIR/veb
+--exec mkdir -p $veb_dir
+
+call mtr.add_suppression("Orphaned expansion directory found but not removed");
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--let $restart_parameters = restart: --veb-dir=$veb_dir
+--source include/restart_mysqld.inc
+
+# Build and install the aggregate VDF test extension (provides vdf_concat)
+--let $extension_name = agg_vdf_ext
+--let $extension_version = 1.0.0
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/aggregate_vdf.cc
+--source include/villagesql/create_extension_sdk.inc
+
+INSTALL EXTENSION agg_vdf_ext;
+
+# Each row holds a fixed 50-byte string. vdf_concat joins them with a single
+# ',' separator, so for N rows the result is exactly N*50 + (N-1) bytes,
+# independent of aggregation order (only the length is asserted; the order in
+# which rows are concatenated is not guaranteed).
+CREATE TABLE s_data (id INT PRIMARY KEY AUTO_INCREMENT, s VARCHAR(60));
+
+--disable_query_log
+let $i = 100;
+while ($i)
+{
+  eval INSERT INTO s_data (s) VALUES (REPEAT(CHAR(65 + ($i % 26)), 50));
+  dec $i;
+}
+--enable_query_log
+
+# 30 rows -> 30*50 + 29 = 1529 bytes. Past the 1 KiB default buffer, so this
+# requires one grow-and-retry.
+SELECT LENGTH(agg_vdf_ext.vdf_concat(s)) AS len FROM s_data WHERE id <= 30;
+
+# 100 rows -> 100*50 + 99 = 5099 bytes. A larger result reached via the same
+# high-water-mark buffer.
+SELECT LENGTH(agg_vdf_ext.vdf_concat(s)) AS len FROM s_data;
+
+# The value is intact, not just long: a full 50-byte field from the middle of
+# the stream must survive uncorrupted (the rows include a run of 50 'A's).
+SELECT INSTR(agg_vdf_ext.vdf_concat(s), REPEAT('A', 50)) > 0 AS field_intact
+FROM s_data;
+
+# After grouping, the aggregate value streams straight to the client, so a
+# per-group result past the buffer default still comes back in full -- the
+# buffer fix applies on this path too. Each group concatenates 20*50 + 19 =
+# 1019 bytes.
+#
+# TODO(villagesql-beta): fix materialization cutoff
+CREATE TABLE g_data (id INT PRIMARY KEY AUTO_INCREMENT, grp INT, s VARCHAR(60));
+--disable_query_log
+let $i = 40;
+while ($i)
+{
+  eval INSERT INTO g_data (grp, s) VALUES ($i % 2, REPEAT('z', 50));
+  dec $i;
+}
+--enable_query_log
+SELECT grp, LENGTH(agg_vdf_ext.vdf_concat(s)) AS len
+FROM g_data
+GROUP BY grp
+ORDER BY grp;
+DROP TABLE g_data;
+
+# Buffer growth is capped by max_allowed_packet: like MySQL's built-in string
+# functions (CONCAT, REPEAT, ...), a result larger than the cap yields a
+# row-level warning and NULL, not a truncated value or a fatal error. Use a
+# fresh connection so the low global value takes effect without disturbing the
+# default connection.
+SET @old_map = @@global.max_allowed_packet;
+SET GLOBAL max_allowed_packet = 1024;
+
+--connect (con_cap, localhost, root,,)
+SELECT LENGTH(agg_vdf_ext.vdf_concat(s)) AS len FROM s_data;
+SHOW WARNINGS;
+--connection default
+--disconnect con_cap
+
+SET GLOBAL max_allowed_packet = @old_map;
+
+# Cleanup
+DROP TABLE s_data;
+UNINSTALL EXTENSION agg_vdf_ext;

--- a/villagesql/sdk/include/villagesql/vsql/func_types.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_types.h
@@ -223,9 +223,13 @@ class StringResult {
     r_->type = VEF_RESULT_VALUE;
   }
   void set(std::string_view sv) {
-    size_t len = sv.size() < r_->max_str_len ? sv.size() : r_->max_str_len;
-    memcpy(r_->str_buf, sv.data(), len);
-    set_length(len);
+    size_t copy_len = sv.size() < r_->max_str_len ? sv.size() : r_->max_str_len;
+    memcpy(r_->str_buf, sv.data(), copy_len);
+    // Report the full size even when it does not fit: the server detects
+    // actual_len > max_str_len, grows the buffer, and re-invokes the VDF
+    // (snprintf-style overflow contract). Only copy_len bytes are valid until
+    // that retry.
+    set_length(sv.size());
   }
   void set_null() { r_->type = VEF_RESULT_NULL; }
   void warning(std::string_view msg) {

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -21,6 +21,7 @@
 #include "my_sys.h"
 #include "mysql/strings/m_ctype.h"
 #include "sql/current_thd.h"
+#include "sql/derror.h"
 #include "sql/item.h"
 #include "sql/item_func.h"
 #include "sql/sql_class.h"
@@ -48,11 +49,35 @@ static bool is_inferrable_string_const(Item *arg) {
   return false;
 }
 
+// Default result-buffer size for STRING/CUSTOM returns when the extension does
+// not declare its own buffer_size. Most JSON/text results fit in 1 KiB, so
+// this avoids a reallocation in the common case.
+static constexpr size_t kDefaultResultBufferSize = 1024;
+
+// Result-buffer growth quantum. Reallocations round up to a multiple of this
+// so a value that creeps larger row-over-row settles after one grow rather
+// than reallocating repeatedly. Must be a power of two.
+static constexpr size_t kResultBufferQuantum = 1024;
+
+static size_t RoundUpResultBuffer(size_t needed) {
+  return (needed + (kResultBufferQuantum - 1)) & ~(kResultBufferQuantum - 1);
+}
+
 vdf_handler::vdf_handler(udf_func *u_d) : m_udf(u_d) {}
 
 bool vdf_handler::returns_string() const {
   return m_udf && m_udf->vdf_func_desc &&
          m_udf->vdf_func_desc->signature->return_type.id == VEF_TYPE_STRING;
+}
+
+bool vdf_handler::MaybeResizeBuffer(size_t needed) {
+  if (needed <= m_result_buffer_size) return false;
+  const size_t new_size = RoundUpResultBuffer(needed);
+  char *buf = pointer_cast<char *>((*THR_MALLOC)->Alloc(new_size));
+  if (buf == nullptr) return true;
+  m_result_buffer = buf;
+  m_result_buffer_size = new_size;
+  return false;
 }
 
 bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
@@ -91,29 +116,25 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
   const vef_type_id return_type =
       m_udf->vdf_func_desc->signature->return_type.id;
   if (return_type == VEF_TYPE_STRING || return_type == VEF_TYPE_CUSTOM) {
-    m_result_buffer_size = m_udf->vdf_func_desc->buffer_size > 0
-                               ? m_udf->vdf_func_desc->buffer_size
-                               : 256;
+    size_t needed = m_udf->vdf_func_desc->buffer_size > 0
+                        ? m_udf->vdf_func_desc->buffer_size
+                        : kDefaultResultBufferSize;
     // STRING-returning VDFs whose argument is a custom type (e.g. the type's
     // to_string / decode VDF) emit output whose size scales with the input
     // value, bounded by max_decode_buffer_length on the argument's
     // TypeContext.  Raise the buffer to fit so that, for example,
     // SVECTOR::to_string(v) has room to decode a wide vector.  prerun can
-    // still grow the buffer further below if it requests more.
+    // still grow the buffer further below if it requests more, and val_str
+    // grows it at row time if the VDF reports its output did not fit.
     if (return_type == VEF_TYPE_STRING) {
       for (uint i = 0; i < arg_count; i++) {
         const auto *tc = m_args[i]->get_type_context();
         if (tc == nullptr) continue;
-        const size_t needed =
-            static_cast<size_t>(tc->max_decode_buffer_length());
-        if (needed > 0 && needed > m_result_buffer_size) {
-          m_result_buffer_size = needed;
-        }
+        const size_t dec = static_cast<size_t>(tc->max_decode_buffer_length());
+        if (dec > needed) needed = dec;
       }
     }
-    m_result_buffer =
-        pointer_cast<char *>((*THR_MALLOC)->Alloc(m_result_buffer_size));
-    if (!m_result_buffer) return true;
+    if (MaybeResizeBuffer(needed)) return true;
   }
 
   m_context.protocol = m_udf->vdf_protocol;
@@ -243,13 +264,7 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
     m_vdf_args.user_data = prerun_result.user_data;
 
     // Handle buffer size request
-    // TODO(villagesql): refactor to MaybeResizeBuffer()
-    if (prerun_result.result_buffer_size > m_result_buffer_size) {
-      m_result_buffer_size = prerun_result.result_buffer_size;
-      m_result_buffer =
-          pointer_cast<char *>((*THR_MALLOC)->Alloc(m_result_buffer_size));
-      if (!m_result_buffer) return true;
-    }
+    if (MaybeResizeBuffer(prerun_result.result_buffer_size)) return true;
   }
 
   // Set return type_context if this VDF returns a custom type. Pass the
@@ -274,13 +289,9 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
     if (m_return_type_context != nullptr) {
       const int64_t buffer_len = m_return_type_context->field_buffer_length();
       assert(!m_return_type_context->is_variable_length() || buffer_len > 0);
-      // TODO(villagesql): refactor to MaybeResizeBuffer()
       if (buffer_len > 0 &&
-          static_cast<size_t>(buffer_len) > m_result_buffer_size) {
-        m_result_buffer_size = static_cast<size_t>(buffer_len);
-        m_result_buffer =
-            pointer_cast<char *>((*THR_MALLOC)->Alloc(m_result_buffer_size));
-        if (!m_result_buffer) return true;
+          MaybeResizeBuffer(static_cast<size_t>(buffer_len))) {
+        return true;
       }
     }
   }
@@ -514,36 +525,72 @@ String *vdf_handler::val_str(String *str, String *save_str,
                              const CHARSET_INFO *charset) {
   marshal_args();
 
-  // Set up result structure based on return type
-  vef_vdf_result_t result{};
-  result.type = VEF_RESULT_VALUE;
-  result.actual_len = 0;
-  m_error_msg[0] = '\0';
-  result.error_msg = m_error_msg;
-
   const vef_type_id return_type =
       m_udf->vdf_func_desc->signature->return_type.id;
   const bool is_binary = (return_type == VEF_TYPE_CUSTOM);
 
-  if (is_binary) {
-    result.bin_buf = reinterpret_cast<unsigned char *>(m_result_buffer);
-    result.max_bin_len = m_result_buffer_size;
-    result.alt_bin_buf = nullptr;
-    if (m_return_type_context != nullptr) {
-      const auto &params = m_return_type_context->parameters();
-      result.type_params = {params.count(), params.key_data(),
-                            params.value_data()};
-    } else {
-      result.type_params = {0, nullptr, nullptr};
-    }
-  } else {
-    result.str_buf = m_result_buffer;
-    result.max_str_len = m_result_buffer_size;
-    result.alt_str_buf = nullptr;
-  }
+  // Call the VDF, growing the result buffer and retrying once if the VDF
+  // reports (via actual_len) that its output did not fit. The SDK result
+  // wrappers follow an snprintf-style contract: they copy what fits but set
+  // actual_len to the full size that *would* have been written. One retry
+  // always suffices because actual_len tells us exactly how large the buffer
+  // must be. marshal_args() stays outside the loop: the re-invocation runs on
+  // the already-marshaled arguments (aggregates re-serialize their accumulated
+  // state; deterministic scalars reproduce the same bytes).
+  vef_vdf_result_t result{};
+  for (int attempt = 0; attempt < 2; ++attempt) {
+    result = vef_vdf_result_t{};
+    result.type = VEF_RESULT_VALUE;
+    result.actual_len = 0;
+    m_error_msg[0] = '\0';
+    result.error_msg = m_error_msg;
 
-  // Call the VDF function
-  m_udf->vdf_func_desc->vdf(&m_context, &m_vdf_args, &result);
+    if (is_binary) {
+      result.bin_buf = reinterpret_cast<unsigned char *>(m_result_buffer);
+      result.max_bin_len = m_result_buffer_size;
+      result.alt_bin_buf = nullptr;
+      if (m_return_type_context != nullptr) {
+        const auto &params = m_return_type_context->parameters();
+        result.type_params = {params.count(), params.key_data(),
+                              params.value_data()};
+      } else {
+        result.type_params = {0, nullptr, nullptr};
+      }
+    } else {
+      result.str_buf = m_result_buffer;
+      result.max_str_len = m_result_buffer_size;
+      result.alt_str_buf = nullptr;
+    }
+
+    m_udf->vdf_func_desc->vdf(&m_context, &m_vdf_args, &result);
+
+    if (result.type != VEF_RESULT_VALUE ||
+        result.actual_len <= m_result_buffer_size) {
+      break;
+    }
+
+    // The output overflowed our buffer. Grow to fit and retry once.
+    if (attempt == 1) {
+      // A well-behaved VDF reports a stable size, so the grown buffer must
+      // fit. Guard against a pathological VDF rather than loop forever.
+      my_printf_error(ER_UDF_ERROR,
+                      "VDF result for function '%s' did not fit after resize",
+                      MYF(0), func_name);
+      return nullptr;
+    }
+    // Mirror MySQL's built-in string functions (e.g. CONCAT, REPEAT): a result
+    // larger than max_allowed_packet is a row-level warning and NULL, not a
+    // fatal error that aborts the statement.
+    if (result.actual_len > current_thd->variables.max_allowed_packet) {
+      push_warning_printf(
+          current_thd, Sql_condition::SL_WARNING,
+          ER_WARN_ALLOWED_PACKET_OVERFLOWED,
+          ER_THD(current_thd, ER_WARN_ALLOWED_PACKET_OVERFLOWED), func_name,
+          current_thd->variables.max_allowed_packet);
+      return nullptr;
+    }
+    if (MaybeResizeBuffer(result.actual_len)) return nullptr;
+  }
 
   // Handle result
   switch (result.type) {

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -130,8 +130,8 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
       for (uint i = 0; i < arg_count; i++) {
         const auto *tc = m_args[i]->get_type_context();
         if (tc == nullptr) continue;
-        const size_t dec = static_cast<size_t>(tc->max_decode_buffer_length());
-        if (dec > needed) needed = dec;
+        needed = std::max(needed,
+                          static_cast<size_t>(tc->max_decode_buffer_length()));
       }
     }
     if (MaybeResizeBuffer(needed)) return true;

--- a/villagesql/vdf/vdf_handler.h
+++ b/villagesql/vdf/vdf_handler.h
@@ -87,6 +87,12 @@ class vdf_handler {
   // Process result string and return appropriate String pointer
   String *result_string(const char *res, size_t res_length, String *str,
                         String *save_str, const CHARSET_INFO *charset);
+
+  // Grow m_result_buffer to hold at least `needed` bytes, rounding up to a
+  // fixed quantum so a result that grows by a few bytes row-over-row does not
+  // trigger a fresh allocation each time. No-op if already large enough.
+  // Returns true on allocation failure.
+  bool MaybeResizeBuffer(size_t needed);
 };
 
 }  // namespace vdf


### PR DESCRIPTION
This prevents truncation that was happening in some cases.

This also changes the default buffer size to 1024.

Fixes #641
