### PR TITLE
Disable push activation for 0.0.5

### DIFF
--- a/.github/workflows/release-dev-server.yml
+++ b/.github/workflows/release-dev-server.yml
@@ -23,9 +23,6 @@ name: Release Dev Server
 #   - builds: sandboxes for extension builds
 
 on:
-  push:
-    tags:
-      - '[0-9]*.[0-9]*.[0-9]*'
   workflow_dispatch:
     inputs:
       tag:


### PR DESCRIPTION
## Description

Remove the push trigger for this workflow.  In the 0.0.5 release, this will be activated manually.

As we rework and stabilize the release process, I expect this to return is some form before long.

## Related Issue

Part of the Cleanup release-dev-server #595 effort.