### PR TITLE
docker: caching_sha2_password hash

### DIFF
--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -44,6 +44,10 @@ Standard MySQL Docker environment variables are supported:
 - `MYSQL_DATABASE` — create a database on first startup
 - `MYSQL_USER` / `MYSQL_PASSWORD` — create a non-root user on first startup
 
+Additionally, VillageSQL adds support for:
+- `MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX` — set the root caching_sha2_password password hash
+  directly (hexadecimal encoded)
+
 At least one of the password options is required.
 
 Wait for the server to be ready:

--- a/docker/server/docker-entrypoint.sh
+++ b/docker/server/docker-entrypoint.sh
@@ -2,6 +2,12 @@
 # Adapted from https://github.com/docker-library/mysql
 # Original: Copyright (c) Docker Community and MySQL Team, licensed under GPL v2
 # See: https://github.com/docker-library/mysql/blob/master/docker-entrypoint.sh
+#
+# We've started to modify this file relative to the upstream file. Notable
+# changes that must be preserved:
+#  - Added MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX environment variable to
+#    provide the ability to set a specific root password hash instead of a
+#    plaintext password.
 set -eo pipefail
 shopt -s nullglob
 
@@ -139,13 +145,14 @@ docker_temp_server_stop() {
 
 # Verify that the minimally required password settings are set for new databases.
 docker_verify_minimum_env() {
-	if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+	if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" -a -z "$MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX" ]; then
 		mysql_error <<-'EOF'
 			Database is uninitialized and password option is not specified
 			    You need to specify one of the following as an environment variable:
 			    - MYSQL_ROOT_PASSWORD
 			    - MYSQL_ALLOW_EMPTY_PASSWORD
 			    - MYSQL_RANDOM_ROOT_PASSWORD
+			    - MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX
 		EOF
 	fi
 
@@ -157,6 +164,20 @@ docker_verify_minimum_env() {
 			    - MYSQL_ROOT_PASSWORD
 			    - MYSQL_ALLOW_EMPTY_PASSWORD
 			    - MYSQL_RANDOM_ROOT_PASSWORD
+			    - MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX
+		EOF
+	fi
+
+	# The shebang is explicitly using bash, so we can use the [[ ]] variant for regexp checking.
+	# the password hashes will have the form `$A$<rounds>$salt$digest$`.
+	# Enforce that the password hash has the correct prefix ($A$ encodes as
+	# 0x244124) and that there are an even number of hex nibbles following
+	# that.
+	if [ -n "$MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX" ] && ! [[ "$MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX" =~ ^244124([0-9a-fA-F][0-9a-fA-F])+$ ]]; then
+		mysql_error <<-'EOF'
+			MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX was specified, but, its value is not fully hexadecimal or lacks the correct prefix.
+			    The value must be a hexadecimal encoded password hash that encodes a mysql caching_sha2_password password hash.
+			    These passwords will generally have the form `$A$<rounds>$salt$digest$` (before hex encoding)
 		EOF
 	fi
 
@@ -236,6 +257,7 @@ docker_setup_env() {
 	file_env 'MYSQL_USER'
 	file_env 'MYSQL_PASSWORD'
 	file_env 'MYSQL_ROOT_PASSWORD'
+	file_env 'MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX'
 
 	declare -g DATABASE_ALREADY_EXISTS
 	if [ -d "$DATADIR/mysql" ]; then
@@ -276,6 +298,19 @@ docker_setup_db() {
 		MYSQL_ROOT_PASSWORD="$(openssl rand -base64 24)"; export MYSQL_ROOT_PASSWORD
 		mysql_note "GENERATED ROOT PASSWORD: $MYSQL_ROOT_PASSWORD"
 	fi
+
+	local identifiedClause=
+	if [ -n "$MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX" ]; then
+		# no, we don't care if read finds a terminating character in this heredoc (see above)
+		read -r -d '' identifiedClause <<-EOSQL || true
+			IDENTIFIED WITH caching_sha2_password AS 0x${MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX}
+		EOSQL
+	else
+		read -r -d '' identifiedClause <<-EOSQL || true
+			IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}'
+		EOSQL
+	fi
+
 	# Sets root password and creates root users for non-localhost hosts
 	local rootCreate=
 	# default root to listen for connections from anywhere
@@ -283,7 +318,7 @@ docker_setup_db() {
 		# no, we don't care if read finds a terminating character in this heredoc
 		# https://unix.stackexchange.com/questions/265149/why-is-set-o-errexit-breaking-this-read-heredoc-expression/265151#265151
 		read -r -d '' rootCreate <<-EOSQL || true
-			CREATE USER 'root'@'${MYSQL_ROOT_HOST}' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+			CREATE USER 'root'@'${MYSQL_ROOT_HOST}' ${identifiedClause?} ;
 			GRANT ALL ON *.* TO 'root'@'${MYSQL_ROOT_HOST}' WITH GRANT OPTION ;
 		EOSQL
 	fi
@@ -291,7 +326,7 @@ docker_setup_db() {
 	local passwordSet=
 	# no, we don't care if read finds a terminating character in this heredoc (see above)
 	read -r -d '' passwordSet <<-EOSQL || true
-		ALTER USER 'root'@'localhost' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+		ALTER USER 'root'@'localhost' ${identifiedClause?} ;
 	EOSQL
 
 	# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is just now being set

--- a/docker/server/docker-entrypoint.sh
+++ b/docker/server/docker-entrypoint.sh
@@ -145,41 +145,53 @@ docker_temp_server_start() {
 
 	# Force the error log to a known file (regardless of any configured
 	# log-error) so we can watch it for readiness; a regular file also means
-	# mysqld never blocks on a full pipe. Launch directly in the background so
-	# $! is mysqld itself, not a pipeline element.
-	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" \
-		--log-error="${MYSQL_TEMP_SERVER_LOG}" &
+	# mysqld never blocks on a full pipe. Disable the X plugin so the only
+	# "ready for connections" line is the main server's. Launch directly in
+	# the background so $! is mysqld itself, not a pipeline element.
+	"$@" --skip-networking --skip-mysqlx --default-time-zone=SYSTEM \
+		--socket="${SOCKET}" --log-error="${MYSQL_TEMP_SERVER_LOG}" &
 	MYSQL_TEMP_SERVER_PID=$!
 
-	# Watcher: grep exits 0 as soon as the server logs that it is ready.
-	# `tail -n +0 -f` streams the whole log from the start then follows it
-	# (event-driven via inotify). We feed tail via a process substitution rather
-	# than a `tail | grep` pipeline on purpose: the background job is then grep
-	# alone, so it completes the instant grep matches. In a pipeline the job would
-	# also include `tail -f`, which does not exit until its next write faults on
-	# the closed pipe — so if the server went quiet right after logging readiness,
-	# the job (and the wait below) would stall. We use -f (not -F): the log should
-	# not be renamed under us, and we would rather fail than follow a rotation.
-	# Match "Version" too so we don't trip on the X Plugin's own
-	# "ready for connections" line.
-	grep -q -m1 'ready for connections\. Version' \
-		< <(tail -n +0 -f "${MYSQL_TEMP_SERVER_LOG}") &
+	# Readiness watcher. We run `tail` and `grep` as two separately-tracked
+	# background jobs joined by a FIFO (rather than a `tail | grep` pipeline or a
+	# process substitution) so that we hold both PIDs and can reap them
+	# explicitly below — otherwise the follower `tail` is left behind as a zombie
+	# once this shell exec()s the real server. `tail -n +0 -f` streams the log
+	# from the start then follows it; `grep -m1` exits the instant the
+	# readiness line appears.
+	# mysqlx is disabled above, so the only "ready for connections" line is the
+	# main server's.
+	local -r fifo="$(mktemp -u)"
+	mkfifo "${fifo}"
+
+	tail -n +0 -f "${MYSQL_TEMP_SERVER_LOG}" > "${fifo}" &
+	local tail_pid=$!
+
+	grep -q -m1 'ready for connections' < "${fifo}" &
 	local watcher_pid=$!
 
-	# Block until whichever comes first: the watcher sees readiness, or mysqld
-	# exits (startup failure). `wait -n` (bash 4.3+) returns as soon as the next
-	# background job finishes, so a crash wakes us immediately with no polling
-	# and no deadline. Guard against set -e since a crashed mysqld exits nonzero.
+	# Both jobs now hold the FIFO open, so drop its direntry immediately.
+	rm -f "${fifo}"
+
+	# Block until whichever comes first:
+	#  - the watcher sees readiness (grep exits),
+	#  - mysqld exits (startup failure).
+	#
+	# `wait -n` returns as soon as the next background job
+	# finishes, so a crash wakes us immediately with no polling and no
+	# deadline (WAL recovery on a large datadir can legitimately take a
+	# long time). tail never exits on its own, so it is never the job that
+	# returns here. Guard set -e since a crashed mysqld exits nonzero.
 	wait -n || true
 
-	if kill -0 "${MYSQL_TEMP_SERVER_PID}" 2>/dev/null; then
-		# Server is up: the watcher must be what returned. Reap it (its tail dies
-		# via SIGPIPE once the running server writes its next log line).
-		wait "${watcher_pid}" 2>/dev/null || true
-	else
+	# Stop and reap both watcher jobs either way (grep may already have exited on
+	# the ready path; tail is still following). This is what keeps tail from
+	# lingering.
+	kill "${tail_pid}" "${watcher_pid}" 2>/dev/null || true
+	wait "${tail_pid}" "${watcher_pid}" 2>/dev/null || true
+
+	if ! kill -0 "${MYSQL_TEMP_SERVER_PID}" 2>/dev/null; then
 		# mysqld exited before becoming ready.
-		kill "${watcher_pid}" 2>/dev/null || true
-		wait "${watcher_pid}" 2>/dev/null || true
 		cat "${MYSQL_TEMP_SERVER_LOG}" >&2
 		mysql_error "Temporary server exited during startup before it became ready."
 	fi

--- a/docker/server/docker-entrypoint.sh
+++ b/docker/server/docker-entrypoint.sh
@@ -127,20 +127,76 @@ mysql_socket_fix() {
 	fi
 }
 
-# Do a temporary startup of the MySQL server, for init purposes
+# PID and error-log file of the temporary init-time server (see
+# docker_temp_server_start / docker_temp_server_stop).
+MYSQL_TEMP_SERVER_PID=
+MYSQL_TEMP_SERVER_LOG=
+
+# Do a temporary startup of the MySQL server, for init purposes.
+#
+# We run it backgrounded rather than with --daemonize so it stays a child
+# process we can stop with a signal and reap with `wait` (see
+# docker_temp_server_stop) instead of polling. Readiness is detected by racing a
+# log watcher against the server process: whichever finishes first tells us
+# whether the server came up or died. There is deliberately no timeout — WAL
+# recovery on a large datadir can legitimately take a long time.
 docker_temp_server_start() {
-	# For 5.7+ the server is ready for use as soon as startup command unblocks
-	if ! "$@" --daemonize --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}"; then
-		mysql_error "Unable to start server."
+	MYSQL_TEMP_SERVER_LOG="$(mktemp)"
+
+	# Force the error log to a known file (regardless of any configured
+	# log-error) so we can watch it for readiness; a regular file also means
+	# mysqld never blocks on a full pipe. Launch directly in the background so
+	# $! is mysqld itself, not a pipeline element.
+	"$@" --skip-networking --default-time-zone=SYSTEM --socket="${SOCKET}" \
+		--log-error="${MYSQL_TEMP_SERVER_LOG}" &
+	MYSQL_TEMP_SERVER_PID=$!
+
+	# Watcher: grep exits 0 as soon as the server logs that it is ready.
+	# `tail -n +0 -f` streams the whole log from the start then follows it
+	# (event-driven via inotify). We feed tail via a process substitution rather
+	# than a `tail | grep` pipeline on purpose: the background job is then grep
+	# alone, so it completes the instant grep matches. In a pipeline the job would
+	# also include `tail -f`, which does not exit until its next write faults on
+	# the closed pipe — so if the server went quiet right after logging readiness,
+	# the job (and the wait below) would stall. We use -f (not -F): the log should
+	# not be renamed under us, and we would rather fail than follow a rotation.
+	# Match "Version" too so we don't trip on the X Plugin's own
+	# "ready for connections" line.
+	grep -q -m1 'ready for connections\. Version' \
+		< <(tail -n +0 -f "${MYSQL_TEMP_SERVER_LOG}") &
+	local watcher_pid=$!
+
+	# Block until whichever comes first: the watcher sees readiness, or mysqld
+	# exits (startup failure). `wait -n` (bash 4.3+) returns as soon as the next
+	# background job finishes, so a crash wakes us immediately with no polling
+	# and no deadline. Guard against set -e since a crashed mysqld exits nonzero.
+	wait -n || true
+
+	if kill -0 "${MYSQL_TEMP_SERVER_PID}" 2>/dev/null; then
+		# Server is up: the watcher must be what returned. Reap it (its tail dies
+		# via SIGPIPE once the running server writes its next log line).
+		wait "${watcher_pid}" 2>/dev/null || true
+	else
+		# mysqld exited before becoming ready.
+		kill "${watcher_pid}" 2>/dev/null || true
+		wait "${watcher_pid}" 2>/dev/null || true
+		cat "${MYSQL_TEMP_SERVER_LOG}" >&2
+		mysql_error "Temporary server exited during startup before it became ready."
 	fi
+
+	# Surface the startup log in `docker logs`.
+	cat "${MYSQL_TEMP_SERVER_LOG}" >&2
 }
 
-# Stop the server. When using a local socket file mysqladmin will block until
-# the shutdown is complete.
+# Stop the temporary server via signal + wait. SIGTERM triggers a clean mysqld
+# shutdown and needs no authentication, so this works even in the hash path
+# where we no longer know root's password. `wait` blocks in waitpid (no poll).
 docker_temp_server_stop() {
-	if ! mysqladmin --defaults-extra-file=<( _mysql_passfile ) shutdown -uroot --socket="${SOCKET}"; then
-		mysql_error "Unable to shut down server."
-	fi
+	kill -TERM "${MYSQL_TEMP_SERVER_PID}"
+	# mysqld traps SIGTERM and exits 0 on a clean shutdown; guard set -e in case
+	# it reports nonzero.
+	wait "${MYSQL_TEMP_SERVER_PID}" || true
+	rm -f "${MYSQL_TEMP_SERVER_LOG}"
 }
 
 # Verify that the minimally required password settings are set for new databases.
@@ -299,6 +355,10 @@ docker_setup_db() {
 		mysql_note "GENERATED ROOT PASSWORD: $MYSQL_ROOT_PASSWORD"
 	fi
 
+	# identifiedClause is the real, intended credential for root: the operator's
+	# caching_sha2_password hash in hash mode, otherwise the plaintext password.
+	# It is applied immediately to the remote root user (rootCreate), which is
+	# never used to authenticate during init.
 	local identifiedClause=
 	if [ -n "$MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX" ]; then
 		# no, we don't care if read finds a terminating character in this heredoc (see above)
@@ -307,6 +367,20 @@ docker_setup_db() {
 		EOSQL
 	else
 		read -r -d '' identifiedClause <<-EOSQL || true
+			IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}'
+		EOSQL
+	fi
+
+	# The rest of init (schema/user creation, initdb.d scripts, and the temporary
+	# server shutdown) authenticates as root@localhost via MYSQL_ROOT_PASSWORD. In
+	# hash mode we don't know the plaintext behind the hash, so give root@localhost
+	# a throwaway random password for the duration of init; the real hash is
+	# applied (via ALTER USER) as the final step before the server is stopped.
+	# In non-hash mode localhost just uses the real credential.
+	local localhostIdentifiedClause="$identifiedClause"
+	if [ -n "$MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX" ]; then
+		MYSQL_ROOT_PASSWORD="$(openssl rand -base64 24)"; export MYSQL_ROOT_PASSWORD
+		read -r -d '' localhostIdentifiedClause <<-EOSQL || true
 			IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}'
 		EOSQL
 	fi
@@ -326,7 +400,7 @@ docker_setup_db() {
 	local passwordSet=
 	# no, we don't care if read finds a terminating character in this heredoc (see above)
 	read -r -d '' passwordSet <<-EOSQL || true
-		ALTER USER 'root'@'localhost' ${identifiedClause?} ;
+		ALTER USER 'root'@'localhost' ${localhostIdentifiedClause?} ;
 	EOSQL
 
 	# tell docker_process_sql to not use MYSQL_ROOT_PASSWORD since it is just now being set
@@ -437,6 +511,16 @@ _main() {
 			docker_process_init_files /docker-entrypoint-initdb.d/*
 
 			mysql_expire_root_user
+
+			if [ -n "$MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX" ]; then
+				# root@localhost still holds the throwaway init password (see
+				# docker_setup_db); set the real hash now. Shutdown below is by
+				# signal, so no password is needed afterward.
+				mysql_note "Setting final root password hash"
+				docker_process_sql --database=mysql <<-EOSQL
+					ALTER USER 'root'@'localhost' IDENTIFIED WITH caching_sha2_password AS 0x${MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX} ;
+				EOSQL
+			fi
 
 			mysql_note "Stopping temporary server"
 			docker_temp_server_stop

--- a/docker/server/test-image.sh
+++ b/docker/server/test-image.sh
@@ -27,14 +27,44 @@ IMAGE="${1:-villagesql/server:latest}"
 CONTAINER="vsql-test-$$"
 PORT=13306
 
+# Extra containers/volumes created by the init-path tests below.
+INIT_CIDS=()
+INIT_VOLS=()
+
 cleanup() {
     echo "==> Cleaning up..."
     docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+    for c in "${INIT_CIDS[@]:-}"; do docker rm -f "$c" >/dev/null 2>&1 || true; done
+    for v in "${INIT_VOLS[@]:-}"; do docker volume rm "$v" >/dev/null 2>&1 || true; done
 }
 trap cleanup EXIT
 
 mysql_cmd() {
     mysql -h 127.0.0.1 -P "$PORT" -u root --skip-column-names -e "$1"
+}
+
+# Start a throwaway init-test container (tracked for cleanup). It talks over its
+# own socket via `docker exec`.
+init_run() {
+    local name=$1; shift
+    INIT_CIDS+=("$name")
+    docker run -d --name "$name" "$@" >/dev/null
+}
+
+# Wait until root (with the given auth args) can run a query. Returns 0 when
+# ready, 2 if the container exited first, 1 on timeout.
+init_wait_ready() {
+    local name=$1 timeout=$2; shift 2
+    local i status
+    for i in $(seq 1 "$timeout"); do
+        status=$(docker inspect -f '{{.State.Status}}' "$name" 2>/dev/null || echo gone)
+        [ "$status" = exited ] && return 2
+        if docker exec "$name" mysql "$@" -N -e 'SELECT 1' >/dev/null 2>&1; then
+            return 0
+        fi
+        sleep 1
+    done
+    return 1
 }
 
 echo "==> Starting container from $IMAGE..."
@@ -88,6 +118,110 @@ echo "==> Uninstalling all extensions..."
 for ext in vsql_uuid vsql_network_address vsql_ai vsql_crypto; do
     mysql_cmd "UNINSTALL EXTENSION $ext;"
 done
+
+# --- First-time initialization regression tests -------------------------
+# Guard the init logic in docker-entrypoint.sh: the caching_sha2_password hash
+# path (including the remote root user), the fail-fast temporary-server
+# lifecycle, and init idempotency on an already-populated datadir.
+
+echo ""
+echo "==> [init] caching_sha2_password hash path..."
+# Generate a real hash from the image, then feed it back in via the hash env.
+GEN="${CONTAINER}-gen"
+init_run "$GEN" -e MYSQL_ROOT_PASSWORD=hashpw "$IMAGE"
+HASHHEX=
+if init_wait_ready "$GEN" 90 -uroot -phashpw; then
+    HASHHEX=$(docker exec "$GEN" mysql -uroot -phashpw -N \
+        -e "SELECT HEX(authentication_string) FROM mysql.user WHERE user='root' AND host='localhost'" 2>/dev/null)
+fi
+docker rm -f "$GEN" >/dev/null 2>&1 || true
+if [ -z "$HASHHEX" ]; then
+    echo "FAIL: could not generate a caching_sha2_password hash from the image"
+    exit 1
+fi
+HASHC="${CONTAINER}-hash"
+init_run "$HASHC" -e MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX="$HASHHEX" "$IMAGE"
+if ! init_wait_ready "$HASHC" 90 -uroot -phashpw; then
+    echo "FAIL: root login with the caching_sha2 hash did not work"
+    docker logs "$HASHC" 2>&1 | tail -20
+    exit 1
+fi
+# The remote root user must carry the same hash (it once got an empty
+# credential in hash mode).
+RHASH=$(docker exec "$HASHC" mysql -uroot -phashpw -N \
+    -e "SELECT HEX(authentication_string) FROM mysql.user WHERE user='root' AND host='%' AND plugin='caching_sha2_password'" 2>/dev/null || true)
+if [ "$RHASH" != "$HASHHEX" ]; then
+    echo "FAIL: root@% not created with the supplied caching_sha2 hash"
+    exit 1
+fi
+# The temp-server log watcher tail process must not outlive init.
+#if docker exec "$HASHC" sh -c 'ps -eo comm 2>/dev/null | grep -qx tail'; then
+if docker exec "$HASHC" sh -c 'pgrep tail > /dev/null'; then
+    echo "FAIL: a 'tail' process lingers after init"
+    exit 1
+fi
+docker rm -f "$HASHC" >/dev/null 2>&1 || true
+echo "    PASS: hash applied to root@localhost and root@%, watcher cleaned up"
+
+echo "==> [init] temporary-server startup failure is fail-fast (no hang)..."
+# Generate a 115-character unix socket filename (which is longer than sun_path
+# (~107)).
+# --initialize doesn't open the socket, so so the datadir bootstraps fine; the
+# temporary server then fails to bind and exits during startup, exercising the
+# wait -n / kill -0 crash-detection branch in docker-entrypoint.sh.
+FAILC="${CONTAINER}-fail"
+LONGSOCK="/var/lib/mysql/$(printf '%03d' $(seq 1 34)).sock"
+init_run "$FAILC" -e MYSQL_ROOT_PASSWORD=x "$IMAGE" mysqld --socket="$LONGSOCK"
+RC=
+for i in $(seq 1 90); do
+    st=$(docker inspect -f '{{.State.Status}}' "$FAILC" 2>/dev/null || echo gone)
+    if [ "$st" = exited ]; then RC=$(docker inspect -f '{{.State.ExitCode}}' "$FAILC"); break; fi
+    sleep 1
+done
+if [ -z "$RC" ]; then
+    echo "FAIL: container hung (did not exit) on temporary-server startup failure"
+    docker logs "$FAILC" 2>&1 | tail -20
+    exit 1
+fi
+if [ "$RC" = 0 ]; then
+    echo "FAIL: expected a non-zero exit on startup failure, got 0"
+    exit 1
+fi
+if ! docker logs "$FAILC" 2>&1 | grep -q 'exited during startup before it became ready'; then
+    echo "FAIL: expected 'exited during startup' message not found in logs"
+    docker logs "$FAILC" 2>&1 | tail -20
+    exit 1
+fi
+docker rm -f "$FAILC" >/dev/null 2>&1 || true
+echo "    PASS: failed fast with exit code $RC"
+
+echo "==> [init] initialization is skipped on an already-populated datadir..."
+IVOL="${CONTAINER}-vol"
+INIT_VOLS+=("$IVOL")
+docker volume create "$IVOL" >/dev/null
+I1="${CONTAINER}-init1"
+init_run "$I1" -v "$IVOL":/var/lib/mysql -e MYSQL_ROOT_PASSWORD=secret1 "$IMAGE"
+if ! init_wait_ready "$I1" 90 -uroot -psecret1; then
+    echo "FAIL: first init run did not become ready"
+    docker logs "$I1" 2>&1 | tail -20
+    exit 1
+fi
+docker rm -f "$I1" >/dev/null 2>&1 || true
+# Second run on the populated volume: init must be skipped, the new
+# MYSQL_ROOT_PASSWORD ignored, and 'secret1' still in effect.
+I2="${CONTAINER}-init2"
+init_run "$I2" -v "$IVOL":/var/lib/mysql -e MYSQL_ROOT_PASSWORD=ignored2 "$IMAGE"
+if ! init_wait_ready "$I2" 90 -uroot -psecret1; then
+    echo "FAIL: original password not preserved on restart (init not skipped?)"
+    docker logs "$I2" 2>&1 | tail -20
+    exit 1
+fi
+if docker logs "$I2" 2>&1 | grep -qi 'Initializing database'; then
+    echo "FAIL: datadir was re-initialized on the second run"
+    exit 1
+fi
+docker rm -f "$I2" >/dev/null 2>&1 || true
+echo "    PASS: existing datadir left intact, new password env ignored"
 
 echo ""
 echo "=== All tests passed ==="


### PR DESCRIPTION
In production deployments, one generally endeavors to avoid storing
plain-text passwords anywhere. The root password is particularly
sensitive, so if it can be calculated as a digest and set without the
plaintext, it's particularly helpful.

To this end, add a `MYSQL_ROOT_PASSWORD_CACHING_SHA2_HASH_HEX`
environment variable and use that to set the root password hash to that
value. It's expected to be hex-encoded, and we validate that it has an
appropriate prefix at startup (if set).

Additionally, convert the bootstrap `mysqld`'s launch to be shell backgrounded
instead of daemonized so we can `kill -TERM` and `wait` on it instead of needing
to keep the root password available.

Disable the `mysqlx` plugin during bootstrapping so the process isn't listening on
any ports while there's no root password and/or we're still doing some setup.
(this was enabled by default in mysql 8.4)