### PR TITLE
Revert ABI fixed width types

### DIFF
--- a/villagesql/sdk/README.md
+++ b/villagesql/sdk/README.md
@@ -47,23 +47,6 @@ server.
 Any changes to the ABI/API must be done in the Unstable/Development version of the headers.
 See [API_ABI.md](API_ABI.md) for more details on the API and ABI.
 
-### Fixed-Width Types
-
-Use fixed-width integer types (`int64_t`, `uint64_t`, `uint32_t`, ...) in the
-ABI/API — never platform-dependent types such as `size_t`, `long`, `long long`,
-or `unsigned int`. The width of `size_t`/`long` varies by platform, and even
-same-width types are distinct: `int64_t` is `long` on 64-bit Linux but
-`long long` on macOS. Platform types make the binary layout and the function
-signatures non-portable across the platforms an extension may target — a
-mismatch that frequently compiles on one platform and fails on another. Format
-integer values with the `<cinttypes>` macros (`PRId64`, `PRIu64`, `SCNd64`)
-instead of `%lld`/`%llu` with casts.
-
-This applies to the ABI headers and the C++ API surface. Server-side code that
-bridges to MySQL's own machinery (e.g. a `PLUGIN_VAR_LONGLONG` system variable)
-should still use MySQL's types (`longlong`) at that boundary, since it must
-match the type of the object MySQL owns.
-
 ### Stabilizing a Protocol
 
 When the functionality in the new protocol is ready, then it should be

--- a/villagesql/sdk/include/villagesql/abi/preview/keyring.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/keyring.h
@@ -63,8 +63,8 @@ typedef enum {
 typedef vef_keyring_result_t (*vef_read_keyring_fn)(const char *data_id,
                                                     const char *auth_id,
                                                     unsigned char *buf,
-                                                    uint64_t buf_len,
-                                                    uint64_t *out_len);
+                                                    size_t buf_len,
+                                                    size_t *out_len);
 
 // Write a secret to the MySQL keyring component.
 //   data_id:   identifier for the secret.
@@ -74,7 +74,7 @@ typedef vef_keyring_result_t (*vef_read_keyring_fn)(const char *data_id,
 typedef vef_keyring_result_t (*vef_write_keyring_fn)(const char *data_id,
                                                      const char *auth_id,
                                                      const unsigned char *data,
-                                                     uint64_t data_len);
+                                                     size_t data_len);
 
 typedef struct {
   // Capability ABI version. Always the first field in every capability vtable.

--- a/villagesql/sdk/include/villagesql/abi/preview/sql_query.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/sql_query.h
@@ -83,7 +83,7 @@ typedef struct {
   const char *sqlstate;
   // UTF-8 message. Never null; may be empty.
   const char *message;
-  uint64_t message_len;
+  size_t message_len;
 } vef_sql_diag_t;
 
 // Open a session bound to the background thread's security context.
@@ -101,12 +101,12 @@ typedef void (*vef_sql_close_session_fn)(vef_sql_session_t *session);
 // The entire result set is buffered before returning.
 typedef vef_sql_result_t *(*vef_sql_execute_fn)(vef_sql_session_t *session,
                                                 const char *sql,
-                                                uint64_t sql_len);
+                                                size_t sql_len);
 
 // Row callback for for_each_row. Called once per row with the same row/lengths
 // pointers as fetch_row. Return true to continue, false to stop early.
 typedef bool (*vef_sql_row_cb)(const char **row, const unsigned long *lengths,
-                               uint32_t num_columns, void *ctx);
+                               unsigned int num_columns, void *ctx);
 
 // Execute a SQL statement and invoke cb once per row as rows are produced,
 // without buffering the full result set. sql is UTF-8, sql_len bytes.
@@ -116,7 +116,7 @@ typedef bool (*vef_sql_row_cb)(const char **row, const unsigned long *lengths,
 // The handle must be closed with close_result.
 typedef vef_sql_result_t *(*vef_sql_for_each_row_fn)(vef_sql_session_t *session,
                                                      const char *sql,
-                                                     uint64_t sql_len,
+                                                     size_t sql_len,
                                                      vef_sql_row_cb cb,
                                                      void *ctx);
 
@@ -128,7 +128,7 @@ typedef bool (*vef_sql_fetch_row_fn)(vef_sql_result_t *result,
                                      const unsigned long **lengths_out);
 
 // Number of columns in the result set. Valid after a successful execute().
-typedef uint32_t (*vef_sql_num_columns_fn)(vef_sql_result_t *result);
+typedef unsigned int (*vef_sql_num_columns_fn)(vef_sql_result_t *result);
 
 // Close the result handle. Must be called for every non-NULL handle returned
 // by execute or for_each_row.
@@ -145,12 +145,13 @@ typedef bool (*vef_sql_get_error_fn)(const vef_sql_result_t *result,
                                      vef_sql_diag_t *out);
 
 // Number of warning/note diagnostics attached to the result.
-typedef uint32_t (*vef_sql_warning_count_fn)(const vef_sql_result_t *result);
+typedef unsigned int (*vef_sql_warning_count_fn)(
+    const vef_sql_result_t *result);
 
 // Copy the i-th warning into *out. Returns true if i < warning_count();
 // false (and leaves *out untouched) otherwise.
 typedef bool (*vef_sql_get_warning_fn)(const vef_sql_result_t *result,
-                                       uint32_t i, vef_sql_diag_t *out);
+                                       unsigned int i, vef_sql_diag_t *out);
 
 // Server-provided vtable for SQL execution.
 typedef struct {

--- a/villagesql/sdk/include/villagesql/abi/preview/statement_event.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/statement_event.h
@@ -106,7 +106,7 @@ typedef struct {
   // Query text. Not null-terminated; use query_len.
   // Lifetime: copy before return.
   const char *query;
-  uint64_t query_len;
+  size_t query_len;
 
   // Authenticated user name, or empty string.
   // Lifetime: connection lifetime.

--- a/villagesql/sdk/include/villagesql/abi/preview/status_var.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/status_var.h
@@ -50,7 +50,7 @@ extern "C" {
 // Status variable type. Unlike system variables (which are configurable),
 // status variables are read-only counters and gauges exposed via SHOW STATUS.
 typedef enum {
-  VEF_STATUS_VAR_INT = 0,     // int64_t counter/gauge (shown as unsigned)
+  VEF_STATUS_VAR_INT = 0,     // long long counter/gauge (shown as unsigned)
   VEF_STATUS_VAR_DOUBLE = 1,  // double gauge
 } vef_status_var_type_t;
 
@@ -69,7 +69,7 @@ typedef struct {
   // lifetime of the extension. The extension writes to this; the server reads
   // it at SHOW STATUS time.
   union {
-    int64_t *integer_ptr;
+    long long *integer_ptr;
     double *double_ptr;
   };
 } vef_status_var_desc_t;

--- a/villagesql/sdk/include/villagesql/abi/preview/sys_var.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/sys_var.h
@@ -63,7 +63,7 @@ typedef struct {
   // Only the field matching type is valid.
   union {
     bool bool_val;
-    int64_t int_val;
+    long long int_val;
     double dbl_val;
     // For VEF_VAR_STR: points to the newly allocated string. Valid for the
     // duration of the callback; do not retain the pointer.
@@ -98,10 +98,10 @@ typedef struct {
       bool def_val;
     } boolean;
     struct {
-      int64_t *value_ptr;
-      int64_t def_val;
-      int64_t min_val;
-      int64_t max_val;
+      long long *value_ptr;
+      long long def_val;
+      long long min_val;
+      long long max_val;
     } integer;
     struct {
       double *value_ptr;
@@ -134,7 +134,7 @@ typedef struct {
 // Returns false on success, true on error.
 typedef bool (*vef_sys_var_get_func_t)(const char *component_name,
                                        const char *name, void **val,
-                                       uint64_t *val_len);
+                                       size_t *val_len);
 
 // Sets a system variable to a string value.
 //

--- a/villagesql/sdk/include/villagesql/abi/preview/thread_worker.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/thread_worker.h
@@ -58,7 +58,7 @@ struct vef_thread_handle_t;
 // To set a new poll fd, return its value (must be > 0).
 // To explicitly clear the poll fd, return poll_fd == -1.
 typedef struct {
-  uint32_t sleep_ms;
+  unsigned int sleep_ms;
   int poll_fd;
 } vef_next_wakeup_t;
 
@@ -88,7 +88,7 @@ typedef struct {
   // Default interval between wakeups in milliseconds. Used as the initial
   // sleep_ms until work_fn returns a non-zero value. 0 means no periodic
   // wakeup (thread only wakes on poll_fd or explicit stop).
-  uint32_t sleep_ms;
+  unsigned int sleep_ms;
 
   // Thread name suffix (e.g. "monitor"). The server prepends the extension
   // name to form the full thread name (e.g. "my_ext/monitor").

--- a/villagesql/sdk/include/villagesql/abi/types.h
+++ b/villagesql/sdk/include/villagesql/abi/types.h
@@ -162,7 +162,7 @@
 //          │                                                   │
 //
 
-typedef enum : uint32_t {
+typedef enum : unsigned int {
   VEF_PROTOCOL_0,  // Not used
   VEF_PROTOCOL_1,  // Stable as of v0.0.1, likely to be deprecated.
   VEF_PROTOCOL_2,  // Deprecated. Was the unstable development version before
@@ -200,9 +200,9 @@ typedef enum : uint32_t {
 //   A) How do we handle encodings and collations?
 //   B) Resizing the buffer can probably be done in a smarter way.
 typedef struct {
-  uint32_t major;
-  uint32_t minor;
-  uint32_t patch;
+  unsigned int major;
+  unsigned int minor;
+  unsigned int patch;
 
   // Owned by whoever owns this struct.
   const char *extra;
@@ -249,15 +249,15 @@ typedef struct {
 
   union {
     struct {
-      uint64_t str_len;
+      size_t str_len;
       const char *str_value;
     };
     struct {
-      uint64_t bin_len;
+      size_t bin_len;
       const unsigned char *bin_value;
     };
     double real_value;
-    int64_t int_value;
+    long long int_value;
   };
 } vef_invalue_v1_t;
 
@@ -266,7 +266,7 @@ typedef struct {
 // keys[i] pairs with values[i]. count == 0 for non-parameterized or
 // non-custom types.
 typedef struct {
-  uint32_t count;
+  unsigned int count;
   const char *const *keys;
   const char *const *values;
 } vef_type_params_t;
@@ -289,12 +289,12 @@ typedef struct {
   // INPUT: caller-supplied buffer for the canonical "k=v,k=v" params string.
   char *buf;
   // INPUT: capacity of buf in bytes.
-  uint64_t max_buf_len;
+  size_t max_buf_len;
   // OUTPUT: number of bytes that would have been written (no NUL). 0 means
   // no params were inferred (e.g., the extension's from_string did not call
   // p.set(), the call errored, or the type does not register
   // params_to_strings).
-  uint64_t actual_len;
+  size_t actual_len;
   // OUTPUT: true if actual_len > max_buf_len. When true, buf is not safe to
   // read; the caller should retry with a larger buffer.
   bool overflow;
@@ -310,13 +310,13 @@ typedef struct {
   union {
     // For TYPE_STRING: human-readable text
     struct {
-      uint64_t str_len;
+      size_t str_len;
       const char *str_value;
     };
 
     // For TYPE_CUSTOM: binary data (persisted format)
     struct {
-      uint64_t bin_len;
+      size_t bin_len;
       const unsigned char *bin_value;
 
       // protocol >= VEF_PROTOCOL_3
@@ -330,7 +330,7 @@ typedef struct {
     double real_value;
 
     // For TYPE_INT
-    int64_t int_value;
+    long long int_value;
   };
 } vef_invalue_t;
 
@@ -365,7 +365,7 @@ typedef struct {
   // The actual length of the result (set iff type is IS_VALUE for
   // STRING/CUSTOM) If type is IS_BUF_TOO_SMALL, this indicates the required
   // buffer size. For REAL and INT types, this field is unused.
-  uint64_t actual_len;
+  size_t actual_len;
 
   // Caller-provided buffer for error message (size VEF_MAX_ERROR_LEN).
   // Write a null-terminated string here if type == IS_ERROR.
@@ -378,7 +378,7 @@ typedef struct {
       char *str_buf;
 
       // Size of str_buf in bytes
-      uint64_t max_str_len;
+      size_t max_str_len;
 
       // Callee can return a different pointer than str_buf, e.g., if it already
       // has the result in its memory and wants to avoid a copy. To do this,
@@ -401,7 +401,7 @@ typedef struct {
       unsigned char *bin_buf;
 
       // Size of bin_buf in bytes
-      uint64_t max_bin_len;
+      size_t max_bin_len;
 
       // Callee can return a different pointer than bin_buf. Same semantics
       // as alt_str_buf above.
@@ -416,7 +416,7 @@ typedef struct {
     double real_value;
 
     // For INT return type
-    int64_t int_value;
+    long long int_value;
   };
 
   // protocol >= VEF_PROTOCOL_3
@@ -454,7 +454,7 @@ typedef struct {
   void *user_data;
 
   // Number of input values
-  uint32_t value_count;
+  unsigned int value_count;
 
   // Check ctx->protocol to determine which union member to read.
   union {
@@ -485,7 +485,7 @@ typedef struct {
 #define VEF_PARAM_VARARGS UINT_MAX
 
 typedef struct {
-  uint32_t param_count;
+  unsigned int param_count;
   const vef_type_t *params;
 
   vef_type_t return_type;
@@ -512,7 +512,7 @@ typedef void (*vef_vdf_func_t)(vef_context_t *ctx, vef_vdf_args_t *args,
 
 typedef struct {
   // Number of arguments that will be passed to each vdf call
-  uint32_t arg_count;
+  unsigned int arg_count;
 
   // Type of each argument. Array has arg_count elements.
   vef_type_t *arg_types;
@@ -536,7 +536,7 @@ typedef struct {
   char *error_msg;
 
   // Requested result buffer size (0 = use default from type)
-  uint64_t result_buffer_size;
+  size_t result_buffer_size;
 
   // Extension-allocated state. Set this to pass data to vdf and postrun.
   // Caller initializes to NULL.
@@ -612,7 +612,7 @@ typedef struct {
   vef_postrun_func_t postrun;
 
   // Minimum buffer size requested for string results (0 = use default)
-  uint64_t buffer_size;
+  size_t buffer_size;
 
   // protocol >= VEF_PROTOCOL_3
   // If true, the function always returns the same result for the same inputs
@@ -850,10 +850,10 @@ typedef struct vef_registration_t {
   vef_version_t sdk_version;
   const char *deprecated_extension_name;
 
-  uint32_t func_count;
+  unsigned int func_count;
   vef_func_desc_t **funcs;
 
-  uint32_t type_count;
+  unsigned int type_count;
   vef_type_desc_t **types;
 
   // protocol >= VEF_PROTOCOL_3
@@ -862,7 +862,7 @@ typedef struct vef_registration_t {
   // the capability struct pointed to by each entry before vef_register()
   // returns. If a capability is unavailable or there is an ABI struct
   // mismatch, loading the extension fails with an error.
-  uint32_t required_capability_count;
+  unsigned int required_capability_count;
   const vef_required_capability_t *required_capabilities;
 } vef_registration_t;
 

--- a/villagesql/sdk/include/villagesql/detail/func_builder.h
+++ b/villagesql/sdk/include/villagesql/detail/func_builder.h
@@ -303,7 +303,7 @@ struct FuncWithMetadata {
   vef_type_t return_type;
   std::array<vef_type_t, kMaxParams> param_types;
   size_t num_params;
-  uint64_t buffer_size;
+  size_t buffer_size;
   uint64_t max_result_length;
   bool deterministic;
   // When true, the function accepts a variable number of arguments. The
@@ -714,7 +714,7 @@ struct TypeHashVdfWrapper {
       result->type = VEF_RESULT_NULL;
       return;
     }
-    result->int_value = static_cast<int64_t>(Func(CustomArg(&arg)));
+    result->int_value = static_cast<long long>(Func(CustomArg(&arg)));
     result->type = VEF_RESULT_VALUE;
   }
 };
@@ -868,7 +868,7 @@ struct TypeHashWithCacheVdfWrapper {
       result->type = VEF_RESULT_NULL;
       return;
     }
-    result->int_value = static_cast<int64_t>(Func(CustomArgWith<P>(&arg)));
+    result->int_value = static_cast<long long>(Func(CustomArgWith<P>(&arg)));
     result->type = VEF_RESULT_VALUE;
   }
 };
@@ -1034,7 +1034,7 @@ struct StaticFuncDesc {
   vef_postrun_func_t postrun_;
   vef_vdf_clear_func_t clear_;
   vef_vdf_accumulate_func_t accumulate_;
-  uint64_t buffer_size_;
+  size_t buffer_size_;
   uint64_t max_result_length_;
   bool deterministic_;
   bool is_varargs_;
@@ -1056,7 +1056,7 @@ struct StaticFuncDesc {
     if (max_result_length_ > 0) return VEF_PROTOCOL_4;
     return is_varargs_ ? VEF_PROTOCOL_3 : VEF_PROTOCOL_1;
   }
-  constexpr uint64_t buffer_size() const { return buffer_size_; }
+  constexpr size_t buffer_size() const { return buffer_size_; }
   constexpr uint64_t max_result_length() const { return max_result_length_; }
   constexpr bool deterministic() const { return deterministic_; }
   constexpr auto check_params_cache_bound() const -> bool (*)() {

--- a/villagesql/sdk/include/villagesql/preview/keyring_impl.h
+++ b/villagesql/sdk/include/villagesql/preview/keyring_impl.h
@@ -25,7 +25,7 @@ inline KeyringCapability::ReadResult KeyringCapability::read(
     std::string_view data_id, std::string_view auth_id) const {
   std::string value;
   value.resize(4096);
-  uint64_t out_len = 0;
+  size_t out_len = 0;
   vef_keyring_result_t result = abi_->read(
       data_id.data(), auth_id.empty() ? nullptr : auth_id.data(),
       reinterpret_cast<unsigned char *>(value.data()), value.size(), &out_len);

--- a/villagesql/sdk/include/villagesql/preview/status_var.h
+++ b/villagesql/sdk/include/villagesql/preview/status_var.h
@@ -48,7 +48,7 @@ struct StatusVarDescriptor {
   Type type;
   const char *name;
   union {
-    int64_t *integer_ptr;
+    long long *integer_ptr;
     double *double_ptr;
   };
 };
@@ -59,8 +59,8 @@ struct StatusVarDescriptor {
 //
 // Usage:
 //
-//   static int64_t g_hits = 0;
-//   static int64_t g_misses = 0;
+//   static long long g_hits = 0;
+//   static long long g_misses = 0;
 //
 //   namespace sv = vsql::preview_status_var;
 //
@@ -122,7 +122,7 @@ class StatusVarCapability
 //       sv::make_int   ("hits",    &g_hits),
 //       sv::make_double("latency", &g_latency),
 //   });
-inline StatusVarDescriptor make_int(const char *name, int64_t *value_ptr) {
+inline StatusVarDescriptor make_int(const char *name, long long *value_ptr) {
   StatusVarDescriptor d;
   d.type = INT;
   d.name = name;

--- a/villagesql/sdk/include/villagesql/preview/sys_var.h
+++ b/villagesql/sdk/include/villagesql/preview/sys_var.h
@@ -71,7 +71,7 @@ class SysVarChange {
     vef_invalue_t v{};
     switch (c->type) {
       case VEF_VAR_BOOL:
-        v.int_value = static_cast<int64_t>(c->bool_val);
+        v.int_value = static_cast<long long>(c->bool_val);
         break;
       case VEF_VAR_INT:
         v.int_value = c->int_val;
@@ -113,10 +113,10 @@ struct SysVarDescriptor {
       bool def_val;
     } boolean;
     struct {
-      int64_t *value_ptr;
-      int64_t def_val;
-      int64_t min_val;
-      int64_t max_val;
+      long long *value_ptr;
+      long long def_val;
+      long long min_val;
+      long long max_val;
     } integer;
     struct {
       double *value_ptr;
@@ -147,7 +147,7 @@ struct SysVarDescriptor {
 //
 // Usage:
 //
-//   static int64_t g_threshold = 1000;
+//   static long long g_threshold = 1000;
 //   static bool g_enabled = true;
 //
 //   namespace sv = vsql::preview_sys_var;
@@ -214,7 +214,7 @@ class SysVarCapability
            std::string &out) const {
     if (abi_ == nullptr || abi_->get == nullptr) return true;
     void *val = nullptr;
-    uint64_t val_len = 0;
+    size_t val_len = 0;
     if (abi_->get(extension_name.data(), var_name.data(), &val, &val_len))
       return true;
     out.assign(static_cast<const char *>(val), val_len);
@@ -290,8 +290,8 @@ inline SysVarDescriptor make_bool(const char *name, const char *comment,
 }
 
 inline SysVarDescriptor make_int(const char *name, const char *comment,
-                                 int64_t *value_ptr, int64_t def_val,
-                                 int64_t min_val, int64_t max_val) {
+                                 long long *value_ptr, long long def_val,
+                                 long long min_val, long long max_val) {
   SysVarDescriptor d;
   d.type = INT;
   d.name = name;

--- a/villagesql/sdk/include/villagesql/vsql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_builder.h
@@ -240,7 +240,7 @@ class FuncBuilder {
   }
 
   constexpr FuncBuilder<Func, NumParams, Mode, HasPrerun> &buffer_size(
-      uint64_t s) {
+      size_t s) {
     buffer_size_ = s;
     return *this;
   }
@@ -425,7 +425,7 @@ class FuncBuilder {
   const char *name_;
   const char *return_type_;
   std::array<const char *, NumParams> param_types_;
-  uint64_t buffer_size_;
+  size_t buffer_size_;
   uint64_t max_result_length_;
   vef_prerun_func_t prerun_;
   vef_postrun_func_t postrun_;
@@ -472,7 +472,7 @@ class AggFuncBuilder {
     return next;
   }
 
-  constexpr AggFuncBuilder<State, Func, NumParams> &buffer_size(uint64_t s) {
+  constexpr AggFuncBuilder<State, Func, NumParams> &buffer_size(size_t s) {
     buffer_size_ = s;
     return *this;
   }
@@ -596,7 +596,7 @@ class AggFuncBuilder {
   const char *name_;
   const char *return_type_;
   std::array<const char *, NumParams> param_types_;
-  uint64_t buffer_size_;
+  size_t buffer_size_;
   uint64_t max_result_length_;
   bool deterministic_;
   vef_vdf_clear_func_t clear_;

--- a/villagesql/services/preview/keyring.cc
+++ b/villagesql/services/preview/keyring.cc
@@ -26,8 +26,8 @@ namespace villagesql::services {
 namespace {
 
 vef_keyring_result_t read_keyring(const char *data_id, const char *auth_id,
-                                  unsigned char *buf, uint64_t buf_len,
-                                  uint64_t *out_len) {
+                                  unsigned char *buf, size_t buf_len,
+                                  size_t *out_len) {
   SERVICE_TYPE(registry) *registry = mysql_plugin_registry_acquire();
   if (registry == nullptr) return VEF_KEYRING_ERROR;
 
@@ -62,8 +62,7 @@ vef_keyring_result_t read_keyring(const char *data_id, const char *auth_id,
 }
 
 vef_keyring_result_t write_keyring(const char *data_id, const char *auth_id,
-                                   const unsigned char *data,
-                                   uint64_t data_len) {
+                                   const unsigned char *data, size_t data_len) {
   SERVICE_TYPE(registry) *registry = mysql_plugin_registry_acquire();
   if (registry == nullptr) return VEF_KEYRING_ERROR;
 

--- a/villagesql/services/preview/sql_query.cc
+++ b/villagesql/services/preview/sql_query.cc
@@ -395,7 +395,7 @@ static vef_sql_session_t *sql_open_session(vef_thread_handle_t *handle) {
 static void sql_close_session(vef_sql_session_t *session) { delete session; }
 
 static vef_sql_result_t *sql_execute(vef_sql_session_t *session,
-                                     const char *sql, uint64_t sql_len) {
+                                     const char *sql, size_t sql_len) {
   if (session == nullptr || session->handle == nullptr ||
       session->handle->thd == nullptr)
     return nullptr;
@@ -436,7 +436,7 @@ static vef_sql_result_t *sql_execute(vef_sql_session_t *session,
 }
 
 static vef_sql_result_t *sql_for_each_row(vef_sql_session_t *session,
-                                          const char *sql, uint64_t sql_len,
+                                          const char *sql, size_t sql_len,
                                           vef_sql_row_cb cb, void *ctx) {
   if (session == nullptr || session->handle == nullptr ||
       session->handle->thd == nullptr || cb == nullptr)

--- a/villagesql/services/sys_var_access.cc
+++ b/villagesql/services/sys_var_access.cc
@@ -67,7 +67,7 @@ static void one_var_update_trampoline(MYSQL_THD, SYS_VAR *, void *val_ptr,
 }  // namespace
 
 bool get_variable(const char *component_name, const char *name, void **val,
-                  uint64_t *val_len) {
+                  size_t *val_len) {
   SERVICE_TYPE(registry) *registry = mysql_plugin_registry_acquire();
   if (registry == nullptr) return true;
 

--- a/villagesql/services/sys_var_access.h
+++ b/villagesql/services/sys_var_access.h
@@ -17,7 +17,7 @@
 #ifndef VILLAGESQL_SERVICES_SYS_VAR_ACCESS_H
 #define VILLAGESQL_SERVICES_SYS_VAR_ACCESS_H
 
-#include <cstdint>
+#include <stddef.h>
 #include <string_view>
 
 namespace villagesql::services {
@@ -55,7 +55,7 @@ void unregister_one_sys_var(std::string_view extension_name,
 //
 // Returns false on success, true on error.
 bool get_variable(const char *component_name, const char *name, void **val,
-                  uint64_t *val_len);
+                  size_t *val_len);
 
 // Set the value of a system variable.
 //

--- a/villagesql/test-extensions/update-test-v1/src/extension.cc
+++ b/villagesql/test-extensions/update-test-v1/src/extension.cc
@@ -80,7 +80,7 @@ void counter_double(vsql::CustomArg in, vsql::IntResult out) {
   out.set(static_cast<long long>(val) * 2);
 }
 
-static int64_t g_threshold;
+static long long g_threshold;
 
 // INT sys var in range [0, 1000]. Used by extension_update tests to
 // exercise persisted-value behavior across version updates.

--- a/villagesql/test-extensions/update-test-v2/src/extension.cc
+++ b/villagesql/test-extensions/update-test-v2/src/extension.cc
@@ -84,7 +84,7 @@ void counter_double(vsql::CustomArg in, vsql::IntResult out) {
   out.set(static_cast<long long>(val) * 3);
 }
 
-static int64_t g_threshold;
+static long long g_threshold;
 
 static auto SYS_VARS = sv::make_capability({
     sv::make_int("threshold", "v2 threshold: INT in range [0, 1000]",

--- a/villagesql/test-extensions/vsql-config-vars-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-config-vars-test/src/extension.cc
@@ -39,7 +39,7 @@
 using namespace vsql;
 namespace sv = vsql::preview_sys_var;
 
-static int64_t g_max_items;
+static long long g_max_items;
 static char *g_label;
 
 static auto SYS_VARS = sv::make_capability({

--- a/villagesql/test-extensions/vsql-range-clamp-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-range-clamp-test/src/extension.cc
@@ -48,7 +48,7 @@
 // be used here because on_change is called while MySQL holds the sys_var lock,
 // and calling set() would attempt to re-acquire the same lock and deadlock.
 //
-// Direct writes to the other variable's int64_t global are safe: MySQL reads
+// Direct writes to the other variable's long long global are safe: MySQL reads
 // them under the same lock that protects the write path, so the adjusted value
 // is visible to other sessions on their next read.
 
@@ -58,8 +58,8 @@
 using namespace vsql;
 namespace sv = vsql::preview_sys_var;
 
-static int64_t g_min_setting = 0;
-static int64_t g_max_setting = 100;
+static long long g_min_setting = 0;
+static long long g_max_setting = 100;
 static char *g_label = nullptr;
 static char g_last_label[256] = "";
 

--- a/villagesql/test-extensions/vsql-slow-query-log/src/extension.cc
+++ b/villagesql/test-extensions/vsql-slow-query-log/src/extension.cc
@@ -43,7 +43,7 @@ namespace sv = vsql::preview_sys_var;
 namespace se = vsql::preview_statement_event;
 
 static bool g_enabled;
-static int64_t g_threshold_ms;
+static long long g_threshold_ms;
 static char *g_log_filename;
 
 static std::mutex g_log_mutex;

--- a/villagesql/test-extensions/vsql-sys-var-rollback-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-sys-var-rollback-test/src/extension.cc
@@ -25,7 +25,7 @@
 using namespace vsql;
 namespace sv = vsql::preview_sys_var;
 
-static int64_t g_good_int;
+static long long g_good_int;
 static double g_bad_double;
 
 static auto SYS_VARS = sv::make_capability({

--- a/villagesql/test-extensions/vsql-usage-counter/src/extension.cc
+++ b/villagesql/test-extensions/vsql-usage-counter/src/extension.cc
@@ -42,8 +42,8 @@ namespace sv = vsql::preview_status_var;
 // Counters incremented on every add() call. Concurrent increments from
 // multiple query threads may occasionally be lost (non-atomic ++), which is
 // acceptable for approximate counters exposed via SHOW STATUS.
-static int64_t g_add_calls = 0;
-static int64_t g_null_calls = 0;
+static long long g_add_calls = 0;
+static long long g_null_calls = 0;
 
 static auto STATUS_VARS = sv::make_capability({
     sv::make_int("add_calls", &g_add_calls),


### PR DESCRIPTION
Reverts villagesql/villagesql-server#755

It seems we should investigate this more, perhaps when we tackle Windows.

We need to understand whether this is actually a problem or if this is unnecessary.