### PR TITLE
Restore full test suite for slash cmds

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -3,6 +3,23 @@ name: Full Test Suite
 # Workflow to run the full test suite
 
 on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git ref to checkout and test (default main)'
+        required: false
+        type: string
+        default: 'main'
+      build-type:
+        description: 'Build type (debug or release)'
+        required: false
+        type: string
+        default: 'debug'
+      artifact-prefix:
+        description: 'Prefix for artifact names'
+        required: false
+        type: string
+        default: 'full-test'
   workflow_dispatch:
     inputs:
       ref:

--- a/.github/workflows/slash-commands.yml
+++ b/.github/workflows/slash-commands.yml
@@ -144,7 +144,6 @@ jobs:
       ref: ${{ needs.parse.outputs.ref }}
       build-type: debug
       artifact-prefix: testall
-      run-all-suites-conditional: false
     secrets: inherit
 
   # "Finished" comment for /testall. Lives in the caller (not full-test-suite.yml)


### PR DESCRIPTION
## Description

It turns out that the slash-commands action invokes the full-test-suite action.  This restores that integration.

## Related Issue

Part of Cleanup release-dev-server #595 effort.
