### PR TITLE
Add release only tests

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -64,7 +64,15 @@ jobs:
 
     - name: Build VillageSQL
       working-directory: ./source
-      run: ./villagesql/bld_tools/build_ci.sh
+      run: |
+        ./villagesql/bld_tools/build_ci.sh
+
+        # Include the extra tests
+        cd "$BUILD_DIR"
+        make "-j$PARALLEL_JOBS" abi_v1_check-t abi_v2_check-t \
+          custom_indexes-t semver-t type_descriptor-t type_builder-t \
+          type_context-t validate-t victionary_client-t
+
       env:
         PARALLEL_JOBS: 16
         BUILD_TYPE: ${{ inputs.build-type }}


### PR DESCRIPTION
## Description

Expands the regime of full tests to include the often optional "release only" tests.

## Related Issue

Parts of the Cleanup release-dev-server https://github.com/villagesql/villagesql-server/issues/595 effort.
