### PR TITLE
innodb: fix MTR mode in rollback_inserted

### DIFF
--- a/mysql-test/suite/villagesql/create_temporary_table/r/create_temporary_table_rollback_big_rec.result
+++ b/mysql-test/suite/villagesql/create_temporary_table/r/create_temporary_table_rollback_big_rec.result
@@ -1,0 +1,52 @@
+use test;
+CREATE TEMPORARY TABLE t1 (
+i INT,
+b MEDIUMBLOB,
+c COMPLEX,
+PRIMARY KEY pk(i),
+INDEX sk(b(100))
+) ENGINE=InnoDB;
+CREATE PROCEDURE populate_t1()
+begin
+declare i int default 1;
+while (i <= 100) do
+insert into t1 values (i, repeat(i,1000), '(1,1)');
+set i = i + 1;
+end while;
+end|
+CREATE PROCEDURE populate_t1_small()
+begin
+declare i int default 1;
+while (i <= 8) do
+insert into t1 values (i, repeat(i,1000), '(1,1)');
+set i = i + 1;
+end while;
+end|
+begin;
+call populate_t1();
+select count(*) from t1;
+count(*)
+100
+delete from t1 where i < 10;
+select count(*) from t1;
+count(*)
+91
+commit;
+set global innodb_purge_stop_now=ON;
+set global innodb_purge_run_now=ON;
+delete from t1 where i < 20;
+select count(*) from t1;
+count(*)
+81
+begin;
+call populate_t1_small();
+select count(*) from t1;
+count(*)
+89
+rollback;
+select count(*) from t1;
+count(*)
+81
+DROP TABLE t1;
+DROP PROCEDURE populate_t1;
+DROP PROCEDURE populate_t1_small;

--- a/mysql-test/suite/villagesql/create_temporary_table/t/create_temporary_table_rollback_big_rec.test
+++ b/mysql-test/suite/villagesql/create_temporary_table/t/create_temporary_table_rollback_big_rec.test
@@ -1,0 +1,73 @@
+# Regression test for a temporary-table ROLLBACK crash in the custom-column
+# undo hook (introduced by PR #195, "InnoDB: Column Storage for Custom Types").
+#
+# When rolling back inserts that reuse delete-marked records in an InnoDB
+# temporary table, row_undo_mod_remove_clust_low() runs the VillageSQL
+# Custom_column::rollback_inserted() hook, which commits and restarts the
+# mini-transaction. The restart must re-establish MTR_LOG_NO_REDO for the
+# temporary table; otherwise the following pessimistic delete extends the
+# system temporary tablespace with redo logging enabled and trips the
+# fsp_space_modify_check() assertion (fsp0fsp.cc), crashing the server.
+#
+# The large (blob) rows are needed to force the pessimistic B-tree path and the
+# tablespace extension that reach the failing code. The COMPLEX column drives
+# the custom-column undo hook. innodb_purge_stop_now keeps the delete-marked
+# records around so the later inserts reuse them (TRX_UNDO_UPD_DEL_REC).
+
+--source include/have_debug.inc
+--source include/villagesql/install_complex_extension.inc
+
+use test;
+
+CREATE TEMPORARY TABLE t1 (
+  i INT,
+  b MEDIUMBLOB,
+  c COMPLEX,
+  PRIMARY KEY pk(i),
+  INDEX sk(b(100))
+) ENGINE=InnoDB;
+
+delimiter |;
+CREATE PROCEDURE populate_t1()
+  begin
+  declare i int default 1;
+  while (i <= 100) do
+    insert into t1 values (i, repeat(i,1000), '(1,1)');
+    set i = i + 1;
+  end while;
+end|
+CREATE PROCEDURE populate_t1_small()
+  begin
+  declare i int default 1;
+  while (i <= 8) do
+    insert into t1 values (i, repeat(i,1000), '(1,1)');
+    set i = i + 1;
+  end while;
+end|
+delimiter ;|
+
+begin;
+call populate_t1();
+select count(*) from t1;
+delete from t1 where i < 10;
+select count(*) from t1;
+commit;
+
+set global innodb_purge_stop_now=ON;
+set global innodb_purge_run_now=ON;
+--source include/wait_innodb_all_purged.inc
+
+delete from t1 where i < 20;
+select count(*) from t1;
+
+begin;
+call populate_t1_small();
+select count(*) from t1;
+rollback;
+select count(*) from t1;
+
+DROP TABLE t1;
+DROP PROCEDURE populate_t1;
+DROP PROCEDURE populate_t1_small;
+
+--source include/villagesql/uninstall_complex_extension.inc

--- a/storage/innobase/row/row0umod.cc
+++ b/storage/innobase/row/row0umod.cc
@@ -238,7 +238,7 @@ check_if_purged:
   // a different function. That would have eliminated the need for reverse
   // movement using goto. However, it would make it future merge with MySQL
   // harder.
-  if (!checked_custom) {
+  if (node->table->has_extended_storage && !checked_custom) {
     node->pcur.commit_specify_mtr(mtr);
     // Remove extended column data, if any.
     using villagesql::innodb::Custom_column;

--- a/storage/innobase/row/row0umod.cc
+++ b/storage/innobase/row/row0umod.cc
@@ -245,6 +245,11 @@ check_if_purged:
     err = Custom_column::rollback_inserted(node->table, node->undo_row,
                                            &node->pcur);
     mtr_start(mtr);
+    // Restarting the mtr resets it to the default redo-logging mode, so the
+    // no-redo mode the caller established for temporary tables must be
+    // re-applied; otherwise modifying the system temporary tablespace below
+    // trips fsp_space_modify_check.
+    dict_disable_redo_if_temporary(node->table, mtr);
     if (err != DB_SUCCESS) return err;
 
     // Ensure one time execution.


### PR DESCRIPTION
## Fix temp-table ROLLBACK crash in custom-column undo hook

### What
`row_undo_mod_remove_clust_low()`'s VillageSQL `Custom_column::rollback_inserted()`
hook commits and restarts the mini-transaction. A fresh `mtr_start()` defaults to
`MTR_LOG_ALL` (redo on), so the `MTR_LOG_NO_REDO` mode the caller set for temp tables
is lost across the restart. Rolling back inserts that reuse delete-marked records in
an InnoDB **temporary** table then runs a pessimistic delete that extends the system
temp tablespace with redo enabled, tripping `fsp_space_modify_check()` →
`ut_ad(!fsp_is_system_temporary(id))` (`fsp0fsp.cc:755`), crashing the server.

**Fix:** re-apply `dict_disable_redo_if_temporary(node->table, mtr)` after the restart,
matching every other `mtr_start()` in the file. No-op for non-temp tables.

### History
Introduced by #195 (*InnoDB: Column Storage for Custom Types*), which added the hook.
The sibling hook in `row0uins.cc` was placed *before* `mtr_start()`, so it kept the
correct pairing; only the `row0umod.cc` site restarts the mtr mid-operation and dropped
the no-redo mode. Not caught earlier because per-PR CI runs only the `village` suite;
the upstream `innodb` test that exposes it runs only in the full/nightly suite.

### Confidence this is the cause / the fix
- **Deterministic repro:** the stock `innodb.dml_operations_temp_table_debug` aborts at
  `ROLLBACK` with this exact assertion, both in CI and locally.
- **Mechanism matches the stack:** crash is `trx_rollback → row_undo_mod →
  btr_cur_pessimistic_delete → fsp_try_extend_data_file_with_pages →
  fsp_space_modify_check`; the assertion fires only when the mtr is `MTR_LOG_ALL` on the
  temp tablespace — exactly the state left by the un-paired `mtr_start()`.
- **TDD red/green:** new regression test (temp table + `COMPLEX` column; big-record
  delete/reinsert/rollback) crashes with the same assertion **without** the fix and
  passes **with** it (verified by rebuilding each way). Lives in
  `villagesql/create_temporary_table`, so `--do-suite=village` runs it on every CI run.

### Debug-only note
The tripwire is a `ut_ad` (debug builds). In release the assertion is compiled out and
the server won't crash, but redo would still be written for the temp tablespace — a
correctness/downgrade-safety issue — so this is a real bug, not just a test artifact.