### PR TITLE
resolve_params to supply defaults

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_bitfield_create_table.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_bitfield_create_table.result
@@ -1,23 +1,30 @@
-# Install the variable-length, non-parameterized bit field extension.
+# Install the variable-length bit field extension.
 INSTALL EXTENSION vsql_bitfield_test;
 SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
 EXTENSION_NAME	EXTENSION_VERSION
 vsql_bitfield_test	0.0.1
-# A column declared without any length or parameters; the bit length is
-# decided per value.
+# A column declared in the bare form. resolve_params fills in the default
+# 'max_number_of_bits', so the column stores explicit canonical params.
 CREATE TABLE bits (
 id INT PRIMARY KEY,
 b vsql_bitfield_test.BITFIELD
 );
+SHOW CREATE TABLE bits;
+Table	Create Table
+bits	CREATE TABLE `bits` (
+  `id` int NOT NULL,
+  `b` vsql_bitfield_test.BITFIELD('max_number_of_bits=4096') DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 # Bit fields of DIFFERENT bit lengths coexist in the same column.
 INSERT INTO bits VALUES (1, '1');
 INSERT INTO bits VALUES (2, '101');
 INSERT INTO bits VALUES (3, '11110000');
 INSERT INTO bits VALUES (4, '1010101010101010');
 INSERT INTO bits VALUES (5, '');
-# Each value round-trips at its own bit length. bitfield_length reports
-# the number of bits; bitfield_popcount the number of set bits. A 16-bit
-# value is packed into 2 bytes, not 16.
+# The bare column carries known params, so it can be passed to functions.
+# bitfield_length reports the number of bits; bitfield_popcount the number
+# of set bits. A 16-bit value is packed into 2 bytes, not 16.
 SELECT id, b,
 vsql_bitfield_test.bitfield_length(b) AS nbits,
 vsql_bitfield_test.bitfield_popcount(b) AS nset
@@ -47,15 +54,49 @@ id	b	nbits
 # A character other than '0'/'1' is rejected by from_string.
 INSERT INTO bits VALUES (6, '1021');
 ERROR HY000: Incorrect BITFIELD value: '1021' for column 'b' at row 1
-# BITFIELD is not parameterized, so it does not accept a length or
-# parameter spec. Both the integer-length and the string-parameter forms
-# are rejected at parse time.
-CREATE TABLE bad_bits (b BITFIELD(5));
-ERROR 42000: Type 'vsql_bitfield_test.BITFIELD' is not parameterized and cannot have a length specification near 'BITFIELD(5))' at line 1
-CREATE TABLE bad_bits (b BITFIELD('max_size=5'));
-ERROR 42000: Type 'vsql_bitfield_test.BITFIELD' does not accept parameters near 'BITFIELD('max_size=5'))' at line 1
+# The integer-length form is rejected: the type provides resolve_params
+# but not int_to_params, so it does not accept a length specification.
+CREATE TABLE bad_bits (b vsql_bitfield_test.BITFIELD(5));
+ERROR 42000: Type 'vsql_bitfield_test.BITFIELD' does not accept a length specification near 'vsql_bitfield_test.BITFIELD(5))' at line 1
+# The 'max_number_of_bits' parameter caps the column. Values within the
+# cap are stored; a value exceeding it is rejected by from_string.
+CREATE TABLE capped (
+id INT PRIMARY KEY,
+b vsql_bitfield_test.BITFIELD('max_number_of_bits=8')
+);
+SHOW CREATE TABLE capped;
+Table	Create Table
+capped	CREATE TABLE `capped` (
+  `id` int NOT NULL,
+  `b` vsql_bitfield_test.BITFIELD('max_number_of_bits=8') DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+INSERT INTO capped VALUES (1, '10101010');
+INSERT INTO capped VALUES (2, '101010101');
+ERROR HY000: Incorrect BITFIELD value: '101010101' for column 'b' at row 1
+SELECT id, b, vsql_bitfield_test.bitfield_length(b) AS nbits
+FROM capped ORDER BY id;
+id	b	nbits
+1	10101010	8
+# A different max_number_of_bits is a distinct parameterization, so an
+# insert across the two columns is rejected regardless of bit count.
+CREATE TABLE capped10 (
+id INT PRIMARY KEY,
+b vsql_bitfield_test.BITFIELD('max_number_of_bits=10')
+);
+INSERT INTO capped10 VALUES (1, '1010101010');
+INSERT INTO capped10 VALUES (2, '101');
+INSERT INTO capped (id, b) SELECT id + 100, b FROM capped10 WHERE id = 1;
+ERROR HY000: Cannot implicitly cast from vsql_bitfield_test.BITFIELD('max_number_of_bits=10') to vsql_bitfield_test.BITFIELD('max_number_of_bits=8') for column 'b' at row 1
+INSERT INTO capped (id, b) SELECT id + 100, b FROM capped10 WHERE id = 2;
+ERROR HY000: Cannot implicitly cast from vsql_bitfield_test.BITFIELD('max_number_of_bits=10') to vsql_bitfield_test.BITFIELD('max_number_of_bits=8') for column 'b' at row 1
+# An out-of-range cap is rejected by resolve_params at parse time.
+CREATE TABLE bad_cap (b vsql_bitfield_test.BITFIELD('max_number_of_bits=0'));
+ERROR 42000: BITFIELD 'max_number_of_bits' must be a positive integer <= 4096 near 'vsql_bitfield_test.BITFIELD('max_number_of_bits=0'))' at line 1
 # Clean up.
 DROP TABLE bits;
+DROP TABLE capped;
+DROP TABLE capped10;
 UNINSTALL EXTENSION vsql_bitfield_test;
 SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
 EXTENSION_NAME	EXTENSION_VERSION

--- a/mysql-test/suite/villagesql/extension/t/extension_bitfield_create_table.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_bitfield_create_table.test
@@ -1,27 +1,27 @@
-# Acceptance test for issue #535:
-#   "Support variable-length, non-parameterized types"
-#
 # BITFIELD is a variable-length bit field whose length (in bits) is decided per
-# value, a max_persisted_length upper bound, and NO params/resolve_params.
-# Its element is a single BIT: from_string packs each '0'/'1' character into
-# one bit (8 bits per byte), so a 64-character bit string stores in 8 packed
-# bytes, not 64.
+# value. Its element is a single BIT: from_string packs each '0'/'1' character
+# into one bit (8 bits per byte), so a 64-character bit string stores in 8
+# packed bytes, not 64.
 #
-# Fixture: vsql_bitfield_test exposes BITFIELD. Stored layout is a 2-byte
-# little-endian bit count followed by the packed bits, so any bit length
-# round-trips exactly.
+# BITFIELD exposes resolve_params with an optional 'max_number_of_bits'
+# parameter (default 4096) that caps how many bits any value in the column may
+# hold. resolve_params writes the resolved value back into the params, so even
+# a bare declaration stores explicit (canonical) params -- the column's type
+# parameters are fully determined, which is what lets a bare column be passed
+# to bitfield_length()/bitfield_popcount().
 
---echo # Install the variable-length, non-parameterized bit field extension.
+--echo # Install the variable-length bit field extension.
 INSTALL EXTENSION vsql_bitfield_test;
 
 SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;
 
---echo # A column declared without any length or parameters; the bit length is
---echo # decided per value.
+--echo # A column declared in the bare form. resolve_params fills in the default
+--echo # 'max_number_of_bits', so the column stores explicit canonical params.
 CREATE TABLE bits (
   id INT PRIMARY KEY,
   b vsql_bitfield_test.BITFIELD
 );
+SHOW CREATE TABLE bits;
 
 --echo # Bit fields of DIFFERENT bit lengths coexist in the same column.
 INSERT INTO bits VALUES (1, '1');
@@ -30,9 +30,9 @@ INSERT INTO bits VALUES (3, '11110000');
 INSERT INTO bits VALUES (4, '1010101010101010');
 INSERT INTO bits VALUES (5, '');
 
---echo # Each value round-trips at its own bit length. bitfield_length reports
---echo # the number of bits; bitfield_popcount the number of set bits. A 16-bit
---echo # value is packed into 2 bytes, not 16.
+--echo # The bare column carries known params, so it can be passed to functions.
+--echo # bitfield_length reports the number of bits; bitfield_popcount the number
+--echo # of set bits. A 16-bit value is packed into 2 bytes, not 16.
 SELECT id, b,
        vsql_bitfield_test.bitfield_length(b) AS nbits,
        vsql_bitfield_test.bitfield_popcount(b) AS nset
@@ -52,15 +52,44 @@ FROM bits WHERE id = 1;
 --error ER_TRUNCATED_WRONG_VALUE_FOR_FIELD
 INSERT INTO bits VALUES (6, '1021');
 
---echo # BITFIELD is not parameterized, so it does not accept a length or
---echo # parameter spec. Both the integer-length and the string-parameter forms
---echo # are rejected at parse time.
+--echo # The integer-length form is rejected: the type provides resolve_params
+--echo # but not int_to_params, so it does not accept a length specification.
 --error ER_PARSE_ERROR
-CREATE TABLE bad_bits (b BITFIELD(5));
+CREATE TABLE bad_bits (b vsql_bitfield_test.BITFIELD(5));
+
+--echo # The 'max_number_of_bits' parameter caps the column. Values within the
+--echo # cap are stored; a value exceeding it is rejected by from_string.
+CREATE TABLE capped (
+  id INT PRIMARY KEY,
+  b vsql_bitfield_test.BITFIELD('max_number_of_bits=8')
+);
+SHOW CREATE TABLE capped;
+INSERT INTO capped VALUES (1, '10101010');
+--error ER_TRUNCATED_WRONG_VALUE_FOR_FIELD
+INSERT INTO capped VALUES (2, '101010101');
+SELECT id, b, vsql_bitfield_test.bitfield_length(b) AS nbits
+FROM capped ORDER BY id;
+
+--echo # A different max_number_of_bits is a distinct parameterization, so an
+--echo # insert across the two columns is rejected regardless of bit count.
+CREATE TABLE capped10 (
+  id INT PRIMARY KEY,
+  b vsql_bitfield_test.BITFIELD('max_number_of_bits=10')
+);
+INSERT INTO capped10 VALUES (1, '1010101010');
+INSERT INTO capped10 VALUES (2, '101');
+--error ER_VILLAGESQL_GENERIC_ERROR
+INSERT INTO capped (id, b) SELECT id + 100, b FROM capped10 WHERE id = 1;
+--error ER_VILLAGESQL_GENERIC_ERROR
+INSERT INTO capped (id, b) SELECT id + 100, b FROM capped10 WHERE id = 2;
+
+--echo # An out-of-range cap is rejected by resolve_params at parse time.
 --error ER_PARSE_ERROR
-CREATE TABLE bad_bits (b BITFIELD('max_size=5'));
+CREATE TABLE bad_cap (b vsql_bitfield_test.BITFIELD('max_number_of_bits=0'));
 
 --echo # Clean up.
 DROP TABLE bits;
+DROP TABLE capped;
+DROP TABLE capped10;
 UNINSTALL EXTENSION vsql_bitfield_test;
 SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS;

--- a/villagesql/examples/vsql-tvector/src/tvector.cc
+++ b/villagesql/examples/vsql-tvector/src/tvector.cc
@@ -132,9 +132,9 @@ size_t bytes_per_element(const std::map<std::string, std::string> &params) {
 }
 
 // Convert TYPE(N) integer to parameter key-value pairs.
-// Populates params map with {"dimension": "<N>", "type": "float"}.
-// Setting type explicitly ensures TVECTOR(3) produces the same canonical
-// params as TVECTOR('dimension=3,type=float').
+// Populates params map with the single {"dimension": "<N>"} pair; the "type"
+// default is supplied by tvector_resolve_params. TVECTOR(3) thus canonicalizes
+// to the same params as TVECTOR('dimension=3,type=float').
 bool tvector_int_to_params(int64_t value,
                            std::map<std::string, std::string> &params,
                            char *error_msg) {
@@ -145,12 +145,13 @@ bool tvector_int_to_params(int64_t value,
     return true;
   }
   params["dimension"] = std::to_string(value);
-  params["type"] = "float";
   return false;
 }
 
 // Validate type parameters and compute storage characteristics.
-bool tvector_resolve_params(const std::map<std::string, std::string> &params,
+// TVECTOR(N) and TVECTOR('dimension=N') both canonicalize to
+// 'dimension=N,type=float'.
+bool tvector_resolve_params(std::map<std::string, std::string> &params,
                             vsql::ResolvedTypeParams *result, char *error_msg) {
   auto it = params.find("dimension");
   if (it == params.end()) {
@@ -172,10 +173,11 @@ bool tvector_resolve_params(const std::map<std::string, std::string> &params,
     return true;
   }
 
-  // Validate "type" parameter if present.
+  // Validate "type" if present; otherwise fill in the default.
   auto type_it = params.find("type");
-  if (type_it != params.end() && type_it->second != "float" &&
-      type_it->second != "double") {
+  if (type_it == params.end()) {
+    params["type"] = "float";
+  } else if (type_it->second != "float" && type_it->second != "double") {
     snprintf(error_msg, VEF_MAX_ERROR_LEN,
              "TVECTOR: type must be 'float' or 'double', got '%s'",
              type_it->second.c_str());

--- a/villagesql/schema/descriptor/type_context.cc
+++ b/villagesql/schema/descriptor/type_context.cc
@@ -178,7 +178,18 @@ void TypeContext::resolve_cached_values() {
         std::string result;
         char err[VEF_MAX_ERROR_LEN] = {0};
         if (!descriptor_->int_to_params_fn()->invoke(n, &result, err)) {
-          TypeParameters candidate = TypeParameters::from_raw(result);
+          // int_to_params may emit only a subset of the params.
+          // Need to call resolve_params to fill in defaults.
+          // A type providing int_to_params must also provide resolve_params
+          // (enforced at registration), so it is always present here.
+          assert(descriptor_->resolve_params_fn().has_value());
+          ResolvedTypeParams tmp = {};
+          char rerr[VEF_MAX_ERROR_LEN] = {0};
+          std::string canonical = result;
+          if (descriptor_->resolve_params_fn()->invoke(result, &tmp, rerr,
+                                                       &canonical))
+            continue;
+          TypeParameters candidate = TypeParameters::from_raw(canonical);
           if (candidate == key_.parameters()) {
             qualified_name_ += "(";
             qualified_name_ += std::to_string(n);

--- a/villagesql/schema/descriptor/type_context.cc
+++ b/villagesql/schema/descriptor/type_context.cc
@@ -162,9 +162,10 @@ void TypeContext::resolve_cached_values() {
 
   // Build qualified_name_: "ext.type", "ext.type(N)", or
   // "ext.type('k1=v1,k2=v2,...')".
-  // When int_to_params is available, try each integer-valued parameter to see
-  // if int_to_params(N) reproduces our exact params. If so, use the shorter
-  // TYPE(N) form. Otherwise fall back to TYPE('k=v,...').
+  // When int_to_params is available, try each integer-valued parameter and,
+  // after filling defaults via resolve_params, check if the result reproduces
+  // our exact params. If so, use the shorter TYPE(N) form. Otherwise fall back
+  // to TYPE('k=v,...').
   qualified_name_ = descriptor_->qualified_base_name();
   if (!key_.parameters().empty()) {
     bool used_shorthand = false;
@@ -178,10 +179,13 @@ void TypeContext::resolve_cached_values() {
         std::string result;
         char err[VEF_MAX_ERROR_LEN] = {0};
         if (!descriptor_->int_to_params_fn()->invoke(n, &result, err)) {
-          // int_to_params may emit only a subset of the params.
-          // Need to call resolve_params to fill in defaults.
-          // A type providing int_to_params must also provide resolve_params
-          // (enforced at registration), so it is always present here.
+          // Check whether TYPE(N) reproduces the stored params. Responsibility
+          // for filling in defaults is now split between int_to_params and
+          // resolve_params: int_to_params (should) emits only the pair derived
+          // from N, so we run resolve_params on its output here to fill the
+          // rest before comparing. A type providing int_to_params must also
+          // provide resolve_params (enforced at registration), so it is always
+          // present here.
           assert(descriptor_->resolve_params_fn().has_value());
           ResolvedTypeParams tmp = {};
           char rerr[VEF_MAX_ERROR_LEN] = {0};

--- a/villagesql/sdk/include/villagesql/detail/func_builder.h
+++ b/villagesql/sdk/include/villagesql/detail/func_builder.h
@@ -911,6 +911,65 @@ struct IntrinsicDefaultWithCacheWrapper {
   }
 };
 
+// Serialize a params map into the canonical "key=value,key=value,..." string.
+// Keys and values may not be empty (keys) or contain ',' or '='. On violation,
+// writes error_msg and returns true. op_name is the operation being serialized
+// for; it prefixes the error message.
+inline bool serialize_type_params(
+    const std::map<std::string, std::string> &params, const char *op_name,
+    std::string &out, char *error_msg) {
+  // TODO(villagesql-beta): decide on a broader character set policy.
+  out.clear();
+  for (const auto &[key, value] : params) {
+    if (key.empty() || key.find_first_of(",=") != std::string::npos) {
+      snprintf(error_msg, VEF_MAX_ERROR_LEN,
+               "%s: key '%s' is empty or contains ',' or '='", op_name,
+               key.c_str());
+      return true;
+    }
+    if (value.find_first_of(",=") != std::string::npos) {
+      snprintf(error_msg, VEF_MAX_ERROR_LEN,
+               "%s: value '%s' contains ',' or '='", op_name, value.c_str());
+      return true;
+    }
+    if (!out.empty()) out += ',';
+    out += key;
+    out += '=';
+    out += value;
+  }
+  return false;
+}
+
+// Appends ",<byte-len>[,key=value,...]" to result->str_buf, advancing
+// actual_len. Used only by the mutating resolve_params overload so the server
+// adopts the rewritten params as canonical. Prefixing the byte length of the
+// serialized blob makes the params section self-delimiting: the server reads
+// exactly that many bytes, leaving room to append further trailing fields later
+// without ambiguity. Returns true and writes error_msg on a serialization error
+// or if the combined result would overflow str_buf.
+inline bool add_mutated_params(const std::map<std::string, std::string> &params,
+                               vef_vdf_result_t *result) {
+  std::string serialized;
+  if (serialize_type_params(params, "resolve_params", serialized,
+                            result->error_msg)) {
+    return true;
+  }
+  std::string tail = ",";
+  tail += std::to_string(serialized.size());
+  if (!serialized.empty()) {
+    tail += ',';
+    tail += serialized;
+  }
+  if (result->actual_len + tail.size() > result->max_str_len) {
+    snprintf(result->error_msg, VEF_MAX_ERROR_LEN,
+             "resolve_params result too large for buffer");
+    return true;
+  }
+  memcpy(result->str_buf + result->actual_len, tail.data(), tail.size());
+  result->actual_len += tail.size();
+  return false;
+}
+
 // IntToParamsWrapper: wraps IntToTypeParamsFunc into a VDF.
 // VDF signature: (INT) -> STRING.
 template <IntToTypeParamsFunc Func>
@@ -930,27 +989,11 @@ struct IntToParamsWrapper {
       return;
     }
 
-    // TODO(villagesql-beta): decide on a broader character set policy.
     std::string serialized;
-    for (const auto &[key, value] : params) {
-      if (key.empty() || key.find_first_of(",=") != std::string::npos) {
-        result->type = VEF_RESULT_ERROR;
-        snprintf(result->error_msg, VEF_MAX_ERROR_LEN,
-                 "int_to_params: key '%s' is empty or contains ',' or '='",
-                 key.c_str());
-        return;
-      }
-      if (value.find_first_of(",=") != std::string::npos) {
-        result->type = VEF_RESULT_ERROR;
-        snprintf(result->error_msg, VEF_MAX_ERROR_LEN,
-                 "int_to_params: value '%s' contains ',' or '='",
-                 value.c_str());
-        return;
-      }
-      if (!serialized.empty()) serialized += ',';
-      serialized += key;
-      serialized += '=';
-      serialized += value;
+    if (serialize_type_params(params, "int_to_params", serialized,
+                              result->error_msg)) {
+      result->type = VEF_RESULT_ERROR;
+      return;
     }
 
     if (serialized.size() > result->max_str_len) {
@@ -966,10 +1009,19 @@ struct IntToParamsWrapper {
   }
 };
 
-// ResolveParamsWrapper: wraps ResolveTypeParamsFunc into a VDF.
+// ResolveParamsWrapper: wraps a resolve_params callback into a VDF.
 // VDF signature: (STRING) -> STRING.
-template <ResolveTypeParamsFunc Func>
+//
+// The result is "persisted_length,max_decode_buffer_length". When Func is the
+// mutating overload (ResolveTypeParamsMutableFunc), the (possibly rewritten)
+// params are appended as "...,<byte-len>[,key=value,...]" so the server can
+// adopt them as the canonical parameters. The const overload emits only the two
+// numbers.
+template <auto Func>
 struct ResolveParamsWrapper {
+  static constexpr bool is_mutable =
+      std::is_same_v<decltype(Func), ResolveTypeParamsMutableFunc>;
+
   static void invoke(vef_context_t *ctx, vef_vdf_args_t *args,
                      vef_vdf_result_t *result) {
     vef_invalue_t arg = get_invalue(ctx, args, 0);
@@ -1012,9 +1064,18 @@ struct ResolveParamsWrapper {
                "resolve_params result too large for buffer");
       return;
     }
+    result->actual_len = static_cast<size_t>(written);
+
+    // The mutating overload may have rewritten params; append them so the
+    // server adopts the rewritten set as canonical.
+    if constexpr (is_mutable) {
+      if (add_mutated_params(params, result)) {
+        result->type = VEF_RESULT_ERROR;
+        return;
+      }
+    }
 
     result->type = VEF_RESULT_VALUE;
-    result->actual_len = static_cast<size_t>(written);
   }
 };
 

--- a/villagesql/sdk/include/villagesql/vsql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_builder.h
@@ -66,6 +66,16 @@ using ResolveTypeParamsFunc =
     bool (*)(const std::map<std::string, std::string> &params,
              vsql::ResolvedTypeParams *result, char *error_msg);
 
+// resolve_params (mutating overload): same as ResolveTypeParamsFunc but the
+// params map is passed by non-const reference, so the type may rewrite it
+// (e.g. fill in default values. The rewritten map is serialized back and
+// becomes the canonical parameter string persisted for the type. The rewrite
+// must be idempotent: resolving the rewritten params again must yield the same
+// params and storage sizes.
+using ResolveTypeParamsMutableFunc =
+    bool (*)(std::map<std::string, std::string> &params,
+             vsql::ResolvedTypeParams *result, char *error_msg);
+
 }  // namespace func_builder
 }  // namespace vsql
 
@@ -780,7 +790,7 @@ constexpr detail::StaticFuncDesc<1> make_int_to_params(const char *name) {
 }
 
 // make_resolve_params<&fn>("name") — (STRING) -> STRING.
-template <ResolveTypeParamsFunc Func>
+template <auto Func>
 constexpr detail::StaticFuncDesc<1> make_resolve_params(const char *name) {
   detail::FuncWithMetadata meta{};
   meta.f = &detail::ResolveParamsWrapper<Func>::invoke;

--- a/villagesql/sdk/include/villagesql/vsql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/type_builder.h
@@ -240,16 +240,28 @@ class TypeBuilder {
 
   // resolve_params: VDF that validates params and computes storage sizes.
   // Auto-generates VDF name "TYPENAME::resolve_params".
-  // Function signature:
+  // Function signature (either overload is accepted):
   //   bool fn(const std::map<std::string,std::string>&,
   //           vsql::ResolvedTypeParams*, char* error_msg)
+  //   bool fn(std::map<std::string,std::string>&,
+  //           vsql::ResolvedTypeParams*, char* error_msg)
+  // The second (non-const) form may rewrite the params map; the rewritten map
+  // becomes the canonical parameter string persisted for the type and must
+  // resolve idempotently.
   template <auto Func>
   constexpr auto resolve_params() const {
     using namespace detail;
+    static_assert(!HasResolveParams,
+                  "resolve_params<Func>() called more than once; a type may "
+                  "provide only one resolve_params (const or non-const)");
     static_assert(
-        std::is_same_v<decltype(Func), func_builder::ResolveTypeParamsFunc>,
+        std::is_same_v<decltype(Func), func_builder::ResolveTypeParamsFunc> ||
+            std::is_same_v<decltype(Func),
+                           func_builder::ResolveTypeParamsMutableFunc>,
         "resolve_params<Func>() requires: "
         "bool fn(const std::map<std::string,std::string>&, "
+        "vsql::ResolvedTypeParams*, char*) or "
+        "bool fn(std::map<std::string,std::string>&, "
         "vsql::ResolvedTypeParams*, char*)");
     constexpr const char *vdf_name =
         kTypeOpVdfName<Name, TypeOp::kResolveParams>.buf;

--- a/villagesql/test-extensions/vsql-bitfield-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-bitfield-test/src/extension.cc
@@ -13,16 +13,20 @@
 // along with this program; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
 
-// Test fixture for issue #535: a variable-length, NON-parameterized bit field
-// type whose length (in bits) is decided per value.
+// A variable-length bit field type whose length (in bits) is decided
+// per value, with an optional per-column upper bound.
 //
-// BITFIELD declares a max_persisted_length upper bound and NO
-// params/int_to_params/resolve_params, and its element is a single BIT rather
-// than a byte or a fixed-width number. A column is declared without any length
-// or parameters:
-//   CREATE TABLE t (b vsql_bitfield_test.BITFIELD);
-// and each value keeps its own bit length; bit fields of different lengths
-// coexist in the same column.
+// BITFIELD declares a max_persisted_length upper bound and its element is a
+// single BIT rather than a byte or a fixed-width number. Each value keeps its
+// own bit length, so bit fields of different lengths coexist in the same
+// column. The column accepts an optional 'max_number_of_bits' parameter that
+// caps how many bits any value in the column may hold:
+//   CREATE TABLE t (b vsql_bitfield_test.BITFIELD);                  -- max 8
+//   CREATE TABLE t (b vsql_bitfield_test.BITFIELD('max_number_of_bits=64'));
+// The bare form has no parameters, so resolve_params runs with an empty map and
+// falls back to kBitfieldMaxBits. Because the type is parameterized
+// (params + resolve_params), from_string takes a MaybeParams<BitfieldParams>
+// and to_string/compare take CustomArgWith<BitfieldParams>.
 //
 // from_string packs each '0'/'1' character into one BIT (8 bits per byte), so a
 // 64-character string of bits stores in 8 bytes of packed bits, not 64. The
@@ -43,11 +47,17 @@
 #include <villagesql/vsql.h>
 
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <map>
+#include <string>
 #include <string_view>
 
-// Maximum number of bits a BITFIELD value may hold. The bit count is stored in
-// a 2-byte little-endian header, so it must fit in a uint16.
+// Absolute cap on the number of bits a BITFIELD value may hold. The bit count
+// is stored in a 2-byte little-endian header, so it must fit in a uint16. The
+// per-column cap (the 'max_number_of_bits' parameter, below) must not exceed
+// this.
 constexpr int64_t kBitfieldMaxBits = 4096;
 constexpr int64_t kBitfieldHeaderLen = 2;
 // Upper bound on the stored value: 2-byte header plus ceil(maxBits/8) packed
@@ -72,12 +82,67 @@ static int get_bit(const unsigned char *data, size_t i) {
   return (data[i / 8] >> (7 - (i % 8))) & 1;
 }
 
+// Type parameter: the maximum number of bits any value in the column may hold.
+// Defaults to kBitfieldMaxBits when the column omits the parameter.
+struct BitfieldParams {
+  int64_t max_bits = kBitfieldMaxBits;
+
+  static BitfieldParams parse(
+      const std::map<std::string, std::string> &params) {
+    BitfieldParams p;
+    auto it = params.find("max_number_of_bits");
+    if (it != params.end())
+      p.max_bits = strtoll(it->second.c_str(), nullptr, 10);
+    return p;
+  }
+
+  static void to_strings(const BitfieldParams &p,
+                         std::map<std::string, std::string> &out) {
+    out["max_number_of_bits"] = std::to_string(p.max_bits);
+  }
+};
+
+// resolve_params validates 'max_number_of_bits' (default kBitfieldMaxBits) and
+// computes the storage sizes for this parameterization. The bare form routes
+// here with an empty map and falls back to the default, so a missing parameter
+// is accepted rather than rejected.
+bool bitfield_resolve_params(std::map<std::string, std::string> &params,
+                             vsql::ResolvedTypeParams *result,
+                             char *error_msg) {
+  auto it = params.find("max_number_of_bits");
+  int64_t max_bits = it != params.end()
+                         ? strtoll(it->second.c_str(), nullptr, 10)
+                         : kBitfieldMaxBits;
+  if (max_bits <= 0 || max_bits > kBitfieldMaxBits) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "BITFIELD 'max_number_of_bits' must be a positive integer <= %lld",
+             static_cast<long long>(kBitfieldMaxBits));
+    return true;
+  }
+  params["max_number_of_bits"] = std::to_string(max_bits);
+  // Variable-length: persisted_length is the upper bound on the backing field
+  // for this parameterization (header + ceil(max_bits/8)); the per-value length
+  // is still reported via out.set_length() in from_string.
+  result->max_decode_buffer_length = max_bits;
+  return false;
+}
+
 // STRING -> binary: pack each '0'/'1' character into one bit. The number of
-// bits is decided per value (not a type parameter); the actual byte length is
-// reported via out.set_length().
-void bitfield_from_string(std::string_view from, vsql::CustomResult out) {
+// bits is decided per value; the actual byte length is reported via
+// out.set_length(). The column's 'max_number_of_bits' caps how many bits a
+// value may hold. params is unknown only on the constant-string inference path;
+// there we fall back to the default cap.
+void bitfield_from_string(vsql::MaybeParams<BitfieldParams> &p,
+                          std::string_view from, vsql::CustomResult out) {
+  if (!p.is_known()) p.set(BitfieldParams{});
+  const int64_t max_bits = p.value().max_bits;
+
   auto buf = out.buffer();
   const size_t nbits = from.size();
+  if (static_cast<int64_t>(nbits) > max_bits) {
+    out.warning("BITFIELD: value exceeds max_number_of_bits");
+    return;
+  }
   const size_t nbytes = (nbits + 7) / 8;
   if (kBitfieldHeaderLen + nbytes > buf.size()) {
     out.warning("BITFIELD: value exceeds max length");
@@ -101,8 +166,12 @@ void bitfield_from_string(std::string_view from, vsql::CustomResult out) {
   out.set_length(kBitfieldHeaderLen + nbytes);
 }
 
-// binary -> STRING: emit exactly bit-count '0'/'1' characters, MSB-first.
-void bitfield_to_string(vsql::CustomArg in, vsql::StringResult out) {
+// binary -> STRING: emit exactly bit-count '0'/'1' characters, MSB-first. The
+// bit count is read from the value's header, so the params are not needed here;
+// the CustomArgWith<BitfieldParams> signature is required only because the type
+// is parameterized.
+void bitfield_to_string(vsql::CustomArgWith<BitfieldParams> in,
+                        vsql::StringResult out) {
   auto data = in.value();
   auto buf = out.buffer();
   if (data.size() < static_cast<size_t>(kBitfieldHeaderLen)) {
@@ -119,7 +188,9 @@ void bitfield_to_string(vsql::CustomArg in, vsql::StringResult out) {
 }
 
 // Bit-by-bit comparison; a shorter bit field sorts first on a common prefix.
-int bitfield_compare(vsql::CustomArg a, vsql::CustomArg b) {
+// Comparison is purely on the stored bits, so the params are not consulted.
+int bitfield_compare(vsql::CustomArgWith<BitfieldParams> a,
+                     vsql::CustomArgWith<BitfieldParams> b) {
   auto da = a.value();
   auto db = b.value();
   size_t nabits = da.size() >= static_cast<size_t>(kBitfieldHeaderLen)
@@ -197,6 +268,9 @@ constexpr auto BITFIELD = vsql::make_type<kBitfieldTypeName>()
                               .variable_length_type()
                               .max_persisted_length(kBitfieldMaxLen)
                               .max_decode_buffer_length(kBitfieldMaxText)
+                              .params<BitfieldParams, &BitfieldParams::parse,
+                                      &BitfieldParams::to_strings>()
+                              .resolve_params<&bitfield_resolve_params>()
                               .from_string<&bitfield_from_string>()
                               .to_string<&bitfield_to_string>()
                               .compare<&bitfield_compare>()

--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -119,8 +119,12 @@ class PT_custom_type : public PT_type {
                                          const TypeContext *&type_context) {
     char error_msg[VEF_MAX_ERROR_LEN] = {0};
     ResolvedTypeParams resolved = {};
+    // A type using the mutating resolve_params overload can rewrite its params
+    // (e.g. fill in defaults). When it does, the rewritten string becomes the
+    // canonical parameters we key the context on and persist.
+    std::string canonical_params = params_str;
     if (descriptor->resolve_params_fn()->invoke(params_str, &resolved,
-                                                error_msg)) {
+                                                error_msg, &canonical_params)) {
       thd->syntax_error_at(pos, "%s", error_msg);
       return true;
     }
@@ -151,7 +155,11 @@ class PT_custom_type : public PT_type {
       return true;
     }
 
-    TypeParameters params(params_str);
+    // Re-canonicalize in case resolve_params rewrote the params. from_raw
+    // normalizes ordering/case; a no-op when the params were left unchanged.
+    TypeParameters params = canonical_params == params_str
+                                ? TypeParameters(params_str)
+                                : TypeParameters::from_raw(canonical_params);
 
     type_context = nullptr;
     if (AcquireOrCreateTypeContext(descriptor, params, *thd->mem_root,

--- a/villagesql/types/type_function.cc
+++ b/villagesql/types/type_function.cc
@@ -27,12 +27,12 @@ namespace villagesql {
 
 namespace {
 
-// Parses the optional rewritten-params section a mutating resolve_params VDF
-// appends after the two length fields: "<byte-len>[,key=value,...]". section is
-// the text following the ',' that introduces it, and points into a
-// NUL-terminated buffer. On success writes the params string to *params (empty
-// when the length is 0) and returns false; on malformed input writes error_msg
-// and returns true.
+// Parses the optional rewritten-params section that mutating resolve_params VDF
+// appends after peristed_length,max_decode_buffer_length fields:
+// "<byte-len>[,key=value,...]". Section is the text following the ',' that
+// introduces it, and points into a NUL-terminated buffer. On success writes
+// the params string to *params (empty when the length is 0) and returns false;
+// on malformed input writes error_msg and returns true.
 bool parse_rewritten_params(std::string_view section, std::string *params,
                             char *error_msg) {
   char *len_end = nullptr;

--- a/villagesql/types/type_function.cc
+++ b/villagesql/types/type_function.cc
@@ -19,10 +19,51 @@
 #include <cstdlib>
 #include <cstring>
 #include <string>
+#include <string_view>
 
 #include "villagesql/types/special_vdf_call.h"
 
 namespace villagesql {
+
+namespace {
+
+// Parses the optional rewritten-params section a mutating resolve_params VDF
+// appends after the two length fields: "<byte-len>[,key=value,...]". section is
+// the text following the ',' that introduces it, and points into a
+// NUL-terminated buffer. On success writes the params string to *params (empty
+// when the length is 0) and returns false; on malformed input writes error_msg
+// and returns true.
+bool parse_rewritten_params(std::string_view section, std::string *params,
+                            char *error_msg) {
+  char *len_end = nullptr;
+  long long params_len = strtoll(section.data(), &len_end, 10);
+  if (len_end == section.data() || params_len < 0) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "resolve_params VDF returned invalid rewritten params length");
+    return true;
+  }
+
+  params->clear();
+  if (params_len == 0) return false;
+
+  size_t consumed = static_cast<size_t>(len_end - section.data());
+  if (*len_end != ',') {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "resolve_params VDF returned malformed rewritten params");
+    return true;
+  }
+  consumed++;  // the ',' separating the length from the params bytes
+  if (section.size() - consumed < static_cast<size_t>(params_len)) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "resolve_params VDF returned rewritten params shorter than its "
+             "declared length");
+    return true;
+  }
+  params->assign(section.data() + consumed, static_cast<size_t>(params_len));
+  return false;
+}
+
+}  // namespace
 
 bool IntToParamsFunction::invoke(int64_t value, std::string *result,
                                  char *error_msg) const {
@@ -42,8 +83,8 @@ bool IntToParamsFunction::invoke(int64_t value, std::string *result,
 }
 
 bool ResolveParamsFunction::invoke(const std::string &params_str,
-                                   ResolvedTypeParams *result,
-                                   char *error_msg) const {
+                                   ResolvedTypeParams *result, char *error_msg,
+                                   std::string *rewritten_params) const {
   char str_buffer[VEF_MAX_TYPE_PARAMS_STRING_LEN];
   SpecialVdfCall<StringResult, StringArg> call(vdf_);
   call.init();
@@ -58,7 +99,12 @@ bool ResolveParamsFunction::invoke(const std::string &params_str,
       call.alt_str_buf() != nullptr ? call.alt_str_buf() : str_buffer;
   std::string output(result_data, *r);
 
-  // Parse "persisted_length,max_decode_buffer_length"
+  // Parse "persisted_length,max_decode_buffer_length" with an optional trailing
+  // rewritten-params section from the mutating resolve_params overload:
+  //   "persisted_length,max_decode_buffer_length,<byte-len>[,key=value,...]"
+  // The byte length makes the params section self-delimiting, so it reads
+  // exactly that many bytes and further trailing fields could be added after
+  // them without ambiguity.
   size_t comma = output.find(',');
   if (comma == std::string::npos) {
     snprintf(error_msg, VEF_MAX_ERROR_LEN,
@@ -75,11 +121,23 @@ bool ResolveParamsFunction::invoke(const std::string &params_str,
   }
   result->max_decode_buffer_length =
       strtoll(output.c_str() + comma + 1, &endptr, 10);
-  if (*endptr != '\0') {
+  // endptr now points at the terminator: '\0' for the two-field (const) form,
+  // or ',' introducing the rewritten-params section for the mutating overload.
+  if (*endptr == '\0') return false;
+  if (*endptr != ',') {
     snprintf(error_msg, VEF_MAX_ERROR_LEN,
              "resolve_params VDF returned invalid max_decode_buffer_length");
     return true;
   }
+
+  // Rewritten-params section from the mutating overload:
+  // "<byte-len>[,key=value,...]", starting just past this comma.
+  std::string_view section(
+      endptr + 1,
+      output.size() - static_cast<size_t>(endptr + 1 - output.c_str()));
+  std::string params;
+  if (parse_rewritten_params(section, &params, error_msg)) return true;
+  if (rewritten_params != nullptr) *rewritten_params = std::move(params);
 
   return false;
 }

--- a/villagesql/types/type_function.h
+++ b/villagesql/types/type_function.h
@@ -133,9 +133,17 @@ class ResolveParamsFunction {
 
   // Validates parameters and computes storage characteristics.
   // Takes a canonical "key=value,..." string.
+  //
+  // If the type's resolve_params uses the mutating overload, it may rewrite the
+  // parameters (e.g. fill in defaults). When rewritten_params is non-null and
+  // the VDF emitted a rewritten parameter string, it is written there in
+  // canonical "key=value,..." form; callers should treat it as the new
+  // canonical parameter string. When the VDF emits no rewrite, rewritten_params
+  // is left untouched.
+  //
   // Returns false on success, true on error (writes to error_msg).
   bool invoke(const std::string &params_str, ResolvedTypeParams *result,
-              char *error_msg) const;
+              char *error_msg, std::string *rewritten_params = nullptr) const;
 
  private:
   const vef_func_desc_t *vdf_{nullptr};


### PR DESCRIPTION
Give parameterized custom types a mutating resolve_params overload so a type can canonicalize its parameters -- fill in omitted defaults -- and have the rewritten set persisted as the column's canonical parameters. This makes resolve_params the single place that both validates and completes a type's parameters, so int_to_params only needs to emit the one pair that the integer shorthand maps to.

Closes #791