### PR TITLE
Update for is_dirty in build info

### DIFF
--- a/mysql-test/suite/sys_vars/r/villagesql_build_info_basic.result
+++ b/mysql-test/suite/sys_vars/r/villagesql_build_info_basic.result
@@ -3,10 +3,10 @@
 # Test 1: Check that the variable exists and is readable
 SHOW VARIABLES LIKE 'villagesql_build_info';
 Variable_name	Value
-villagesql_build_info	{"git_sha":"SHA","files_added":N,"files_deleted":N,"files_modified":N,"build_timestamp":"TS","build_host":"HOST","build_os":"OS","build_arch":"ARCH"}
+villagesql_build_info	{"git_sha":"SHA","is_dirty":DIRTY,"files_added":N,"files_deleted":N,"files_modified":N,"build_timestamp":"TS","build_host":"HOST","build_os":"OS","build_arch":"ARCH"}
 SELECT @@GLOBAL.villagesql_build_info AS build_info;
 build_info
-{"git_sha":"SHA","files_added":N,"files_deleted":N,"files_modified":N,"build_timestamp":"TS","build_host":"HOST","build_os":"OS","build_arch":"ARCH"}
+{"git_sha":"SHA","is_dirty":DIRTY,"files_added":N,"files_deleted":N,"files_modified":N,"build_timestamp":"TS","build_host":"HOST","build_os":"OS","build_arch":"ARCH"}
 # Test 2: Verify the variable is READ_ONLY
 SET GLOBAL villagesql_build_info = '999';
 ERROR HY000: Variable 'villagesql_build_info' is a read only variable

--- a/mysql-test/suite/sys_vars/t/villagesql_build_info_basic.test
+++ b/mysql-test/suite/sys_vars/t/villagesql_build_info_basic.test
@@ -7,10 +7,10 @@
 # The value is build/machine specific (git SHA, file counts, timestamp, host,
 # OS, arch), so redact every field to a placeholder and assert only the JSON
 # structure and keys.
---replace_regex /"git_sha":"[^"]*"/"git_sha":"SHA"/ /"files_added":[0-9]+/"files_added":N/ /"files_deleted":[0-9]+/"files_deleted":N/ /"files_modified":[0-9]+/"files_modified":N/ /"build_timestamp":"[^"]*"/"build_timestamp":"TS"/ /"build_host":"[^"]*"/"build_host":"HOST"/ /"build_os":"[^"]*"/"build_os":"OS"/ /"build_arch":"[^"]*"/"build_arch":"ARCH"/
+--replace_regex /"git_sha":"[^"]*"/"git_sha":"SHA"/ /"is_dirty":(true|false)/"is_dirty":DIRTY/ /"files_added":[0-9]+/"files_added":N/ /"files_deleted":[0-9]+/"files_deleted":N/ /"files_modified":[0-9]+/"files_modified":N/ /"build_timestamp":"[^"]*"/"build_timestamp":"TS"/ /"build_host":"[^"]*"/"build_host":"HOST"/ /"build_os":"[^"]*"/"build_os":"OS"/ /"build_arch":"[^"]*"/"build_arch":"ARCH"/
 SHOW VARIABLES LIKE 'villagesql_build_info';
 
---replace_regex /"git_sha":"[^"]*"/"git_sha":"SHA"/ /"files_added":[0-9]+/"files_added":N/ /"files_deleted":[0-9]+/"files_deleted":N/ /"files_modified":[0-9]+/"files_modified":N/ /"build_timestamp":"[^"]*"/"build_timestamp":"TS"/ /"build_host":"[^"]*"/"build_host":"HOST"/ /"build_os":"[^"]*"/"build_os":"OS"/ /"build_arch":"[^"]*"/"build_arch":"ARCH"/
+--replace_regex /"git_sha":"[^"]*"/"git_sha":"SHA"/ /"is_dirty":(true|false)/"is_dirty":DIRTY/ /"files_added":[0-9]+/"files_added":N/ /"files_deleted":[0-9]+/"files_deleted":N/ /"files_modified":[0-9]+/"files_modified":N/ /"build_timestamp":"[^"]*"/"build_timestamp":"TS"/ /"build_host":"[^"]*"/"build_host":"HOST"/ /"build_os":"[^"]*"/"build_os":"OS"/ /"build_arch":"[^"]*"/"build_arch":"ARCH"/
 SELECT @@GLOBAL.villagesql_build_info AS build_info;
 
 --echo # Test 2: Verify the variable is READ_ONLY


### PR DESCRIPTION
## Description

Fix a failing test due to change in build info content

The villagesql_build_info JSON now emits an "is_dirty":false field that the expected .result file lacks — the result file is stale.

## Related Issue

Part of Cleanup release-dev-server https://github.com/villagesql/villagesql-server/issues/595 effort.

## How was this tested?

```
mysql-test-run.pl  sys_vars.villagesql_build_info_basic
```
Before and after
