### PR TITLE
Tidy up run-tests usage

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Show ccache statistics
       run: ccache -s
 
-    - name: Run tests
+    - name: Run standard tests (unit, integration, only suite village)
       uses: ./source/.github/actions/run-tests
       with:
         artifact-name: nightly-test-logs-${{ github.run_number }}
@@ -49,6 +49,7 @@ jobs:
       uses: ./source/.github/actions/run-tests
       with:
         run-unit-tests: false
+        run-integration-tests: false
         run-big-tests: true
         artifact-name: nightly-big-test-logs-${{ github.run_number }}
 


### PR DESCRIPTION
## Description

Since the standard tests (line #43) run the integration tests, no need to rerun them with the big tests.

## Related Issue

Part of the effort to Cleanup release-dev-server #595
