### PR TITLE
CI: Upload per-worker mysqld error logs

### DIFF
--- a/.github/actions/run-tests/action.yml
+++ b/.github/actions/run-tests/action.yml
@@ -106,6 +106,7 @@ runs:
         path: |
           ${{ env.BUILD_DIR }}/mysql-test-report.xml
           ${{ env.BUILD_DIR }}/mysql-test/var/log/
+          ${{ env.BUILD_DIR }}/mysql-test/var/*/log/
           ${{ env.BUILD_DIR }}/mysql-test/var/ctest.log
           ${{ env.BUILD_DIR }}/Testing/Temporary/LastTest.log
           ${{ env.BUILD_DIR }}/CMakeCache.txt

--- a/mysql-test/suite/villagesql/extension/vsql-index-test/t/create_index.test
+++ b/mysql-test/suite/villagesql/extension/vsql-index-test/t/create_index.test
@@ -12,8 +12,6 @@
 #   - (col profile)                         -- unqualified per-column index profile
 #   - (col extension.profile)               -- qualified per-column index profile
 
---echo "Induce failure to test CI packaging"
-
 SET PERSIST vsql_allow_preview_extensions = ON;
 INSTALL EXTENSION vsql_index_test;
 

--- a/mysql-test/suite/villagesql/extension/vsql-index-test/t/create_index.test
+++ b/mysql-test/suite/villagesql/extension/vsql-index-test/t/create_index.test
@@ -12,6 +12,8 @@
 #   - (col profile)                         -- unqualified per-column index profile
 #   - (col extension.profile)               -- qualified per-column index profile
 
+--echo "Induce failure to test CI packaging"
+
 SET PERSIST vsql_allow_preview_extensions = ON;
 INSTALL EXTENSION vsql_index_test;
 


### PR DESCRIPTION
Each parallel MTR worker writes mysqld.N.err into its own private vardir (var/<worker_id>/log/), not the shared var/log/ directory. On failure, only the datadir gets moved into var/log/<test>/, so the error log was silently excluded from every test-logs artifact.

Add var/*/log/ to the upload path so these logs are captured too.