### PR TITLE
testfix: fix opt build failure

### DIFF
--- a/unittest/gunit/villagesql/type_context-t.cc
+++ b/unittest/gunit/villagesql/type_context-t.cc
@@ -47,7 +47,10 @@ static int dummy_compare(const unsigned char *, size_t, const unsigned char *,
 // non-empty value (a header). Returns false (success).
 static bool two_byte_encode(unsigned char *out, size_t out_cap, const char *,
                             size_t, size_t *written) {
-  assert(out_cap >= 2);
+  if (out_cap < 2) {
+    ADD_FAILURE() << "out_cap too small: " << out_cap;
+    return true;  // false == success, so true == failure
+  }
   out[0] = 0xAB;
   out[1] = 0xCD;
   *written = 2;


### PR DESCRIPTION
Replace assert with error in debug and opt mode.

## Description

Fix build break in opt mode

## Related Issue

N/A

## How was this tested?

built in opt mode

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
