### PR TITLE
Enable big tests for nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Show ccache statistics
       run: ccache -s
 
-    - name: Run standard tests (unit, integration, only suite village)
+    - name: Run standard tests (unit, integration with only suite village)
       uses: ./source/.github/actions/run-tests
       with:
         artifact-name: nightly-test-logs-${{ github.run_number }}
@@ -49,7 +49,6 @@ jobs:
       uses: ./source/.github/actions/run-tests
       with:
         run-unit-tests: false
-        run-integration-tests: false
         run-big-tests: true
         artifact-name: nightly-big-test-logs-${{ github.run_number }}
 


### PR DESCRIPTION
## Description

Enables the villagesql big tests, as seemingly intended.

It turns out that big tests is a sub-category of the integration tests, so disabling integration tests prevents the big tests from ever running.

## Related Issue

Part of Cleanup release-dev-server #595 effort.
