### PR TITLE
Remove confusing workflow_call section

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -3,29 +3,13 @@ name: Full Test Suite
 # Workflow to run the full test suite
 
 on:
-  workflow_call:
+  workflow_dispatch:
     inputs:
       ref:
         description: 'Git ref to checkout and test (default main)'
         required: false
         type: string
         default: 'main'
-      build-type:
-        description: 'Build type (debug or release)'
-        required: false
-        type: string
-        default: 'debug'
-      artifact-prefix:
-        description: 'Prefix for artifact names'
-        required: false
-        type: string
-        default: 'full-test'
-  workflow_dispatch:
-    inputs:
-      ref:
-        description: 'Git ref to checkout and test'
-        required: true
-        type: string
       build-type:
         description: 'Build type (debug or release)'
         required: false


### PR DESCRIPTION
## Description

Moves the git ref option configuration to the workflow_dispatch section and eliminates the workflow_call section.

The workflow_call section can be restored when the use case is identified.

## Related Issue

Part of Cleanup release-dev-server #595 effort.