### PR TITLE
auth: add token-driven role activation

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-auth/r/auth_roles.result
+++ b/mysql-test/suite/villagesql/extension/vsql-auth/r/auth_roles.result
@@ -1,0 +1,30 @@
+call mtr.add_suppression("VEF auth: role .* is not granted; skipping");
+INSTALL EXTENSION vsql_auth_test;
+CREATE USER auth_user IDENTIFIED WITH vsql_auth_test;
+CREATE USER vsql_auth_test_user;
+GRANT SELECT ON *.* TO vsql_auth_test_user;
+GRANT PROXY ON vsql_auth_test_user TO auth_user;
+CREATE ROLE vsql_role_granted;
+CREATE ROLE vsql_role_denied;
+GRANT vsql_role_granted TO vsql_auth_test_user;
+CREATE ROLE `vsql_role@weird`;
+GRANT `vsql_role@weird` TO vsql_auth_test_user;
+SELECT CURRENT_USER(), CURRENT_ROLE();
+CURRENT_USER()	CURRENT_ROLE()
+vsql_auth_test_user@%	`vsql_role_granted`@`%`
+SELECT CURRENT_ROLE();
+CURRENT_ROLE()
+`vsql_role@weird`@`%`
+SELECT CURRENT_ROLE();
+CURRENT_ROLE()
+NONE
+SET DEFAULT ROLE vsql_role_granted TO vsql_auth_test_user;
+SELECT CURRENT_ROLE();
+CURRENT_ROLE()
+`vsql_role_granted`@`%`
+UNINSTALL EXTENSION vsql_auth_test;
+DROP USER auth_user;
+DROP USER vsql_auth_test_user;
+DROP ROLE vsql_role_granted;
+DROP ROLE vsql_role_denied;
+DROP ROLE `vsql_role@weird`;

--- a/mysql-test/suite/villagesql/extension/vsql-auth/t/auth_roles.test
+++ b/mysql-test/suite/villagesql/extension/vsql-auth/t/auth_roles.test
@@ -1,0 +1,69 @@
+# Test token-driven role activation via the vsql::preview::auth set_active_roles
+# op. The vsql_auth_test extension, on the "-token-roles" token, stages two
+# roles: vsql_role_granted (which this test grants to the account) and
+# vsql_role_denied (which it does NOT grant). Verifies:
+#   - the granted role is activated on the session (CURRENT_ROLE shows it)
+#   - the ungranted requested role is silently skipped -- a token cannot
+#     activate a role the DBA never granted (the no-escalation guarantee)
+#   - the plain token stages no roles, so the account's default-role behavior is
+#     preserved: with no default role CURRENT_ROLE() is NONE, and after
+#     SET DEFAULT ROLE the default activates as usual (the token doesn't disturb
+#     the normal default-role path)
+#   - a staged role name containing a quoted '@' is parsed whole (like SET ROLE),
+#     not split at the '@' -- the "-token-quoted-role" token stages
+#     `vsql_role@weird`, which activates only because the '@' stays part of the
+#     name (a naive name@host split would look up the wrong role and fail)
+#
+# The token arrives in the password slot via mysql_clear_password, so each login
+# connects with the CLEARTEXT option.
+
+# The "-token-roles" login intentionally requests an ungranted role, which the
+# server refuses and logs as a warning -- that warning is the behavior under
+# test, so suppress it in the error-log check.
+call mtr.add_suppression("VEF auth: role .* is not granted; skipping");
+
+INSTALL EXTENSION vsql_auth_test;
+
+CREATE USER auth_user IDENTIFIED WITH vsql_auth_test;
+CREATE USER vsql_auth_test_user;
+GRANT SELECT ON *.* TO vsql_auth_test_user;
+GRANT PROXY ON vsql_auth_test_user TO auth_user;
+
+CREATE ROLE vsql_role_granted;
+CREATE ROLE vsql_role_denied;
+GRANT vsql_role_granted TO vsql_auth_test_user;
+
+# A role whose name literally contains '@' (quoted), granted to the account.
+CREATE ROLE `vsql_role@weird`;
+GRANT `vsql_role@weird` TO vsql_auth_test_user;
+
+--connect(roles_con, localhost, auth_user, vsql-auth-test-token-roles, , , , CLEARTEXT)
+SELECT CURRENT_USER(), CURRENT_ROLE();
+--connection default
+--disconnect roles_con
+
+# The quoted-'@' role activates: its name was parsed whole, not split at the '@'.
+--connect(quoted_con, localhost, auth_user, vsql-auth-test-token-quoted-role, , , , CLEARTEXT)
+SELECT CURRENT_ROLE();
+--connection default
+--disconnect quoted_con
+
+--connect(plain_con, localhost, auth_user, vsql-auth-test-token, , , , CLEARTEXT)
+SELECT CURRENT_ROLE();
+--connection default
+--disconnect plain_con
+
+# With a default role set, the plain token (which stages nothing) must leave the
+# normal default-role activation intact -- CURRENT_ROLE() is the default.
+SET DEFAULT ROLE vsql_role_granted TO vsql_auth_test_user;
+--connect(default_con, localhost, auth_user, vsql-auth-test-token, , , , CLEARTEXT)
+SELECT CURRENT_ROLE();
+--connection default
+--disconnect default_con
+
+UNINSTALL EXTENSION vsql_auth_test;
+DROP USER auth_user;
+DROP USER vsql_auth_test_user;
+DROP ROLE vsql_role_granted;
+DROP ROLE vsql_role_denied;
+DROP ROLE `vsql_role@weird`;

--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -1169,7 +1169,7 @@ inline const char *mpvio_client_plugin_name(MPVIO_EXT *mpvio) {
   if (mpvio->plugin != nullptr) return client_plugin_name(mpvio->plugin);
   // A VEF auth method is required to pin a non-null client_auth_plugin at
   // INSTALL EXTENSION, so this is non-null on the VEF path.
-  return mpvio->vef_client_auth_plugin;
+  return mpvio->vef_auth_info.vef_client_auth_plugin;
 }
 
 LEX_CSTRING validate_password_plugin_name = {
@@ -4251,7 +4251,14 @@ int acl_authenticate(THD *thd, enum_server_command command) {
         List_of_auth_id_refs default_roles;
         if (!acl_cache_lock.lock()) return 1;
         Auth_id_ref authid = create_authid_from(acl_user);
-        if (opt_always_activate_granted_roles) {
+        // VillageSQL: a VEF auth handler may have staged a token-driven role
+        // set via set_active_roles(); if so it replaces default-role activation
+        // for this login (grant-checked inside, so it cannot escalate). Falls
+        // through to the normal default-role path when nothing was staged.
+        if (villagesql::services::maybe_apply_vef_auth_state(
+                &mpvio, sctx, acl_user->user, acl_user->host.get_host())) {
+          // staged roles applied
+        } else if (opt_always_activate_granted_roles) {
           activate_all_granted_and_mandatory_roles(acl_user, sctx);
         } else {
           /* The server policy is to only activate default roles */

--- a/sql/auth/sql_authentication.h
+++ b/sql/auth/sql_authentication.h
@@ -36,6 +36,7 @@
 #include "mysql/plugin_auth_common.h"
 #include "mysql/strings/m_ctype.h"
 #include "sql/sql_plugin_ref.h"  // plugin_ref
+#include "villagesql/services/preview/auth_info.h"
 
 class ACL_USER;
 class Protocol_classic;
@@ -93,12 +94,8 @@ struct MPVIO_EXT : public MYSQL_PLUGIN_VIO {
   Thd_charset_adapter *charset_adapter;
   LEX_CSTRING acl_user_plugin;
   int vio_is_encrypted;
-  // VillageSQL: for a VEF extension-provided auth method there is no MySQL
-  // plugin (`plugin` is null), so the client-side auth plugin the handshake
-  // should advertise/expect comes from the method's config instead of from
-  // client_plugin_name(plugin). Set by the VEF auth seam before invoking the
-  // handler; nullptr for normal plugin-based auth.
-  const char *vef_client_auth_plugin;
+  // VillageSQL: populated by the VEF auth seam.
+  villagesql::services::VefAuthInfo vef_auth_info;
   bool can_authenticate();
 };
 

--- a/villagesql/sdk/include/villagesql/abi/preview/auth.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/auth.h
@@ -121,6 +121,17 @@ typedef struct {
 
   // Set the original external identity for the audit trail (@@external_user).
   void (*set_external_user)(vef_auth_ctx_t *ctx, const char *identity);
+
+  // Stage the set of roles the token says should be active on this session,
+  // replacing default-role activation for this login. `roles` is an array of
+  // `n_roles` NUL-terminated role names. The server applies them AFTER account
+  // resolution, using the same grant-checked activation as SET ROLE: only roles
+  // actually granted to the authenticated_as account are activated -- names not
+  // granted are ignored, so the token can never grant or escalate beyond what
+  // the DBA provisioned. The strings are copied; the caller need not keep them.
+  // Passing n_roles == 0 activates no roles (equivalent to SET ROLE NONE).
+  void (*set_active_roles)(vef_auth_ctx_t *ctx, const char *const *roles,
+                           uint32_t n_roles);
 } vef_auth_ops_t;
 
 // The handler the extension implements. Invoked synchronously on the connecting

--- a/villagesql/sdk/include/villagesql/preview/auth.h
+++ b/villagesql/sdk/include/villagesql/preview/auth.h
@@ -82,6 +82,15 @@ class AuthContext {
     ops_->set_external_user(ctx_, identity);
   }
 
+  // Stage the session's active roles, replacing the account's default-role
+  // activation. The server activates them grant-checked after account
+  // resolution: only roles actually granted to the account take effect, so a
+  // token can never grant or escalate. n_roles == 0 activates no roles
+  // (SET ROLE NONE).
+  void set_active_roles(const char *const *roles, uint32_t n_roles) {
+    ops_->set_active_roles(ctx_, roles, n_roles);
+  }
+
  private:
   vef_auth_ctx_t *ctx_;
   const vef_auth_ops_t *ops_;

--- a/villagesql/services/preview/auth.cc
+++ b/villagesql/services/preview/auth.cc
@@ -189,6 +189,14 @@ bool maybe_apply_vef_auth_state(MPVIO_EXT *mpvio, Security_context *sctx,
               acl_user_host != nullptr ? acl_user_host : "");
     }
   }
+  // A non-null staged set replaces the account's default roles, even if it
+  // resolves to no active roles -- because it was empty (n_roles == 0, i.e. SET
+  // ROLE NONE) or because every requested role was ungranted and skipped above.
+  // Only a null state (handler staged nothing) keeps the defaults.
+  //
+  // TODO(villagesql-beta): make the all-skipped/empty outcome configurable --
+  // some deployments may prefer falling back to the account's default roles
+  // when a staged set activates nothing, rather than ending with no roles.
   return true;  // staged state applied; caller must NOT also activate defaults
 }
 

--- a/villagesql/services/preview/auth.cc
+++ b/villagesql/services/preview/auth.cc
@@ -26,8 +26,11 @@
 #include "my_sys.h"
 #include "mysql/plugin_auth_common.h"
 #include "mysqld_error.h"
+#include "sql/auth/auth_common.h"
 #include "sql/auth/sql_authentication.h"
+#include "sql/auth/sql_security_ctx.h"
 #include "sql/hostname_cache.h"
+#include "sql/mem_root_array.h"
 #include "strmake.h"
 #include "villagesql/include/error.h"
 #include "villagesql/schema/systable/helpers.h"
@@ -41,6 +44,21 @@ struct vef_auth_ctx_t {
 };
 
 namespace villagesql::services {
+
+// The roles a VEF handler staged via set_active_roles(), as the raw name
+// strings the handler passed. The array and its strings are allocated on the
+// connection MEM_ROOT (freed with the connection). The element type is
+// trivially destructible, so the array needs no destructor run -- it is safe to
+// leave on the MEM_ROOT and never destruct (only the constructor, which takes
+// the root, must run). Parsing of each "role"/"role@host" name is deferred to
+// apply time so it can reuse the server's own quote-aware splitter (see
+// maybe_apply_vef_auth_state). An empty `roles` (with a non-null VefAuthState)
+// means "activate no roles" (SET ROLE NONE), distinct from a null VefAuthState
+// pointer ("handler staged nothing; use the account's default roles").
+struct VefAuthState {
+  explicit VefAuthState(MEM_ROOT *mem_root) : roles(mem_root) {}
+  Mem_root_array<const char *> roles;
+};
 
 namespace {
 
@@ -110,15 +128,69 @@ void vef_auth_set_external_user(vef_auth_ctx_t *ctx, const char *identity) {
           sizeof(ctx->mpvio->auth_info.external_user) - 1);
 }
 
+void vef_auth_set_active_roles(vef_auth_ctx_t *ctx, const char *const *roles,
+                               uint32_t n_roles) {
+  MPVIO_EXT *mpvio = ctx->mpvio;
+  MEM_ROOT *mem_root = mpvio->mem_root;
+
+  // Allocate/replace the state on the connection MEM_ROOT (freed with the
+  // connection; no manual cleanup). Re-staging replaces the prior set. Copy
+  // each name so nothing points into the extension's transient buffer; the
+  // "role"/"role@host" parse is deferred to apply time.
+  auto *state = new (mem_root) VefAuthState(mem_root);
+  state->roles.reserve(n_roles);
+
+  for (uint32_t i = 0; i < n_roles; ++i) {
+    const char *r = roles[i];
+    if (r == nullptr || r[0] == '\0') continue;  // skip empties defensively
+    state->roles.push_back(strdup_root(mem_root, r));
+  }
+
+  mpvio->vef_auth_info.vef_auth_state = state;
+}
+
 const vef_auth_ops_t g_vef_auth_ops = {
     VEF_PREVIEW_AUTH_ABI_VERSION,  vef_auth_read_packet,
     vef_auth_write_packet,         vef_auth_user_name,
     vef_auth_auth_string,          vef_auth_host_or_ip,
-    vef_auth_set_authenticated_as, vef_auth_set_external_user};
+    vef_auth_set_authenticated_as, vef_auth_set_external_user,
+    vef_auth_set_active_roles};
 
 }  // namespace
 
 vef_preview_auth_t *preview_auth_vtable() { return &g_auth_vtable; }
+
+bool maybe_apply_vef_auth_state(MPVIO_EXT *mpvio, Security_context *sctx,
+                                const char *acl_user_authid,
+                                const char *acl_user_host) {
+  const VefAuthState *state = mpvio->vef_auth_info.vef_auth_state;
+  if (state == nullptr) return false;  // handler staged nothing; use defaults
+
+  // The caller holds the ACL cache lock (this replaces the account's
+  // default-role activation, which runs under the same lock) and calls
+  // checkout_access_maps() afterward. Activate each staged role grant-checked:
+  // activate_role(..., validate_access=true) refuses a role not granted to the
+  // authenticated account, so a token can only activate what the DBA granted --
+  // never grant or escalate. An empty set activates nothing (SET ROLE NONE).
+  for (const char *staged : state->roles) {
+    // Parse "role"/"role@host" the same way SET ROLE does: split on an unquoted
+    // '@' and default the host to '%', so a role name containing a quoted '@'
+    // is not mis-split. activate_role() copies the strings, so the temporaries
+    // outlive the call.
+    const auto [name, host] = get_authid_from_quoted_string(staged);
+    const LEX_CSTRING role{name.c_str(), name.length()};
+    const LEX_CSTRING role_host{host.c_str(), host.length()};
+    if (sctx->activate_role(role, role_host, /*validate_access=*/true)) {
+      LogVSQL(WARNING_LEVEL,
+              "VEF auth: role '%s'@'%s' requested for account '%s'@'%s' is not "
+              "granted; skipping",
+              role.str, role_host.str,
+              acl_user_authid != nullptr ? acl_user_authid : "",
+              acl_user_host != nullptr ? acl_user_host : "");
+    }
+  }
+  return true;  // staged state applied; caller must NOT also activate defaults
+}
 
 AuthMethodRef::AuthMethodRef() {
   g_inflight.fetch_add(1, std::memory_order_seq_cst);
@@ -242,7 +314,7 @@ static bool try_vef_authenticate(const vef_auth_cc_t *cc, MPVIO_EXT *mpvio) {
   // Stash the method's pinned client-plugin name on the connection before
   // driving the handler: the handler's first read_packet triggers the handshake
   // change-plugin request that reads it back via mpvio_client_plugin_name().
-  mpvio->vef_client_auth_plugin = cc->client_auth_plugin;
+  mpvio->vef_auth_info.vef_client_auth_plugin = cc->client_auth_plugin;
 
   // Run the extension's authenticator over an ops table on this MPVIO_EXT.
   vef_auth_ctx_t ctx{mpvio};

--- a/villagesql/services/preview/auth.h
+++ b/villagesql/services/preview/auth.h
@@ -132,6 +132,8 @@ struct VefAuthState;
 // the role graph under it). Does nothing (returns false = "not handled, use
 // default roles") when `mpvio` has no staged state. Returns true when it
 // applied staged state, so the caller skips its own default-role activation.
+// The bool is a handled/not-handled discriminator, NOT the usual MySQL
+// true==error convention -- true here is the success path.
 //
 // `sctx` is the session's Security_context (the same one the default-role path
 // activates onto); `acl_user_authid`/`acl_user_host` identify the resolved

--- a/villagesql/services/preview/auth.h
+++ b/villagesql/services/preview/auth.h
@@ -28,6 +28,7 @@
 // would create distinct villagesql::services::* types and break linkage against
 // the caller in sql/auth/, which uses the global ones.
 class THD;
+class Security_context;
 struct MPVIO_EXT;
 struct MYSQL_LEX_CSTRING;
 
@@ -114,6 +115,32 @@ std::optional<bool> handle_vef_user_bind(std::string_view method_name,
 // MySQL plugin -- keeping do_auth_once() itself vanilla.
 int vsql_do_auth_once(THD *thd, const MYSQL_LEX_CSTRING &auth_plugin_name,
                       MPVIO_EXT *mpvio);
+
+// Opaque per-login state a VEF auth handler stages during the handshake, to be
+// applied after account resolution. Its definition and all its fields live in
+// auth.cc; core auth (sql/auth/) only holds a pointer to it on MPVIO_EXT and
+// forwards it to maybe_apply_vef_auth_state() below. Today it carries the roles
+// set via set_active_roles(); anything else a handler needs to stage post-auth
+// goes here too, with no further change to MPVIO_EXT.
+struct VefAuthState;
+
+// Apply whatever a VEF handler staged for this login, AFTER the account has
+// been resolved. Currently: activate the staged role set on `sctx`, replacing
+// default-role activation, using the server's grant-checked activation (a role
+// not granted to the account is skipped) so a token can never escalate. The
+// caller must already hold the ACL cache lock (grant-checked activation reads
+// the role graph under it). Does nothing (returns false = "not handled, use
+// default roles") when `mpvio` has no staged state. Returns true when it
+// applied staged state, so the caller skips its own default-role activation.
+//
+// `sctx` is the session's Security_context (the same one the default-role path
+// activates onto); `acl_user_authid`/`acl_user_host` identify the resolved
+// account for warning messages. Roles are activated but access maps are NOT
+// checked out here -- the caller does checkout_access_maps() once afterward, as
+// it already does for the default-role path.
+bool maybe_apply_vef_auth_state(MPVIO_EXT *mpvio, Security_context *sctx,
+                                const char *acl_user_authid,
+                                const char *acl_user_host);
 
 }  // namespace villagesql::services
 

--- a/villagesql/services/preview/auth_info.h
+++ b/villagesql/services/preview/auth_info.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+#ifndef VILLAGESQL_SERVICES_PREVIEW_AUTH_INFO_H
+#define VILLAGESQL_SERVICES_PREVIEW_AUTH_INFO_H
+
+namespace villagesql::services {
+
+// Opaque per-login state staged by a VEF auth handler (e.g. the roles set via
+// set_active_roles). Owned and defined by the VEF auth seam in
+// villagesql/services/preview/auth.cc; core auth only forwards it to
+// maybe_apply_vef_auth_state() after account resolution and never inspects it.
+struct VefAuthState;
+
+// The VEF-auth-specific fields on MPVIO_EXT, grouped so core auth carries a
+// single member instead of one field per VEF feature. Core reads/forwards these
+// but does not interpret them; the VEF auth seam populates them. All nullptr
+// for a normal (non-VEF) plugin-based login.
+struct VefAuthInfo {
+  // For a VEF extension-provided auth method there is no MySQL plugin
+  // (`plugin` is null), so the client-side auth plugin the handshake should
+  // advertise/expect comes from the method's config instead of from
+  // client_plugin_name(plugin). Set by the seam before invoking the handler.
+  const char *vef_client_auth_plugin;
+  villagesql::services::VefAuthState *vef_auth_state;
+};
+
+}  // namespace villagesql::services
+
+#endif  // VILLAGESQL_SERVICES_PREVIEW_AUTH_INFO_H

--- a/villagesql/test-extensions/vsql-auth-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-auth-test/src/extension.cc
@@ -16,8 +16,22 @@
 // Trivial VillageSQL auth extension exercising the vsql::preview::auth
 // capability end to end -- no JWT, no crypto. It registers an auth method named
 // "vsql_auth_test"; an account created with IDENTIFIED WITH vsql_auth_test
-// authenticates iff the client sends the fixed token below, and is then mapped
-// to the account "vsql_auth_test_user".
+// authenticates iff the client sends one of the fixed tokens below, and is then
+// mapped to the account "vsql_auth_test_user".
+//
+// Accepted tokens:
+//   kToken           -- accept, map to the account, stage no roles (the
+//                       account's default roles apply).
+//   kTokenRoles      -- accept and additionally stage a fixed role set via
+//                       set_active_roles: one role the test grants to the
+//                       account ("vsql_role_granted") and one it does NOT
+//                       ("vsql_role_denied"). Lets auth_roles.test assert that
+//                       a granted role activates while an ungranted requested
+//                       role is silently skipped (the no-escalation guarantee).
+//   kTokenQuotedRole -- accept and stage a role whose name contains a quoted
+//                       '@' ("`vsql_role@weird`"), so auth_roles.test can
+//                       assert the name is parsed whole rather than split at
+//                       the '@'.
 //
 // Pairs with the built-in mysql_clear_password client plugin so the token
 // arrives verbatim in the password slot (client must use
@@ -33,13 +47,33 @@ using namespace vsql;
 namespace {
 
 constexpr char kToken[] = "vsql-auth-test-token";
+constexpr char kTokenRoles[] = "vsql-auth-test-token-roles";
+constexpr char kTokenQuotedRole[] = "vsql-auth-test-token-quoted-role";
 constexpr char kMappedAccount[] = "vsql_auth_test_user";
 
 using vsql::preview_auth::AuthContext;
 using vsql::preview_auth::AuthResult;
 
+// Roles the kTokenRoles path stages. The test grants the first to the account
+// and leaves the second ungranted, so activation must pick up the granted one
+// and skip the denied one (no escalation).
+constexpr char kRoleGranted[] = "vsql_role_granted";
+constexpr char kRoleDenied[] = "vsql_role_denied";
+
+// Role staged by the kTokenQuotedRole path: a name that literally contains '@',
+// backtick-quoted so the server's role parser keeps the '@' as part of the name
+// (host defaults to '%') instead of splitting it as name@host. The test grants
+// exactly this role, so it activates only if the '@' was not mis-split.
+constexpr char kRoleWithAt[] = "`vsql_role@weird`";
+
+bool token_matches(const unsigned char *pkt, size_t token_len,
+                   const char *expected) {
+  return token_len == std::strlen(expected) &&
+         std::memcmp(pkt, expected, token_len) == 0;
+}
+
 // The authenticator. Reads one packet (the token), compares it to the fixed
-// test token, and on success maps to the fixed account. Fail closed otherwise.
+// test tokens, and on success maps to the fixed account. Fail closed otherwise.
 AuthResult authenticate(AuthContext &c) {
   auto pkt = c.read_packet();
   if (pkt.empty()) return AuthResult::kError;
@@ -48,15 +82,28 @@ AuthResult authenticate(AuthContext &c) {
   size_t token_len = pkt.size();
   if (pkt[token_len - 1] == '\0') --token_len;
 
-  if (token_len != std::strlen(kToken) ||
-      std::memcmp(pkt.data(), kToken, token_len) != 0) {
-    return AuthResult::kReject;
-  }
+  const bool plain = token_matches(pkt.data(), token_len, kToken);
+  const bool with_roles = token_matches(pkt.data(), token_len, kTokenRoles);
+  const bool quoted_role =
+      token_matches(pkt.data(), token_len, kTokenQuotedRole);
+  if (!plain && !with_roles && !quoted_role) return AuthResult::kReject;
 
   c.authenticate_as(kMappedAccount);
   // @@external_user is the original identity for the audit trail: the account
   // the client connected as, NOT the account we mapped to.
   c.set_external_user(c.user_name());
+
+  if (with_roles) {
+    // Stage a granted + an ungranted role. The server activates only the
+    // granted one (grant-checked); the ungranted one is silently skipped.
+    const char *roles[] = {kRoleGranted, kRoleDenied};
+    c.set_active_roles(roles, 2);
+  } else if (quoted_role) {
+    // Stage a role whose name contains a quoted '@'; it activates only if the
+    // name was parsed whole rather than split at the '@'.
+    const char *roles[] = {kRoleWithAt};
+    c.set_active_roles(roles, 1);
+  }
   return AuthResult::kOk;
 }
 


### PR DESCRIPTION
Adds the ability for an extension to set which roles to activate when authenticating, corresponding to the SQL SET ROLE .... The use-case is to use information in, for example, a JWT token's claims field to say what roles the authenticating user should have — i.e. "I'm user <user> and I want to log in with roles <roles>".

Only roles already granted to the user are accepted (a role the token asks for but the user doesn't hold is skipped), so a token can't escalate privileges.

part of #640