### PR TITLE
Nightly build should be debug

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -34,6 +34,7 @@ jobs:
       working-directory: ./source
       run: ./villagesql/bld_tools/build_ci.sh
       env:
+        BUILD_TYPE: debug
         PARALLEL_JOBS: 16
         CMAKE_EXTRA_FLAGS: -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
 


### PR DESCRIPTION
## Description

Changes the nightly build into a debug (vs. release) build.

Part of Cleanup release-dev-server #595 effort.
