### PR TITLE
New .result for extension-update var

### DIFF
--- a/mysql-test/r/information_schema_ci.result
+++ b/mysql-test/r/information_schema_ci.result
@@ -804,6 +804,10 @@ information_schema	COLUMNS	COLUMN_TYPE
 information_schema	COLUMNS	DATA_TYPE
 information_schema	COLUMNS	GENERATION_EXPRESSION
 information_schema	EVENTS	EVENT_DEFINITION
+information_schema	EXTENSIONS	PENDING_LAST_ERROR
+information_schema	EXTENSIONS	PENDING_LAST_ERROR_AT
+information_schema	EXTENSIONS	PENDING_REQUESTED_AT
+information_schema	EXTENSIONS	PENDING_VERSION
 information_schema	PARAMETERS	DATA_TYPE
 information_schema	ROUTINES	DATA_TYPE
 information_schema	ROUTINES	DTD_IDENTIFIER
@@ -1355,6 +1359,7 @@ COLUMN_STATISTICS	information_schema.COLUMN_STATISTICS	1
 ENABLED_ROLES	information_schema.ENABLED_ROLES	1
 ENGINES	information_schema.ENGINES	1
 EVENTS	information_schema.EVENTS	1
+EXTENSIONS	information_schema.EXTENSIONS	1
 EXTENSION_REGISTRATION	information_schema.EXTENSION_REGISTRATION	1
 FILES	information_schema.FILES	1
 KEY_COLUMN_USAGE	information_schema.KEY_COLUMN_USAGE	1

--- a/mysql-test/r/mysqld--help-notwin.result
+++ b/mysql-test/r/mysqld--help-notwin.result
@@ -1599,6 +1599,11 @@ The following options may be given as the first argument:
  build (one whose VillageSQL version has a pre-release
  suffix, e.g. '-dev'). Upgrading from a dev build is
  disallowed by default.
+ --villagesql-skip-extension-updates 
+ At startup, skip processing of pending ALTER EXTENSION
+ ... AT RESTART actions. Extensions load at their
+ currently-installed version; pending_action rows remain
+ intact.
  --vsql-allow-preview-extensions 
  Allow loading extensions that use preview capabilities.
  Preview capabilities are unstable and may change or be
@@ -2036,6 +2041,7 @@ validate-config FALSE
 validate-user-plugins TRUE
 verbose TRUE
 villagesql-allow-unsafe-dev-upgrade FALSE
+villagesql-skip-extension-updates FALSE
 vsql-allow-preview-extensions FALSE
 wait-timeout 28800
 windowing-use-high-precision TRUE


### PR DESCRIPTION
## Description

Regenerate two standard-suite result files that lagged the VillageSQL extension-update feature (pending ALTER EXTENSION ... AT RESTART). Both were deterministic failures caused solely by stale expected output; the server output is correct.

- mysqld--help-notwin: add the --villagesql-skip-extension-updates sysvar (help text + default row).
- information_schema_ci: add the information_schema.EXTENSIONS columns PENDING_LAST_ERROR, PENDING_LAST_ERROR_AT, PENDING_REQUESTED_AT, PENDING_VERSION, and the EXTENSIONS table-count row.

Both pass on a clean re-run (macOS arm64, RelWithDebInfo, 7acd7c56ff9)

## Related Issue

Releasing 0.0.5