### PR TITLE
Generate version.h at compile time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2462,6 +2462,7 @@ CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/include/mysql_version.h.in
                ${CMAKE_BINARY_DIR}/include/mysql_version.h )
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/include/mysql_server_suffix.h.in
                ${CMAKE_BINARY_DIR}/include/mysql_server_suffix.h)
+# villagesql/include/version.h is also re-generated at build time
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/villagesql/include/version.h.in
                ${CMAKE_BINARY_DIR}/villagesql/include/version.h )
 CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/sql/sql_builtin.cc.in

--- a/villagesql/cmake/gen_version.cmake
+++ b/villagesql/cmake/gen_version.cmake
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 VillageSQL Contributors
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+# Generates villagesql/include/version.h from version.h.in with the current
+# VillageSQL version. Run at build time via `cmake -P` (not at configure time)
+# so the header always reflects the value in the source tree's VSQL_VERSION on
+# every build, without needing a reconfigure.
+#
+# The core version (code base, major, minor, patch) is read live from
+# VSQL_VERSION here. The pre-release identifier is passed in via -D because it
+# can be overridden at configure time (release builds strip it with
+# -DVSQL_PRE_RELEASE_VERSION=""); that resolved value is forwarded by the
+# caller. Parameters passed in via -D by the caller:
+#   IN_FILE                  - path to version.h.in
+#   OUT_FILE                 - path to the generated version.h
+#   SRC_DIR                  - source tree containing VSQL_VERSION
+#   VSQL_PRE_RELEASE_VERSION - resolved pre-release identifier ("" strips it)
+#
+# configure_file() only rewrites OUT_FILE when the content changes, so this
+# target running on every build does not force spurious recompiles of the
+# files that include version.h.
+
+# Read the value of a keyword from the VSQL_VERSION file. Mirrors
+# VSQL_GET_CONFIG_VALUE in cmake/vsql_version.cmake: the first matching line
+# wins and any trailing content after a space is dropped.
+function(vsql_read_version_value keyword outvar)
+  file(STRINGS "${SRC_DIR}/VSQL_VERSION" _lines REGEX "^[ ]*${keyword}=")
+  if(_lines)
+    list(GET _lines 0 _line)
+    string(REGEX REPLACE "^[ ]*${keyword}=" "" _value "${_line}")
+    string(REGEX REPLACE "[ ].*" "" _value "${_value}")
+    set(${outvar} "${_value}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+vsql_read_version_value("VSQL_CODE_BASE" VSQL_CODE_BASE)
+vsql_read_version_value("VSQL_MAJOR_VERSION" VSQL_MAJOR_VERSION)
+vsql_read_version_value("VSQL_MINOR_VERSION" VSQL_MINOR_VERSION)
+vsql_read_version_value("VSQL_PATCH_VERSION" VSQL_PATCH_VERSION)
+
+if(NOT DEFINED VSQL_CODE_BASE OR
+   NOT DEFINED VSQL_MAJOR_VERSION OR
+   NOT DEFINED VSQL_MINOR_VERSION OR
+   NOT DEFINED VSQL_PATCH_VERSION)
+  message(FATAL_ERROR "VSQL_VERSION file cannot be parsed.")
+endif()
+
+# The pre-release identifier is normally forwarded via -D; fall back to the
+# source-tree value if the caller did not pass one.
+if(NOT DEFINED VSQL_PRE_RELEASE_VERSION)
+  vsql_read_version_value("VSQL_PRE_RELEASE_VERSION" VSQL_PRE_RELEASE_VERSION)
+endif()
+
+configure_file("${IN_FILE}" "${OUT_FILE}" @ONLY)

--- a/villagesql/common/CMakeLists.txt
+++ b/villagesql/common/CMakeLists.txt
@@ -47,6 +47,28 @@ ADD_CUSTOM_TARGET(villagesql_build_info_gen
 
 SET_SOURCE_FILES_PROPERTIES(${VILLAGESQL_BUILD_INFO_CC} PROPERTIES GENERATED TRUE)
 
+# Generated version header. Like the build info above, the generator target is
+# always considered out of date, so every build regenerates version.h from the
+# current VSQL_VERSION in the source tree. configure_file() only rewrites the
+# header when its content changes, so the files that include it (see
+# villagesql_version_gen dependents) recompile only when the version changes.
+#
+# The pre-release identifier is resolved at configure time (honoring the
+# -DVSQL_PRE_RELEASE_VERSION="" release-strip override) and forwarded to the
+# generator; the core version numbers are read live from VSQL_VERSION.
+SET(VILLAGESQL_VERSION_H ${CMAKE_BINARY_DIR}/villagesql/include/version.h)
+
+ADD_CUSTOM_TARGET(villagesql_version_gen
+  BYPRODUCTS ${VILLAGESQL_VERSION_H}
+  COMMAND ${CMAKE_COMMAND}
+    -DSRC_DIR=${CMAKE_SOURCE_DIR}
+    -DIN_FILE=${CMAKE_SOURCE_DIR}/villagesql/include/version.h.in
+    -DOUT_FILE=${VILLAGESQL_VERSION_H}
+    -DVSQL_PRE_RELEASE_VERSION=${VSQL_PRE_RELEASE_VERSION}
+    -P ${CMAKE_SOURCE_DIR}/villagesql/cmake/gen_version.cmake
+  COMMENT "Generating VillageSQL version header"
+  VERBATIM)
+
 # Object library for compilation into sql_main (avoids circular dependencies)
 ADD_LIBRARY(villagesql_common OBJECT
   ${VILLAGESQL_COMMON_SOURCES}

--- a/villagesql/schema/CMakeLists.txt
+++ b/villagesql/schema/CMakeLists.txt
@@ -41,6 +41,8 @@ TARGET_LINK_LIBRARIES(villagesql_schema PRIVATE extra::rapidjson)
 
 ADD_DEPENDENCIES(villagesql_schema GenError)
 ADD_DEPENDENCIES(villagesql_schema GenServerSource)
+# schema_manager.cc includes the generated villagesql/include/version.h
+ADD_DEPENDENCIES(villagesql_schema villagesql_version_gen)
 TARGET_LINK_LIBRARIES(villagesql_schema PRIVATE extra::unordered_dense)
 
 # Configure VillageSQL schema file with version substitution for build directory

--- a/villagesql/sql/CMakeLists.txt
+++ b/villagesql/sql/CMakeLists.txt
@@ -30,4 +30,6 @@ TARGET_LINK_LIBRARIES(villagesql_sql PRIVATE extra::rapidjson)
 
 ADD_DEPENDENCIES(villagesql_sql GenError)
 ADD_DEPENDENCIES(villagesql_sql GenServerSource)
+# initialize.cc includes the generated villagesql/include/version.h
+ADD_DEPENDENCIES(villagesql_sql villagesql_version_gen)
 TARGET_LINK_LIBRARIES(villagesql_sql PRIVATE extra::unordered_dense)

--- a/villagesql/veb/CMakeLists.txt
+++ b/villagesql/veb/CMakeLists.txt
@@ -40,3 +40,6 @@ TARGET_INCLUDE_DIRECTORIES(villagesql_veb SYSTEM PRIVATE
 ADD_DEPENDENCIES(villagesql_veb GenError)
 ADD_DEPENDENCIES(villagesql_veb GenServerSource)
 ADD_DEPENDENCIES(villagesql_veb villagesql_common)
+
+# veb_file.cc includes the generated villagesql/include/version.h
+ADD_DEPENDENCIES(villagesql_veb villagesql_version_gen)


### PR DESCRIPTION
## Description

Generate the version file `sql/villagesql/common/build_info.cc` for each build.

## Related Issue

Part of the effort to Cleanup release-dev-server #595 

