### PR TITLE
Fix nonnull error in release builds

### DIFF
--- a/sql/opt_explain_format.h
+++ b/sql/opt_explain_format.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2011, 2026, Oracle and/or its affiliates.
+   Copyright (c) 2026 VillageSQL Contributors
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,

--- a/sql/opt_explain_format.h
+++ b/sql/opt_explain_format.h
@@ -640,7 +640,7 @@ class Explain_format {
   */
   virtual std::string ExplainJsonToString(Json_object *json [[maybe_unused]]) {
     assert(false);
-    return nullptr;
+    return "";
   }
 };
 


### PR DESCRIPTION
Warning was masked in debug builds with assert above. Issue #443 introduced warnings as errors by default, making release builds fail.
Base class stub formatter, meant to be overridden, returned nullptr. Creating string from nullptr is undefined behavior.

## Related Issue

Related to #443 