### PR TITLE
relnotes: What's New; drop reverted ABI

### DIFF
--- a/Docs/release_notes/release_note_0_0_5.md
+++ b/Docs/release_notes/release_note_0_0_5.md
@@ -2,7 +2,7 @@
 
 Draft release notes — the release commit will be recorded when 0.0.5 is tagged.
 
-## Highlights
+## What's New
 
 ### Custom Types
 
@@ -25,7 +25,6 @@ Draft release notes — the release commit will be recorded when 0.0.5 is tagged
 ### Build & Compatibility
 
 - **MySQL 8.4.10** — Merged upstream `mysql-8.4.10`, which includes two upstream security fixes: an unauthenticated repeated X Protocol TLS upgrade crash (Bug#39204635) and an out-of-bounds read (Bug#39116965). (`2acd413be74`; `874935c05dd`; `6adc159923b`; `413d194f649`)
-- **Fixed-width ABI** — Standardized the extension ABI on fixed-width integer types (`uint32_t`, `int64_t`). (`ba56076ba7d`, #755)
 
 ## Community
 


### PR DESCRIPTION
## Description
Rename the 0.0.5 section header to "What's New" (cover what shipped for users, not a curated subset). Drop the "Fixed-width ABI" entry: #755 was reverted by #773 in the same range, so it did not ship.

AI=CLAUDE

## Related Issue
#769 

## How was this tested?
n/a

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
