### PR TITLE
Custom Index: Fix restart issue

### DIFF
--- a/storage/innobase/villagesql/custom_column.cc
+++ b/storage/innobase/villagesql/custom_column.cc
@@ -141,6 +141,8 @@ void Custom_column::load(dict_table_t *table, dict_col_t *col,
     ib::error(ER_VILLAGESQL_GENERIC_MESSAGE)
         << "InnoDB: Error loading extended column store: " << error_msg;
     col->custom_column->set_storage_ctx(nullptr);
+  } else {
+    custom_column->storage_ctx_->ref = storage_ref;
   }
 }
 

--- a/storage/innobase/villagesql/custom_index.cc
+++ b/storage/innobase/villagesql/custom_index.cc
@@ -147,8 +147,10 @@ dberr_t Custom_index::attach(dict_index_t *index, const IndexContext *meta,
     return DB_SUCCESS;
   }
 
-  dd_index->se_private_data().get(store_key,
-                                  &index->custom_index->storage_ref_);
+  StorageRef storage_ref;
+  dd_index->se_private_data().get(store_key, &storage_ref);
+
+  index->custom_index->set_storage_ref(storage_ref);
   return DB_SUCCESS;
 }
 
@@ -161,11 +163,14 @@ dberr_t Custom_index::load(dict_index_t *new_index,
       attach(new_index, old_custom_index->index_meta().get(), nullptr);
   if (err != DB_SUCCESS) return err;
 
-  Custom_index *custom_index = new_index->custom_index;
-  custom_index->storage_ref_ = old_custom_index->storage_ref_;
-
   dberr_t init_err = init_index_ctx(new_index);
   if (init_err != DB_SUCCESS) return init_err;
+
+  Custom_index *custom_index = new_index->custom_index;
+
+  // We proceed to load only if we have a storage reference from DD. It
+  // means the index was already created and needs to be loaded.
+  if (!custom_index->copy_storage_ref(old_custom_index)) return DB_SUCCESS;
 
   auto arena_alloc = [](vef_storage_arena_t *actx, uint32_t sz) -> void * {
     return mem_heap_zalloc(reinterpret_cast<mem_heap_t *>(actx), sz);
@@ -190,6 +195,7 @@ dberr_t Custom_index::load(dict_index_t *new_index,
     return DB_VILLAGESQL_ERROR;
   }
 
+  storage->ref = custom_index->storage_ref();
   custom_index->set_storage_ctx(storage);
   return DB_SUCCESS;
 }

--- a/storage/innobase/villagesql/custom_index.h
+++ b/storage/innobase/villagesql/custom_index.h
@@ -74,9 +74,26 @@ class Custom_index {
   StorageCtx *storage_ctx() const { return storage_ctx_; }
   void set_storage_ctx(StorageCtx *ctx) { storage_ctx_ = ctx; }
 
-  // Persistent storage reference read from dd::Index se_private_data by
-  // check_and_set(). Used by load() to reconnect to extension storage.
-  StorageRef storage_ref() const { return storage_ref_; }
+  // Persistent storage reference
+  StorageRef storage_ref() const {
+    ut_ad(storage_ref_initialized_);
+    return storage_ref_;
+  }
+
+  // Copy storage reference from a reference index, if initialized.
+  // @return true if a reference could be set, false otherwise
+  bool copy_storage_ref(Custom_index *ref_index) {
+    if (!ref_index->storage_ref_initialized_) return false;
+    storage_ref_initialized_ = true;
+    storage_ref_ = ref_index->storage_ref_;
+    return true;
+  }
+
+  // Set storage reference
+  void set_storage_ref(StorageRef ref) {
+    storage_ref_ = ref;
+    storage_ref_initialized_ = true;
+  }
 
   // Sets up index->custom_index and restores its persistent storage
   // reference from the DD, if available.
@@ -111,6 +128,7 @@ class Custom_index {
   vef_index_ctx_t index_ctx_{};
   StorageCtx *storage_ctx_ = nullptr;
   StorageRef storage_ref_{};
+  bool storage_ref_initialized_ = false;
 };
 
 }  // namespace innodb


### PR DESCRIPTION
1. Skip Custom_index::load() during the index creation path.

2. Restore the storage reference in the custom column and custom index storage contexts. Although the storage reference is normally needed only during loading, the InnoDB index creation path reads it from the storage context and persists it in the data dictionary. For previously loaded custom columns and indexes, the storage context no longer contains this value, causing the data dictionary entry to be overwritten with 0. As a result, the storage reference is lost after restart.

Part of #386

Tested by  https://github.com/villagesql/vsql-vector/pull/28