### PR TITLE
Refine tarball file name (#803)

### DIFF
--- a/.github/workflows/build-server-branch.yml
+++ b/.github/workflows/build-server-branch.yml
@@ -86,6 +86,12 @@ jobs:
       OUTPUT_DIR: ${{ github.workspace }}/output
       EXTS_ROOT: ${{ github.workspace }}/exts
       BUILD_BUNDLED_EXTENSIONS: "1"
+      # SPOOKY ACTION AT A DISTANCE: Resolve the release/-dev decision once, at
+      # job scope, so every step sees the same value. Scripts that re-derive the
+      # version from VSQL_VERSION (get_sdk.sh, package_dev_server.sh) key off
+      # this env var; leave it unset and they fall back to VSQL_VERSION file's
+      # 'dev' suffix regardless of release_build.
+      VSQL_PRE_RELEASE_VERSION: ${{ !inputs.release_build && 'dev' || '' }}
 
     steps:
       - name: Checkout
@@ -120,14 +126,9 @@ jobs:
 
       - name: Build the dev server
         run: |
-          if [[ "${{ inputs.release_build }}" == "true" ]]; then
-            PRE_RELEASE=""
-          else
-            PRE_RELEASE="dev"
-          fi
-          echo "pre_release_version: '${PRE_RELEASE}'"
+          echo "pre_release_version: '${VSQL_PRE_RELEASE_VERSION}'"
 
-          EXTRA_FLAGS="-DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost -DVSQL_PRE_RELEASE_VERSION=${PRE_RELEASE}"
+          EXTRA_FLAGS="-DDOWNLOAD_BOOST=1 -DWITH_BOOST=/tmp/boost -DVSQL_PRE_RELEASE_VERSION=${VSQL_PRE_RELEASE_VERSION}"
           if [ "${{ inputs.os }}" = "macos" ]; then
             EXTRA_FLAGS="$EXTRA_FLAGS -DWITH_SSL=$(brew --prefix openssl)"
           fi
@@ -135,7 +136,6 @@ jobs:
           SOURCE_DIR="$SOURCE_DIR" \
           BUILD_DIR="$BUILD_DIR" \
           CMAKE_EXTRA_FLAGS="$EXTRA_FLAGS" \
-          VSQL_PRE_RELEASE_VERSION="${PRE_RELEASE}" \
             source/villagesql/bld_tools/build_ci.sh
 
       - name: Build bundled extensions

--- a/mysql-test/include/villagesql/create_extension_sdk.inc
+++ b/mysql-test/include/villagesql/create_extension_sdk.inc
@@ -42,8 +42,11 @@ if (!$extension_version)
 # Get paths
 --let $build_dir = `SELECT @@basedir`
 --let $veb_dir = `SELECT @@veb_dir`
---let $sdk_version = `SELECT @@villagesql_server_version`
---let $sdk_dir = $build_dir/villagesql-extension-sdk-$sdk_version
+# @@villagesql_server_version includes the code base as a prefix, separated
+# from the abbreviated version by an underscore (e.g. "mysql-8.4_0.0.5").
+# The SDK directory name uses the abbreviated version.
+--let $sdk_abbr = `SELECT SUBSTRING_INDEX(@@villagesql_server_version, '_', -1)`
+--let $sdk_dir = $build_dir/villagesql-extension-sdk-$sdk_abbr
 --let $ext_build_dir = $MYSQLTEST_VARDIR/tmp/ext_build_$extension_name
 
 # Verify SDK exists

--- a/mysql-test/include/villagesql/create_extension_sdk_expect_build_failure.inc
+++ b/mysql-test/include/villagesql/create_extension_sdk_expect_build_failure.inc
@@ -28,8 +28,11 @@ if (!$extension_version)
 }
 
 --let $build_dir = `SELECT @@basedir`
---let $sdk_version = `SELECT @@villagesql_server_version`
---let $sdk_dir = $build_dir/villagesql-extension-sdk-$sdk_version
+# @@villagesql_server_version includes the code base as a prefix, separated
+# from the abbreviated version by an underscore (e.g. "mysql-8.4_0.0.5").
+# The SDK directory name uses the abbreviated version.
+--let $sdk_abbr = `SELECT SUBSTRING_INDEX(@@villagesql_server_version, '_', -1)`
+--let $sdk_dir = $build_dir/villagesql-extension-sdk-$sdk_abbr
 --let $ext_build_dir = $MYSQLTEST_VARDIR/tmp/ext_build_$extension_name
 
 --exec test -d "$sdk_dir" || (echo "ERROR: SDK not found at $sdk_dir. Run 'make sdk' first." && exit 1)

--- a/mysql-test/suite/villagesql/sdk/t/build_template.test
+++ b/mysql-test/suite/villagesql/sdk/t/build_template.test
@@ -14,9 +14,12 @@
 # Get paths - use @@basedir which points to the build directory where mysqld runs
 --let $veb_dir = `SELECT @@veb_dir`
 --let $build_dir = `SELECT @@basedir`
---let $sdk_version = `SELECT @@villagesql_server_version`
+# @@villagesql_server_version includes the code base as a prefix, separated
+# from the abbreviated version by an underscore (e.g. "mysql-8.4_0.0.5").
+# The SDK directory name uses the abbreviated version.
+--let $sdk_abbr = `SELECT SUBSTRING_INDEX(@@villagesql_server_version, '_', -1)`
 --let $test_dir = $MYSQLTEST_VARDIR/tmp/sdk_test
---let $sdk_dir_name = villagesql-extension-sdk-$sdk_version
+--let $sdk_dir_name = villagesql-extension-sdk-$sdk_abbr
 --let $sdk_tarball = $build_dir/$sdk_dir_name.tar.gz
 --let $sdk_dir = $test_dir/$sdk_dir_name
 

--- a/villagesql/CMakeLists.txt
+++ b/villagesql/CMakeLists.txt
@@ -24,9 +24,10 @@
 # The tarball follows the standard CMake package layout so that
 # find_package(VillageSQLExtensionFramework) works automatically when
 # CMAKE_PREFIX_PATH points to the extracted SDK directory.
+# The SDK name should not include the code base.
 
 set(SDK_VERSION "${VSQL_VERSION_STRING}")
-set(SDK_NAME "villagesql-extension-sdk-${SDK_VERSION}")
+set(SDK_NAME "villagesql-extension-sdk-${VSQL_ABBR_VERSION}")
 set(SDK_STAGING_DIR "${CMAKE_BINARY_DIR}/${SDK_NAME}")
 
 # The stable SDK snapshot to package and use for ABI compliance tests.

--- a/villagesql/bld_tools/build_ci.sh
+++ b/villagesql/bld_tools/build_ci.sh
@@ -8,6 +8,10 @@
 #   BUILD_TYPE         - debug or release (default: release, uses RelWithDebInfo)
 #   PARALLEL_JOBS      - parallel make jobs (default: auto-detected)
 #   CMAKE_EXTRA_FLAGS  - additional cmake flags appended verbatim
+#
+# Control pre-release version naming by including "-DVSQL_PRE_RELEASE_VERSION="
+# in the CMAKE_EXTRA_FLAGS variable. A blank value as above will remove the
+# default '-dev' prerelease version label.
 
 set -euo pipefail
 

--- a/villagesql/bld_tools/get_sdk.sh
+++ b/villagesql/bld_tools/get_sdk.sh
@@ -12,4 +12,4 @@ SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
 source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
 vsql_parse_version "$SOURCE_DIR"
 
-echo "$BUILD_DIR/villagesql-extension-sdk-${VSQL_CODE_BASE}_${VSQL_VERSION}"
+echo "$BUILD_DIR/villagesql-extension-sdk-${VSQL_VERSION}"

--- a/villagesql/bld_tools/package_dev_server.sh
+++ b/villagesql/bld_tools/package_dev_server.sh
@@ -39,7 +39,7 @@ trap cleanup EXIT
 vsql_parse_version "$SOURCE_DIR"
 vsql_platform_info
 
-PACKAGE_NAME="villagesql-dev-server-${VSQL_VERSION}-${PLATFORM}-${ARCH}"
+PACKAGE_NAME="villagesql-dev-server-${VSQL_CODE_BASE}_${VSQL_VERSION}-${PLATFORM}-${ARCH}"
 TARBALL_NAME="${PACKAGE_NAME}.tar.gz"
 
 log_info "VillageSQL Version: $VSQL_VERSION"


### PR DESCRIPTION
## Description

cherry-pick of PR #803/Refine tarball file name

Description from PR #803
Changes the artifact / resource name to align with the natural naming.

- servers are codebase and platform specific
- sdk are only release version specific
- VSQL_PRE_RELEASE_VERSION set for entirety of build-server-branch job build-package

## Related Issue

Part of the Cleanup release-dev-server #595 effort.