### PR TITLE
Release building workflows

### DIFF
--- a/.github/workflows/build-server-branch.yml
+++ b/.github/workflows/build-server-branch.yml
@@ -1,0 +1,183 @@
+name: Build Server Branch
+
+# Builds the dev-server package for a SINGLE target, runs the integration
+# tests, and uploads the package + SDK as run-scoped artifacts.
+#
+# Invoked once per target by release-server-branch (workflow_call), or manually
+# for one target (workflow_dispatch). Multi-target fan-out lives in
+# release-server-branch, which also owns the platform -> runner/os mapping and
+# passes the resolved runner and os in directly.
+#
+# <github.workspace>
+# - source: clone of villagesql-server
+# - build:  cmake compilation sandbox
+# - exts:   sandbox for bundled extensions
+#   - sources: clones of each bundled extension
+#   - builds:  sandboxes for extension builds
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git tag, branch, or SHA to build from.'
+        required: true
+        type: string
+      platform:
+        description: 'Platform label used to name the devserver artifact (e.g. linux-x86_64).'
+        required: true
+        type: string
+      release_build:
+        description: 'Strip the -dev suffix from the version.'
+        required: true
+        type: boolean
+      os:
+        description: 'Build OS family: linux or macos.'
+        required: true
+        type: string
+      runner:
+        description: 'JSON-encoded runs-on value (array or quoted string), e.g. ["self-hosted","linux","x86_64"] or "macos-latest".'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git tag, branch, or SHA to build from (e.g. 0.0.4 or main).'
+        required: true
+        type: string
+      platform:
+        description: 'Platform label used to name the server artifact.'
+        required: false
+        type: choice
+        options:
+          - linux-x86_64
+          - linux-aarch64
+          - macos-arm64
+        default: linux-x86_64
+      release_build:
+        description: 'Release build: strip the -dev suffix from the version. Leave unchecked to include -dev (safe default).'
+        required: false
+        type: boolean
+        default: false
+      os:
+        description: 'Build OS family.'
+        required: true
+        type: choice
+        options:
+          - linux
+          - macos
+        default: linux
+      runner:
+        description: 'JSON-encoded runs-on value, e.g. ["self-hosted","linux","x86_64"] or "macos-latest".'
+        required: true
+        type: string
+        default: '["self-hosted","linux","x86_64"]'
+
+permissions:
+  contents: read
+
+jobs:
+  build-package:
+    name: Build (${{ inputs.platform }})
+    runs-on: ${{ fromJSON(inputs.runner) }}
+
+    env:
+      SOURCE_DIR: ${{ github.workspace }}/source
+      BUILD_DIR: ${{ github.workspace }}/build
+      OUTPUT_DIR: ${{ github.workspace }}/output
+      EXTS_ROOT: ${{ github.workspace }}/exts
+      BUILD_BUNDLED_EXTENSIONS: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+          path: source
+          ref: ${{ inputs.ref }}
+
+      - name: Setup VillageSQL build environment
+        uses: ./source/.github/actions/setup-villagesql-build
+        with:
+          cache-boost: 'true'
+          setup-ccache: 'false'
+
+      - name: Checkout bundled extensions
+        if: env.BUILD_BUNDLED_EXTENSIONS == '1'
+        run: |
+          mkdir -p "$EXTS_ROOT/sources"
+          source/villagesql/bld_tools/checkout_bundled_extensions.sh \
+            "$EXTS_ROOT/sources"
+
+      # Bundled-extension build deps. Slated for separate revision; preserved
+      # as inline steps so BUILD_BUNDLED_EXTENSIONS builds keep working.
+      - name: Install bundled-extension dependencies (Linux)
+        if: env.BUILD_BUNDLED_EXTENSIONS == '1' && inputs.os == 'linux'
+        run: sudo source/scripts/setup_linux_ext_deps.sh
+
+      - name: Install bundled-extension dependencies (macOS)
+        if: env.BUILD_BUNDLED_EXTENSIONS == '1' && inputs.os == 'macos'
+        run: source/scripts/setup_macos_ext_deps.sh
+
+      - name: Build the dev server
+        run: |
+          if [[ "${{ inputs.release_build }}" == "true" ]]; then
+            PRE_RELEASE=""
+          else
+            PRE_RELEASE="dev"
+          fi
+          echo "pre_release_version: '${PRE_RELEASE}'"
+
+          EXTRA_FLAGS="-DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost -DVSQL_PRE_RELEASE_VERSION=${PRE_RELEASE}"
+          if [ "${{ inputs.os }}" = "macos" ]; then
+            EXTRA_FLAGS="$EXTRA_FLAGS -DWITH_SSL=$(brew --prefix openssl)"
+          fi
+
+          SOURCE_DIR="$SOURCE_DIR" \
+          BUILD_DIR="$BUILD_DIR" \
+          CMAKE_EXTRA_FLAGS="$EXTRA_FLAGS" \
+          VSQL_PRE_RELEASE_VERSION="${PRE_RELEASE}" \
+            source/villagesql/bld_tools/build_ci.sh
+
+      - name: Build bundled extensions
+        if: env.BUILD_BUNDLED_EXTENSIONS == '1'
+        run: |
+          SDK_STAGING_DIR="$(source/villagesql/bld_tools/get_sdk.sh "$BUILD_DIR")"
+          source/villagesql/bld_tools/build_bundled_extensions.sh \
+            "$EXTS_ROOT/sources" "${SDK_STAGING_DIR}" "${BUILD_DIR}/veb_output_directory"
+
+      - name: Test bundled extensions
+        if: env.BUILD_BUNDLED_EXTENSIONS == '1'
+        run: |
+          source/villagesql/bld_tools/test_extension_vebs.sh \
+            "$BUILD_DIR" \
+            "$EXTS_ROOT/sources"
+
+      - name: Package dev server tarball
+        run: |
+          mkdir -p "$OUTPUT_DIR"
+
+          BUILD_DIR="$BUILD_DIR" \
+          OUTPUT_DIR="$OUTPUT_DIR" \
+          BUILD_BUNDLED_EXTENSIONS="${BUILD_BUNDLED_EXTENSIONS:-0}" \
+            source/villagesql/bld_tools/package_dev_server.sh
+
+      - name: Run integration tests
+        run: |
+          TARBALL=$(ls "$OUTPUT_DIR"/*.tar.gz | head -1)
+          TEST_DIR=$(mktemp -d)
+          tar xzf "$TARBALL" -C "$TEST_DIR"
+          PACKAGE_DIR=$(echo "$TEST_DIR"/villagesql-dev-server-*)
+          source/villagesql/dev_server/tests/integration_test.sh "$PACKAGE_DIR"
+          rm -rf "$TEST_DIR"
+
+      - name: Upload package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: devserver-${{ inputs.platform }}
+          path: ${{ env.OUTPUT_DIR }}/*.tar.gz
+
+      - name: Upload SDK
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: sdk-${{ inputs.platform }}
+          path: ${{ env.BUILD_DIR }}/villagesql-extension-sdk-*.tar.gz

--- a/.github/workflows/release-server-branch.yml
+++ b/.github/workflows/release-server-branch.yml
@@ -1,0 +1,105 @@
+name: Release Server Branch
+
+# Builds the dev-server package for ALL target platforms by fanning out over
+# build-server-branch (one call per target), then attaches the resulting
+# tarballs to an existing GitHub Release.
+#
+# This workflow handles the multi-target case only; single-target builds live
+# in build-server-branch.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git tag, branch, or SHA to build from.'
+        required: true
+        type: string
+      release_tag:
+        description: 'GitHub Release to attach artifacts to. Defaults to "ref". Blank to skip upload.'
+        required: false
+        type: string
+        default: ''
+      release_build:
+        description: 'Strip the -dev suffix from the version.'
+        required: false
+        type: boolean
+        default: false
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git tag, branch, or SHA to build from (e.g. 0.0.4 or main).'
+        required: true
+        type: string
+      release_tag:
+        description: 'GitHub Release to attach artifacts to. Defaults to "ref". Leave blank to skip upload (useful for test builds — artifacts are still available for download from the Actions run page).'
+        required: false
+        type: string
+        default: ''
+      release_build:
+        description: 'Release build: strip the -dev suffix from the version. Leave unchecked to include -dev (safe default).'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: [self-hosted, linux, x86_64]
+            platform: linux-x86_64
+            os: linux
+          - runner: ubuntu-24.04-arm
+            platform: linux-aarch64
+            os: linux
+          - runner: macos-latest
+            platform: macos-arm64
+            os: macos
+    uses: ./.github/workflows/build-server-branch.yml
+    with:
+      ref: ${{ inputs.ref }}
+      runner: ${{ toJSON(matrix.runner) }}
+      os: ${{ matrix.os }}
+      platform: ${{ matrix.platform }}
+      release_build: ${{ inputs.release_build }}
+
+  attach-release-artifacts:
+    name: Attach Release Artifacts
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Determine release tag
+        id: tag
+        run: echo "tag=${{ inputs.release_tag || inputs.ref }}" >> "$GITHUB_OUTPUT"
+
+      - name: Download all packages
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: devserver-*
+          merge-multiple: true
+          path: packages/
+
+      - name: Download SDK
+        uses: actions/download-artifact@v4
+        with:
+          name: sdk-linux-x86_64
+          path: packages/
+
+      - name: Attach artifacts to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          if gh release view "$TAG" &>/dev/null; then
+            gh release upload "$TAG" packages/*.tar.gz --clobber
+          else
+            echo "No GitHub Release found for '$TAG' — skipping upload. Download artifacts from the Actions run page."
+          fi


### PR DESCRIPTION
## Description

These workflows, build-server-branch and release-server-branch, refactor the existing release-dev-server workflow into two separate processes.  The build-server-branch workflow creates one release bundle for a specific platform and os combination.  The release-server-branch invokes the build-server-branch workflow for the full gamut of valid platform and os choices.

It's possible to ask the build-server-branch workflow to do impossible things or to mis-label the result.  Don't do that.  The release-server-branch workflow is careful not to.

Once this is working as expected, the current release-dev-server workflow will be deleted.

## Related Issue

One of the main parts of the Cleanup release-dev-server #595 effort.
