### PR TITLE
Cleanup full test suite

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -20,11 +20,22 @@ on:
         required: false
         type: string
         default: 'full-test'
-      run-all-suites-conditional:
-        description: 'Check should_run_all_tests.sh before running all suites'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to checkout and test'
+        required: true
+        type: string
+      build-type:
+        description: 'Build type (debug or release)'
         required: false
-        type: boolean
-        default: false
+        type: string
+        default: 'debug'
+      artifact-prefix:
+        description: 'Prefix for artifact names'
+        required: false
+        type: string
+        default: 'full-test'
 
 jobs:
   build-and-test:
@@ -57,8 +68,7 @@ jobs:
         PARALLEL_JOBS: 16
         BUILD_TYPE: ${{ inputs.build-type }}
 
-
-    - name: Run tests
+    - name: Run standard tests (unit, integration, only suite village)
       uses: ./source/.github/actions/run-tests
       with:
         artifact-name: ${{ inputs.artifact-prefix }}-logs-${{ github.run_number }}
@@ -70,25 +80,12 @@ jobs:
         run-big-tests: true
         artifact-name: ${{ inputs.artifact-prefix }}-big-test-logs-${{ github.run_number }}
 
-    - name: Check if should run all tests
-      if: inputs.run-all-suites-conditional
-      id: check-all-tests
-      working-directory: ./source
-      run: |
-        if ./scripts/should_run_all_tests.sh; then
-          echo "run=true" >> $GITHUB_OUTPUT
-        else
-          echo "run=false" >> $GITHUB_OUTPUT
-          echo "Skipping all test suites - commit unchanged from previous nightly"
-        fi
-
     - name: Run all test suites (excluding VillageSQL)
-      if: >
-        !inputs.run-all-suites-conditional ||
-        steps.check-all-tests.outputs.run == 'true'
       uses: ./source/.github/actions/run-tests
       with:
+        # Don't repeat any standard test
         run-unit-tests: false
+        run-integration-tests: false
         run-all-suites: true
         skip-suite: village
         artifact-name: ${{ inputs.artifact-prefix }}-all-suites-logs-${{ github.run_number }}


### PR DESCRIPTION
## Description

Revises the workflow full-test-suit.yml to be manually dispatched.

Removes a repeat execution of the duplicate integration tests from the "Run all test suites (excluding VillageSQL)" step.

Removes the awkward question of "should run all tests".  If the previous nightly build really is the same commit, that should be handled earlier.

## Related Issue

Part of the effort to Cleanup release-dev-server #595

