### PR TITLE
intrinsic defaults for varlen types

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_bitfield_not_null.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_bitfield_not_null.result
@@ -1,0 +1,50 @@
+# Install the variable-length, non-parameterized bit field extension.
+INSTALL EXTENSION vsql_bitfield_test;
+CREATE TABLE bits (
+id INT PRIMARY KEY,
+b vsql_bitfield_test.BITFIELD NOT NULL,
+b_optional vsql_bitfield_test.BITFIELD
+);
+# Providing the NOT NULL column explicitly works.
+INSERT INTO bits (id, b) VALUES (1, '101');
+INSERT INTO bits (id, b, b_optional) VALUES (2, '1111', '00');
+# Omitting the NOT NULL column in strict mode is rejected. DEFAULT values
+# do not apply to custom types, so the error is "no default for field".
+INSERT INTO bits (id, b_optional) VALUES (3, '1');
+ERROR HY000: Field 'b' doesn't have a default value
+# Explicitly storing NULL into the NOT NULL column is rejected.
+INSERT INTO bits (id, b) VALUES (4, NULL);
+ERROR 23000: Column 'b' cannot be null
+# A bad value under INSERT IGNORE falls back to the intrinsic default
+# rather than failing. ('1021' has a non-bit character.) The bad value is
+# replaced by the empty bit field, and the omitted NOT NULL column 'b'
+# also gets the empty default.
+INSERT IGNORE INTO bits (id, b_optional) VALUES (5, '1021');
+Warnings:
+Warning	1366	Incorrect BITFIELD value: '1021' for column 'b_optional' at row 1
+Warning	1364	Field 'b' doesn't have a default value
+# Same fallback for a bad value in the NOT NULL column itself.
+INSERT IGNORE INTO bits (id, b) VALUES (6, '2');
+Warnings:
+Warning	1366	Incorrect BITFIELD value: '2' for column 'b' at row 1
+# The defaulted values are valid, zero-length bit fields (not garbage and
+# not NULL): bitfield_length is 0 and they round-trip to the empty string.
+SELECT id, b, b_optional,
+vsql_bitfield_test.bitfield_length(b) AS nbits,
+b IS NULL AS b_is_null,
+b_optional IS NULL AS opt_is_null
+FROM bits ORDER BY id;
+id	b	b_optional	nbits	b_is_null	opt_is_null
+1	101	NULL	3	0	1
+2	1111	00	4	0	0
+5		NULL	0	0	1
+6		NULL	0	0	1
+# The intrinsic default round-trips: re-encoding an explicit '' matches
+# the defaulted value under the type's compare.
+SELECT id FROM bits WHERE b = '' ORDER BY id;
+id
+5
+6
+# Clean up.
+DROP TABLE bits;
+UNINSTALL EXTENSION vsql_bitfield_test;

--- a/mysql-test/suite/villagesql/extension/r/extension_no_default_type.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_no_default_type.result
@@ -5,4 +5,6 @@ CREATE TABLE t (id INT PRIMARY KEY, val NO_DEFAULT_TYPE NOT NULL);
 ERROR HY000: Type 'vsql_test_only.NO_DEFAULT_TYPE' failed to initialize: from_string VDF failed to encode intrinsic default input '' (expected persisted_length=4)
 CREATE TABLE t (id INT PRIMARY KEY, val NO_DEFAULT_PARAM_TYPE(4) NOT NULL);
 ERROR HY000: Type 'vsql_test_only.NO_DEFAULT_PARAM_TYPE(4)' failed to initialize: from_string VDF failed to encode intrinsic default input '' (expected persisted_length=4)
+CREATE TABLE t (id INT PRIMARY KEY, val NO_DEFAULT_VAR_PARAM_TYPE(4) NOT NULL);
+ERROR HY000: Type 'vsql_test_only.NO_DEFAULT_VAR_PARAM_TYPE(4)' failed to initialize: from_string VDF failed to encode intrinsic default input '' (expected 1..4 bytes)
 UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/r/extension_tarray_create_table.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_tarray_create_table.result
@@ -82,6 +82,22 @@ ERROR 42000: tarray_resolve_params: TARRAY max_size 300 * element size 2 exceeds
 # A non-positive shorthand is rejected by the parser before int_to_params.
 CREATE TABLE bad3 (id INT, v vsql_tarray_test.TARRAY(0));
 ERROR 42000: Invalid length '0' for type 'vsql_tarray_test.TARRAY' near 'vsql_tarray_test.TARRAY(0))' at line 1
+# A variable-length type must be able to encode an intrinsic default.
+# The empty array "[]" encodes to zero bytes (not a usable default), so
+# TARRAY declares intrinsic_default_str('[0]'). A bad value under
+# INSERT IGNORE falls back to that sentinel rather than failing, and a
+# NOT NULL TARRAY column is therefore backed by a valid default value.
+CREATE TABLE arr_def (
+id INT PRIMARY KEY,
+a vsql_tarray_test.TARRAY(4) NOT NULL
+);
+INSERT IGNORE INTO arr_def (id, a) VALUES (1, 'not-an-array');
+Warnings:
+Warning	1366	Incorrect TARRAY value: 'not-an-array' for column 'a' at row 1
+SELECT id, a, vsql_tarray_test.tarray_dim(a) AS na FROM arr_def ORDER BY id;
+id	a	na
+1	[0]	1
+DROP TABLE arr_def;
 # Clean up.
 DROP TABLE arrs;
 UNINSTALL EXTENSION vsql_tarray_test;

--- a/mysql-test/suite/villagesql/extension/t/extension_bitfield_not_null.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_bitfield_not_null.test
@@ -1,0 +1,68 @@
+# End-to-end test for issue #535 follow-up: intrinsic default for a
+# variable-length, non-parameterized custom column.
+#
+# Before this fix, init_intrinsic_default() skipped any type whose
+# persisted_length was <= 0, so variable-length types (persisted_length = -1)
+# never pre-encoded a default. They now encode a default into the field's max
+# capacity and store whatever non-empty result the encoder produces. For
+# BITFIELD, from_string("") yields a valid empty bit field (a 2-byte
+# little-endian bit-count header with count 0), so BITFIELD now has a usable
+# intrinsic default: an empty (zero-bit) value.
+#
+# The intrinsic default is consumed when a bad value is stored under
+# INSERT IGNORE / non-strict mode (mirroring MySQL storing 0/'' for bad values),
+# and as the reset value for a NOT NULL column.
+#
+# Note: this is an integration test confirming the feature works end to end.
+# BITFIELD's decode tolerates a zero-byte value (it reads bit count 0), so the
+# defaulted value renders identically whether stored as 2 bytes or 0 bytes; the
+# byte-level distinction (a valid encoded default vs. an empty buffer) is
+# asserted directly in the type_context-t unit test
+# (TypeContextTest.VariableLengthTypeEncodesIntrinsicDefault).
+
+--echo # Install the variable-length, non-parameterized bit field extension.
+INSTALL EXTENSION vsql_bitfield_test;
+
+CREATE TABLE bits (
+  id INT PRIMARY KEY,
+  b vsql_bitfield_test.BITFIELD NOT NULL,
+  b_optional vsql_bitfield_test.BITFIELD
+);
+
+--echo # Providing the NOT NULL column explicitly works.
+INSERT INTO bits (id, b) VALUES (1, '101');
+INSERT INTO bits (id, b, b_optional) VALUES (2, '1111', '00');
+
+--echo # Omitting the NOT NULL column in strict mode is rejected. DEFAULT values
+--echo # do not apply to custom types, so the error is "no default for field".
+--error ER_NO_DEFAULT_FOR_FIELD
+INSERT INTO bits (id, b_optional) VALUES (3, '1');
+
+--echo # Explicitly storing NULL into the NOT NULL column is rejected.
+--error ER_BAD_NULL_ERROR
+INSERT INTO bits (id, b) VALUES (4, NULL);
+
+--echo # A bad value under INSERT IGNORE falls back to the intrinsic default
+--echo # rather than failing. ('1021' has a non-bit character.) The bad value is
+--echo # replaced by the empty bit field, and the omitted NOT NULL column 'b'
+--echo # also gets the empty default.
+INSERT IGNORE INTO bits (id, b_optional) VALUES (5, '1021');
+
+--echo # Same fallback for a bad value in the NOT NULL column itself.
+INSERT IGNORE INTO bits (id, b) VALUES (6, '2');
+
+--echo # The defaulted values are valid, zero-length bit fields (not garbage and
+--echo # not NULL): bitfield_length is 0 and they round-trip to the empty string.
+SELECT id, b, b_optional,
+       vsql_bitfield_test.bitfield_length(b) AS nbits,
+       b IS NULL AS b_is_null,
+       b_optional IS NULL AS opt_is_null
+FROM bits ORDER BY id;
+
+--echo # The intrinsic default round-trips: re-encoding an explicit '' matches
+--echo # the defaulted value under the type's compare.
+SELECT id FROM bits WHERE b = '' ORDER BY id;
+
+--echo # Clean up.
+DROP TABLE bits;
+UNINSTALL EXTENSION vsql_bitfield_test;

--- a/mysql-test/suite/villagesql/extension/t/extension_no_default_type.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_no_default_type.test
@@ -12,4 +12,10 @@ CREATE TABLE t (id INT PRIMARY KEY, val NO_DEFAULT_TYPE NOT NULL);
 --error ER_VILLAGESQL_GENERIC_ERROR
 CREATE TABLE t (id INT PRIMARY KEY, val NO_DEFAULT_PARAM_TYPE(4) NOT NULL);
 
+# NO_DEFAULT_VAR_PARAM_TYPE is declared .variable_length_type() and its from_string
+# rejects the empty string, so it has no intrinsic default. A type that cannot encode
+# a default is unusable, so any reference fails at initialization.
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE TABLE t (id INT PRIMARY KEY, val NO_DEFAULT_VAR_PARAM_TYPE(4) NOT NULL);
+
 UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/t/extension_tarray_create_table.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_tarray_create_table.test
@@ -87,6 +87,19 @@ CREATE TABLE bad2 (id INT, v vsql_tarray_test.TARRAY(300));
 --error ER_PARSE_ERROR
 CREATE TABLE bad3 (id INT, v vsql_tarray_test.TARRAY(0));
 
+--echo # A variable-length type must be able to encode an intrinsic default.
+--echo # The empty array "[]" encodes to zero bytes (not a usable default), so
+--echo # TARRAY declares intrinsic_default_str('[0]'). A bad value under
+--echo # INSERT IGNORE falls back to that sentinel rather than failing, and a
+--echo # NOT NULL TARRAY column is therefore backed by a valid default value.
+CREATE TABLE arr_def (
+  id INT PRIMARY KEY,
+  a vsql_tarray_test.TARRAY(4) NOT NULL
+);
+INSERT IGNORE INTO arr_def (id, a) VALUES (1, 'not-an-array');
+SELECT id, a, vsql_tarray_test.tarray_dim(a) AS na FROM arr_def ORDER BY id;
+DROP TABLE arr_def;
+
 --echo # Clean up.
 DROP TABLE arrs;
 UNINSTALL EXTENSION vsql_tarray_test;

--- a/unittest/gunit/villagesql/type_context-t.cc
+++ b/unittest/gunit/villagesql/type_context-t.cc
@@ -42,6 +42,26 @@ static int dummy_compare(const unsigned char *, size_t, const unsigned char *,
   return 0;
 }
 
+// Encode that always produces a fixed 2-byte value, regardless of input. Models
+// a variable-length type (e.g. BITFIELD) whose empty default encodes to a small
+// non-empty value (a header). Returns false (success).
+static bool two_byte_encode(unsigned char *out, size_t out_cap, const char *,
+                            size_t, size_t *written) {
+  assert(out_cap >= 2);
+  out[0] = 0xAB;
+  out[1] = 0xCD;
+  *written = 2;
+  return false;
+}
+
+// Encode that produces an empty (zero-byte) value. Models a variable-length
+// type whose empty default is genuinely zero bytes (no usable default).
+static bool empty_encode(unsigned char *, size_t, const char *, size_t,
+                         size_t *written) {
+  *written = 0;
+  return false;
+}
+
 // resolve_params that succeeds and returns computed sizes.
 // Parses "dimension" from the canonical string, computes sizes.
 static void resolve_params_ok_vdf(vef_context_t * /*ctx*/, vef_vdf_args_t *args,
@@ -213,6 +233,11 @@ class TypeContextTest : public ::testing::Test {
       const villagesql::TypeContextKey &key,
       const villagesql::TypeDescriptor *descriptor) {
     return villagesql::TypeContext(key, descriptor);
+  }
+
+  // Invoke the private init_intrinsic_default (TypeContextTest is a friend).
+  static bool init_default(villagesql::TypeContext &ctx, std::string &error) {
+    return ctx.init_intrinsic_default(error);
   }
 };
 
@@ -404,6 +429,101 @@ TEST_F(TypeContextTest, UnknownParametersAreAssignableWithUnknown) {
   EXPECT_TRUE(v_unknown2.is_compatible_with(v_unknown));
   EXPECT_TRUE(v_unknown.is_assignable_with(v_unknown2));
   EXPECT_TRUE(v_unknown2.is_assignable_with(v_unknown));
+}
+
+// A variable-length type (persisted_length = -1, LengthKind::Variable) gets an
+// intrinsic default by encoding into its max capacity and accepting whatever
+// non-empty length the encoder produces.
+TEST_F(TypeContextTest, VariableLengthTypeEncodesIntrinsicDefault) {
+  villagesql::TypeDescriptor desc(
+      villagesql::TypeDescriptorKey("BITFIELD", "test_ext", "1.0.0"),
+      VEF_PROTOCOL_4, 1, /*persisted_len=*/-1, /*max_unpersisted_len=*/256,
+      /*max_persisted_len=*/64, villagesql::LengthKind::Variable,
+      villagesql::EncodeFunction(two_byte_encode),
+      villagesql::DecodeFunction(dummy_decode),
+      villagesql::CompareFunction(dummy_compare));
+  villagesql::TypeContextKey key("BITFIELD", "test_ext", "1.0.0");
+  villagesql::TypeContext ctx = make_context(key, &desc);
+
+  ASSERT_TRUE(ctx.is_variable_length());
+  EXPECT_EQ(ctx.field_buffer_length(), 64);
+
+  std::string error;
+  EXPECT_FALSE(init_default(ctx, error));
+  EXPECT_TRUE(error.empty());
+  ASSERT_NE(ctx.intrinsic_default_buffer(), nullptr);
+  EXPECT_EQ(ctx.intrinsic_default_size(), 2u);
+  EXPECT_EQ(ctx.intrinsic_default_buffer()[0], 0xAB);
+  EXPECT_EQ(ctx.intrinsic_default_buffer()[1], 0xCD);
+}
+
+// A variable-length type whose encode produces zero bytes has no usable
+// default. Like a fixed-length type with no default (NO_DEFAULT_TYPE), this is
+// fatal: init reports an error and stores no buffer. Such a type must supply a
+// non-empty intrinsic_default_str/fn to be usable.
+
+// TODO(villagesql-beta): try to validate on install whether encode("") produces
+// valid default - in case no intrinsic_default_str/fn is provided. Or even
+// check if encode(instrinsic_default_str) produces a valid default.
+TEST_F(TypeContextTest, VariableLengthEmptyEncodeIsFatal) {
+  villagesql::TypeDescriptor desc(
+      villagesql::TypeDescriptorKey("EMPTYVAR", "test_ext", "1.0.0"),
+      VEF_PROTOCOL_4, 1, /*persisted_len=*/-1, /*max_unpersisted_len=*/256,
+      /*max_persisted_len=*/64, villagesql::LengthKind::Variable,
+      villagesql::EncodeFunction(empty_encode),
+      villagesql::DecodeFunction(dummy_decode),
+      villagesql::CompareFunction(dummy_compare));
+  villagesql::TypeContextKey key("EMPTYVAR", "test_ext", "1.0.0");
+  villagesql::TypeContext ctx = make_context(key, &desc);
+
+  std::string error;
+  EXPECT_TRUE(init_default(ctx, error));
+  EXPECT_FALSE(error.empty());
+  EXPECT_EQ(ctx.intrinsic_default_buffer(), nullptr);
+}
+
+// A fixed-length type encodes its default to exactly persisted_length bytes.
+TEST_F(TypeContextTest, FixedLengthTypeEncodesIntrinsicDefault) {
+  villagesql::TypeDescriptor desc(
+      villagesql::TypeDescriptorKey("PAIR", "test_ext", "1.0.0"),
+      VEF_PROTOCOL_3, 1, /*persisted_len=*/2, /*max_unpersisted_len=*/256,
+      /*max_persisted_len=*/0, villagesql::LengthKind::Fixed,
+      villagesql::EncodeFunction(two_byte_encode),
+      villagesql::DecodeFunction(dummy_decode),
+      villagesql::CompareFunction(dummy_compare));
+  villagesql::TypeContextKey key("PAIR", "test_ext", "1.0.0");
+  villagesql::TypeContext ctx = make_context(key, &desc);
+
+  std::string error;
+  EXPECT_FALSE(init_default(ctx, error));
+  EXPECT_TRUE(error.empty());
+  ASSERT_NE(ctx.intrinsic_default_buffer(), nullptr);
+  EXPECT_EQ(ctx.intrinsic_default_size(), 2u);
+}
+
+// A parameterized variable-length type declared without parameters (is_unknown)
+// cannot encode a default yet and is skipped (non-fatal, no buffer).
+TEST_F(TypeContextTest, UnknownParameterizedTypeSkipsIntrinsicDefault) {
+  static auto rp_ok_fd =
+      make_resolve_params_fd("rp_ok_default", &resolve_params_ok_vdf);
+
+  villagesql::TypeDescriptor desc(
+      villagesql::TypeDescriptorKey("VARVECTOR", "test_ext", "1.0.0"),
+      VEF_PROTOCOL_4, 1, /*persisted_len=*/-1, /*max_unpersisted_len=*/256,
+      /*max_persisted_len=*/64, villagesql::LengthKind::Variable,
+      villagesql::EncodeFunction(two_byte_encode),
+      villagesql::DecodeFunction(dummy_decode),
+      villagesql::CompareFunction(dummy_compare), std::nullopt, std::nullopt,
+      villagesql::ResolveParamsFunction(&rp_ok_fd));
+  // No parameters: this is an "unknown" parameterized type.
+  villagesql::TypeContextKey key("VARVECTOR", "test_ext", "1.0.0");
+  villagesql::TypeContext ctx = make_context(key, &desc);
+  ASSERT_TRUE(ctx.is_unknown());
+
+  std::string error;
+  EXPECT_FALSE(init_default(ctx, error));
+  EXPECT_TRUE(error.empty());
+  EXPECT_EQ(ctx.intrinsic_default_buffer(), nullptr);
 }
 
 }  // namespace villagesql_unittest

--- a/villagesql/schema/descriptor/type_context.cc
+++ b/villagesql/schema/descriptor/type_context.cc
@@ -59,23 +59,47 @@ bool TypeContext::init_intrinsic_default(std::string &error_out) {
   if (descriptor_->protocol() < VEF_PROTOCOL_3) return false;
 
   // Pre-encode the intrinsic default value. Returns false (success) when a
-  // default is stored. Returns true (failure) when no source produces a valid
-  // default. Variable-length types with no resolved size skip this entirely.
+  // default is stored or when none is needed. Returns true (failure) when the
+  // type cannot produce its required default; this is fatal for both
+  // fixed-length and variable-length types.
   //
   // Sources tried in order:
   // 1. intrinsic_default_fn VDF: returns a string, which the server converts.
   // 2. intrinsic_default_str: encode the extension-supplied string literal.
   // 3. encode(""): encode the empty string.
   //
-  // Variable-length types with no resolved parameters have persisted_length_ <=
-  // 0, meaning no fixed storage size is known. Skip pre-encoding a default:
-  // there is no buffer size to target, and such types require parameters before
-  // use.
-  if (persisted_length_ <= 0) return false;
+  // Parameterized types declared without parameters (is_unknown) cannot encode
+  // a default yet: both the storage size and the encode behavior depend on the
+  // parameters supplied at column-definition time. Skip them.
+  if (is_unknown()) return false;
 
-  const size_t storage_size = static_cast<size_t>(persisted_length_);
+  // Buffer capacity to encode the default into. Fixed-length and
+  // parameter-resolved types have an exact persisted_length and must encode to
+  // exactly that many bytes. Variable-length types have no fixed size: encode
+  // into the field's max capacity (max_persisted_length) and accept whatever
+  // non-empty length the encoder produces (e.g. an empty bitmap/array).
+  const bool variable_length = is_variable_length();
+  const int64_t capacity =
+      variable_length ? field_buffer_length() : persisted_length_;
+
+  // No known storage size (e.g. a fixed-length type whose parameter resolution
+  // failed). Nothing to encode a default against.
+  if (capacity <= 0) return false;
+
+  const size_t storage_size = static_cast<size_t>(capacity);
   std::vector<unsigned char> buffer(storage_size);
   size_t encoded_length = 0;
+
+  // A fixed-length encode must produce exactly storage_size bytes. A
+  // variable-length encode may produce anything in 1..storage_size.
+  const auto length_ok = [&](size_t len) {
+    return variable_length ? (len > 0 && len <= storage_size)
+                           : (len == storage_size);
+  };
+  const std::string size_expectation =
+      variable_length
+          ? "expected 1.." + std::to_string(storage_size) + " bytes"
+          : "expected persisted_length=" + std::to_string(storage_size);
 
   // Sources 1, 2, and 3 all produce a string that is then converted.
   // Source 1 calls the intrinsic_default VDF to get the string.
@@ -114,38 +138,36 @@ bool TypeContext::init_intrinsic_default(std::string &error_out) {
     auto r =
         vdf_call.invoke(StringSlice(input_str.c_str(), input_str.size()),
                         pointer_cast<uchar *>(buffer.data()), storage_size);
-    if (r && *r == storage_size) {
+    if (r && length_ok(*r)) {
+      buffer.resize(*r);
       intrinsic_default_buffer_ = std::move(buffer);
       intrinsic_default_size_ = *r;
       return false;
     }
     if (!r) {
       error_out = "from_string VDF failed to encode intrinsic default input '" +
-                  input_str + "' (expected persisted_length=" +
-                  std::to_string(storage_size) + ")";
+                  input_str + "' (" + size_expectation + ")";
     } else {
-      error_out =
-          "from_string VDF encoded intrinsic default input '" + input_str +
-          "' to " + std::to_string(*r) +
-          " bytes, expected persisted_length=" + std::to_string(storage_size);
+      error_out = "from_string VDF encoded intrinsic default input '" +
+                  input_str + "' to " + std::to_string(*r) + " bytes, " +
+                  size_expectation;
     }
   } else if (op.fn() != nullptr) {
     bool fn_failed = op.fn()(buffer.data(), storage_size, input_str.c_str(),
                              input_str.size(), &encoded_length);
-    if (!fn_failed && encoded_length == storage_size) {
+    if (!fn_failed && length_ok(encoded_length)) {
+      buffer.resize(encoded_length);
       intrinsic_default_buffer_ = std::move(buffer);
       intrinsic_default_size_ = encoded_length;
       return false;
     }
     if (fn_failed) {
-      error_out =
-          "encode function failed for intrinsic default input '" + input_str +
-          "' (expected persisted_length=" + std::to_string(storage_size) + ")";
+      error_out = "encode function failed for intrinsic default input '" +
+                  input_str + "' (" + size_expectation + ")";
     } else {
-      error_out =
-          "encode function encoded intrinsic default input '" + input_str +
-          "' to " + std::to_string(encoded_length) +
-          " bytes, expected persisted_length=" + std::to_string(storage_size);
+      error_out = "encode function encoded intrinsic default input '" +
+                  input_str + "' to " + std::to_string(encoded_length) +
+                  " bytes, " + size_expectation;
     }
   } else {
     error_out =

--- a/villagesql/schema/descriptor/type_context.h
+++ b/villagesql/schema/descriptor/type_context.h
@@ -343,9 +343,7 @@ class TypeContext {
   // Pre-encode the intrinsic default value. Called once by
   // TableTraits<TypeContext>::create() after construction. Returns true on
   // failure. Sources tried in order: (1) intrinsic_default_fn,
-  // (2) intrinsic_default_str, (3) encode(""). Skipped for variable-length
-  // types where persisted_length_ <= 0 (no storage size known yet — these
-  // types require parameters before use).
+  // (2) intrinsic_default_str, (3) encode("").
   bool init_intrinsic_default(std::string &error_out);
 
   void resolve_cached_values();

--- a/villagesql/test-extensions/vsql-tarray-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-tarray-test/src/extension.cc
@@ -461,6 +461,7 @@ constexpr auto TARRAY =
         .from_string<&tarray_from_string>()
         .to_string<&tarray_to_string>()
         .compare<&tarray_compare>()
+        .intrinsic_default_str("[0]")
         .build();
 
 using namespace vsql;

--- a/villagesql/test-extensions/vsql-test-only/src/extension.cc
+++ b/villagesql/test-extensions/vsql-test-only/src/extension.cc
@@ -59,6 +59,12 @@
 //              - Parameterized version of NO_DEFAULT_TYPE for exercising
 //                parameterized intrinsic-default failures.
 //
+//   NO_DEFAULT_VAR_PARAM_TYPE(N)
+//              - Variable-length version of NO_DEFAULT_PARAM_TYPE (declared
+//                .variable_length_type()). Same from_string that rejects the
+//                empty string, so it has no intrinsic default; exercises the
+//                fatal no-default path through the variable-length branch.
+//
 //   LARGE_DECODE_TYPE(N)
 //              - Parameterized 8-byte type whose decoded string is N 'X'
 //                characters.  Used to exercise the server's result-buffer
@@ -235,6 +241,27 @@ void no_default_param_encode(vsql::MaybeParams<NoDefaultParams> &params,
   no_default_encode(from, out);
 }
 
+// resolve_params for the variable-length no-default type.
+bool no_default_var_resolve_params(
+    const std::map<std::string, std::string> &params,
+    vsql::ResolvedTypeParams *result, char *error_msg) {
+  auto it = params.find("length");
+  if (it == params.end()) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "NO_DEFAULT_VAR_PARAM_TYPE length is required");
+    return true;
+  }
+  int64_t length = std::stoll(it->second);
+  if (length <= 0) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "NO_DEFAULT_VAR_PARAM_TYPE length must be positive");
+    return true;
+  }
+  assert(result->persisted_length <= 0);
+  result->max_decode_buffer_length = 16;
+  return false;
+}
+
 void no_default_param_decode(vsql::CustomArgWith<NoDefaultParams> in,
                              vsql::StringResult out) {
   auto buffer = in.value();
@@ -369,6 +396,8 @@ static void test_result_kind(vsql::StringArg input, vsql::IntResult out) {
 static constexpr const char kFaultBlobTypeName[] = "FAULT_BLOB";
 static constexpr const char kNoDefaultTypeName[] = "NO_DEFAULT_TYPE";
 static constexpr const char kNoDefaultParamTypeName[] = "NO_DEFAULT_PARAM_TYPE";
+static constexpr const char kNoDefaultVarParamTypeName[] =
+    "NO_DEFAULT_VAR_PARAM_TYPE";
 static constexpr const char kLargeDecodeTypeName[] = "LARGE_DECODE_TYPE";
 
 constexpr auto FAULT_BLOB = vsql::make_type<kFaultBlobTypeName>()
@@ -396,6 +425,26 @@ constexpr auto NO_DEFAULT_PARAM_TYPE =
                 &NoDefaultParams::to_strings>()
         .int_to_params<&no_default_int_to_params>()
         .resolve_params<&no_default_resolve_params>()
+        .from_string<&no_default_param_encode>()
+        .to_string<&no_default_param_decode>()
+        .compare<&no_default_param_compare>()
+        .build();
+
+// A variable-length version of NO_DEFAULT_PARAM_TYPE: same parameterized
+// int_to_params/from_string (from_string only accepts "(N)" and rejects the
+// empty string), but declared .variable_length_type() so it is classified as
+// variable-length. Exercises the fatal "no intrinsic default" path through the
+// variable-length branch of TypeContext::init_intrinsic_default (a variable
+// type that cannot encode a default is unusable, same as a fixed-length type).
+constexpr auto NO_DEFAULT_VAR_PARAM_TYPE =
+    vsql::make_type<kNoDefaultVarParamTypeName>()
+        .variable_length_type()
+        .max_decode_buffer_length(16)
+        .max_persisted_length(kNoDefaultSize)
+        .params<NoDefaultParams, &NoDefaultParams::parse,
+                &NoDefaultParams::to_strings>()
+        .int_to_params<&no_default_int_to_params>()
+        .resolve_params<&no_default_var_resolve_params>()
         .from_string<&no_default_param_encode>()
         .to_string<&no_default_param_decode>()
         .compare<&no_default_param_compare>()
@@ -645,6 +694,7 @@ VEF_GENERATE_ENTRY_POINTS(
         .type(FAULT_BLOB)
         .type(NO_DEFAULT_TYPE)
         .type(NO_DEFAULT_PARAM_TYPE)
+        .type(NO_DEFAULT_VAR_PARAM_TYPE)
         .type(LARGE_DECODE_TYPE)
         .type(PVEC)
         // Test VDF: exercises VEF_RESULT_WARNING vs VEF_RESULT_ERROR

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -1125,7 +1125,12 @@ type_conversion_status StoreCustomFieldIntrinsicDefault(Field *field) {
     return TYPE_ERR_BAD_VALUE;
   }
   const size_t cached_size = tc.intrinsic_default_size();
-  assert(cached_size == static_cast<size_t>(tc.persisted_length()));
+  // Fixed-length types store exactly persisted_length bytes; variable-length
+  // types store any non-empty value up to the field's max capacity.
+  assert(tc.is_variable_length()
+             ? cached_size > 0 &&
+                   cached_size <= static_cast<size_t>(tc.field_buffer_length())
+             : cached_size == static_cast<size_t>(tc.persisted_length()));
 
   field->set_notnull();
   return field->store(reinterpret_cast<const char *>(cached_buffer),


### PR DESCRIPTION
TypeContext::init_intrinsic_default previously returned early for any type with persisted_length <= 0, so variable-length custom types (persisted_length == -1) never pre-encoded an intrinsic default. A NOT NULL variable-length column therefore had no valid default and was reset to a raw zero-byte value by Field_varstring::reset().

Closes #793 