### PR TITLE
Custom Type: expand test coverage

### DIFF
--- a/mysql-test/include/villagesql/create_extension_sdk_expect_build_failure.inc
+++ b/mysql-test/include/villagesql/create_extension_sdk_expect_build_failure.inc
@@ -43,6 +43,13 @@ if (!$extension_version)
 
 --exec cp $extension_source $ext_build_dir/src/extension.cc
 
+# Optionally place a shared companion header next to extension.cc so the source
+# can #include it.
+if ($extension_common_header)
+{
+  --exec cp $extension_common_header $ext_build_dir/src/
+}
+
 --exec printf '%s' '{"name": "$extension_name", "version": "$extension_version"}' > $ext_build_dir/manifest.json
 
 --let $cmake_template = $MYSQL_TEST_DIR/suite/villagesql/data/extension_creator/CMakeLists.txt.template
@@ -72,4 +79,5 @@ if ($build_failure_grep)
 --let $extension_name =
 --let $extension_version =
 --let $extension_source =
+--let $extension_common_header =
 --let $build_failure_grep =

--- a/mysql-test/suite/villagesql/extension/r/extension_duplicate_type.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_duplicate_type.result
@@ -1,0 +1,11 @@
+call mtr.add_suppression("Failed to load VEF extension");
+call mtr.add_suppression("already exists");
+# INSTALL fails: duplicate type name within one extension.
+INSTALL EXTENSION vsql_dup_type_test;
+ERROR HY000: Failed to install extension 'vsql_dup_type_test': type 'DUP_TYPE' already exists
+# Verify extension was NOT installed.
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS
+WHERE extension_name = 'vsql_dup_type_test';
+EXTENSION_NAME	EXTENSION_VERSION
+# Verify the error log names the duplicate.
+Found duplicate rejection message in error log

--- a/mysql-test/suite/villagesql/extension/r/extension_empty_int_to_params.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_empty_int_to_params.result
@@ -1,0 +1,16 @@
+INSTALL EXTENSION vsql_test_only;
+# TYPE(N): int_to_params leaves the map empty -> empty parameter string
+# -> rejected at parse time.
+CREATE TABLE t (id INT PRIMARY KEY, v EMPTY_PARAMS_TYPE(4));
+ERROR 42000: Invalid parameter string for type 'vsql_test_only.EMPTY_PARAMS_TYPE' near 'EMPTY_PARAMS_TYPE(4))' at line 1
+# The explicit parameter string supplies 'length' directly and succeeds.
+CREATE TABLE t (id INT PRIMARY KEY, v EMPTY_PARAMS_TYPE('length=4'));
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `id` int NOT NULL,
+  `v` vsql_test_only.EMPTY_PARAMS_TYPE('length=4') DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t;
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/r/extension_intrinsic_default.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_intrinsic_default.result
@@ -1,0 +1,35 @@
+INSTALL EXTENSION vsql_test_only;
+# intrinsic_default_str: NULL under IGNORE becomes the literal default.
+CREATE TABLE t_str (id INT PRIMARY KEY, v DEFAULT_STR_TYPE NOT NULL);
+INSERT IGNORE INTO t_str VALUES (1, NULL);
+Warnings:
+Warning	1048	Column 'v' cannot be null
+INSERT INTO t_str VALUES (2, '(42)');
+SELECT id, v FROM t_str ORDER BY id;
+id	v
+1	(7)
+2	(42)
+DROP TABLE t_str;
+# intrinsic_default VDF: NULL under IGNORE becomes the VDF-computed default.
+CREATE TABLE t_vdf (id INT PRIMARY KEY, v DEFAULT_VDF_TYPE NOT NULL);
+INSERT IGNORE INTO t_vdf VALUES (1, NULL);
+Warnings:
+Warning	1048	Column 'v' cannot be null
+INSERT INTO t_vdf VALUES (2, '(42)');
+SELECT id, v FROM t_vdf ORDER BY id;
+id	v
+1	(9)
+2	(42)
+DROP TABLE t_vdf;
+# Parameterized type
+CREATE TABLE t_param (id INT PRIMARY KEY, v DEFAULT_PARAM_TYPE(3) NOT NULL);
+INSERT IGNORE INTO t_param VALUES (1, NULL);
+Warnings:
+Warning	1048	Column 'v' cannot be null
+INSERT INTO t_param VALUES (2, '(42)');
+SELECT id, v FROM t_param ORDER BY id;
+id	v
+1	(5)
+2	(42)
+DROP TABLE t_param;
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/r/extension_intrinsic_default_errors.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_intrinsic_default_errors.result
@@ -1,0 +1,11 @@
+INSTALL EXTENSION vsql_test_only;
+# A type whose intrinsic default encodes to the wrong length is rejected
+# when the column's TypeContext is created.
+CREATE TABLE t (id INT PRIMARY KEY, v BAD_DEFAULT_LEN_TYPE);
+ERROR HY000: Type 'vsql_test_only.BAD_DEFAULT_LEN_TYPE' failed to initialize: from_string VDF encoded intrinsic default input 'SHORT' to 2 bytes, expected persisted_length=4
+# No table was created.
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 't';
+COUNT(*)
+0
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/r/extension_length_bounds.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_length_bounds.result
@@ -1,0 +1,10 @@
+INSTALL EXTENSION vsql_test_only;
+# Parameterized type resolving beyond max_persisted_length -> DDL error.
+CREATE TABLE t (id INT PRIMARY KEY, v OVERSIZED_PARAM_TYPE(4));
+ERROR 42000: Type 'vsql_test_only.OVERSIZED_PARAM_TYPE' resolved a persisted_length (8) that exceeds its declared max_persisted_length (4) near 'OVERSIZED_PARAM_TYPE(4))' at line 1
+# No table was created.
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 't';
+COUNT(*)
+0
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/r/extension_length_no_upper_bound.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_length_no_upper_bound.result
@@ -1,0 +1,14 @@
+INSTALL EXTENSION vsql_test_only;
+# A fixed type with an over-large persisted_length installs fine, but
+# CREATE TABLE is rejected by MySQL's column-length limit.
+CREATE TABLE t (id INT PRIMARY KEY, v HUGE_FIELD);
+ERROR 42000: Column length too big for column 'v' (max = 65535); use BLOB or TEXT instead
+# Same for a variable-length type with an over-large max_persisted_length.
+CREATE TABLE t (id INT PRIMARY KEY, v HUGE_VAR);
+ERROR 42000: Column length too big for column 'v' (max = 65535); use BLOB or TEXT instead
+# No table was created.
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 't';
+COUNT(*)
+0
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/r/extension_param_key_handling.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_param_key_handling.result
@@ -1,0 +1,47 @@
+INSTALL EXTENSION vsql_test_only;
+# Lenient type: an unknown key in the parameter string is accepted and
+# silently ignored by resolve_params.
+CREATE TABLE t_lenient (id INT PRIMARY KEY, v LENIENT_PARAM_TYPE('length=3,bogus=9'));
+# The unknown key is preserved in the canonical parameters, so the long
+# form is shown.
+SHOW CREATE TABLE t_lenient;
+Table	Create Table
+t_lenient	CREATE TABLE `t_lenient` (
+  `id` int NOT NULL,
+  `v` vsql_test_only.LENIENT_PARAM_TYPE('bogus=9,length=3') DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t_lenient;
+# Strict type: an unknown key in the parameter string is rejected.
+CREATE TABLE t_strict (id INT PRIMARY KEY, v STRICT_PARAM_TYPE('length=4,bogus=1'));
+ERROR 42000: STRICT_PARAM_TYPE: unknown parameter 'bogus' near 'STRICT_PARAM_TYPE('length=4,bogus=1'))' at line 1
+# Strict type accepts the known key, via both the string and (N) forms.
+CREATE TABLE t_strict (id INT PRIMARY KEY, v STRICT_PARAM_TYPE('length=4'));
+SHOW CREATE TABLE t_strict;
+Table	Create Table
+t_strict	CREATE TABLE `t_strict` (
+  `id` int NOT NULL,
+  `v` vsql_test_only.STRICT_PARAM_TYPE(4) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t_strict;
+CREATE TABLE t_strict (id INT PRIMARY KEY, v STRICT_PARAM_TYPE(4));
+SHOW CREATE TABLE t_strict;
+Table	Create Table
+t_strict	CREATE TABLE `t_strict` (
+  `id` int NOT NULL,
+  `v` vsql_test_only.STRICT_PARAM_TYPE(4) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t_strict;
+# int_to_params emits an extra 'bogus' key. SHOW CREATE doesn't show it.
+CREATE TABLE t_extra (id INT PRIMARY KEY, v EXTRA_KEY_PARAM_TYPE(3));
+SHOW CREATE TABLE t_extra;
+Table	Create Table
+t_extra	CREATE TABLE `t_extra` (
+  `id` int NOT NULL,
+  `v` vsql_test_only.EXTRA_KEY_PARAM_TYPE(3) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t_extra;
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/r/extension_resolve_params_invalid_sizes.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_resolve_params_invalid_sizes.result
@@ -1,0 +1,22 @@
+INSTALL EXTENSION vsql_test_only;
+# Fixed-length, TYPE(N) shorthand: int_to_params succeeds, then
+# resolve_params returns persisted_length = -1, rejected for a fixed type.
+CREATE TABLE t (id INT PRIMARY KEY, v BAD_LEN_PARAM_TYPE(4));
+ERROR 42000: Type 'vsql_test_only.BAD_LEN_PARAM_TYPE' resolved an invalid persisted_length (-1); fixed-length types must resolve to a concrete footprint, so persisted_length should be > 0 near 'BAD_LEN_PARAM_TYPE(4))' at line 1
+# Explicit parameter string: same resolve_params rejection.
+CREATE TABLE t (id INT PRIMARY KEY, v BAD_LEN_PARAM_TYPE('length=4'));
+ERROR 42000: Type 'vsql_test_only.BAD_LEN_PARAM_TYPE' resolved an invalid persisted_length (-1); fixed-length types must resolve to a concrete footprint, so persisted_length should be > 0 near 'BAD_LEN_PARAM_TYPE('length=4'))' at line 1
+# Variable-length: resolve_params reports a positive persisted_length,
+# which is rejected (variable-length types must leave it unset).
+CREATE TABLE t (id INT PRIMARY KEY, v VAR_SETS_PERSISTED(4));
+ERROR 42000: Variable-length type 'vsql_test_only.VAR_SETS_PERSISTED' resolved an unexpected fixed persisted_length (4); variable-length types size storage per value, so persisted_length should be <= 0 (stay unset) near 'VAR_SETS_PERSISTED(4))' at line 1
+# resolve_params resolves a non-positive max_decode_buffer_length, which
+# is rejected (it sizes the decode scratch buffer and must be > 0).
+CREATE TABLE t (id INT PRIMARY KEY, v BAD_DECODE_BUF(4));
+ERROR 42000: resolve_params resolved a non-positive max_decode_buffer_length (0); it must be > 0 near 'BAD_DECODE_BUF(4))' at line 1
+# No table was created.
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 't';
+COUNT(*)
+0
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/r/extension_resolve_params_rewrite.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_resolve_params_rewrite.result
@@ -1,0 +1,31 @@
+INSTALL EXTENSION vsql_test_only;
+# An unrecognized key is dropped by resolve_params; the column is created
+# with the reduced canonical parameters.
+CREATE TABLE t (id INT PRIMARY KEY, v DROP_PARAM_TYPE('length=4,bogus=9'));
+# SHOW CREATE reflects the rewritten (reduced) params, not the input.
+# 'bogus' is gone; only 'length' remains, so the short (N) form prints.
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `id` int NOT NULL,
+  `v` vsql_test_only.DROP_PARAM_TYPE(4) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# The column round-trips a value.
+INSERT INTO t VALUES (1, '(3)');
+SELECT id, v FROM t ORDER BY id;
+id	v
+1	(3)
+DROP TABLE t;
+# The (N) shorthand routes through int_to_params then resolve_params and
+# yields the same canonical params.
+CREATE TABLE t2 (id INT PRIMARY KEY, v DROP_PARAM_TYPE(4));
+SHOW CREATE TABLE t2;
+Table	Create Table
+t2	CREATE TABLE `t2` (
+  `id` int NOT NULL,
+  `v` vsql_test_only.DROP_PARAM_TYPE(4) DEFAULT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t2;
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/r/extension_type_builder_build_errors.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_type_builder_build_errors.result
@@ -1,0 +1,27 @@
+# A type without from_string() fails to build.
+Attempting to build type_missing_from_string (expecting build failure)...
+Build failed as expected.
+# A type without to_string() fails to build.
+Attempting to build type_missing_to_string (expecting build failure)...
+Build failed as expected.
+# A type with int_to_params() but no resolve_params() fails to build.
+Attempting to build int_to_params_no_resolve (expecting build failure)...
+Build failed as expected.
+# A parameterized type (params<P>) without resolve_params() fails to build.
+Attempting to build params_no_resolve (expecting build failure)...
+Build failed as expected.
+# A variable-length type without max_persisted_length() fails to build.
+Attempting to build var_no_max_persisted (expecting build failure)...
+Build failed as expected.
+# A variable-length type that also declares persisted_length() fails to
+# build (the two are mutually exclusive).
+Attempting to build var_with_persisted (expecting build failure)...
+Build failed as expected.
+# A type that sets both intrinsic_default_str and intrinsic_default_vdf
+# fails to build (the two are mutually exclusive).
+Attempting to build both_intrinsic_defaults (expecting build failure)...
+Build failed as expected.
+# A fixed, non-parameterized type that sets max_persisted_length fails to
+# build (it is only valid for variable-length or parameterized types).
+Attempting to build fixed_with_max (expecting build failure)...
+Build failed as expected.

--- a/mysql-test/suite/villagesql/extension/t/extension_duplicate_type.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_duplicate_type.test
@@ -1,0 +1,32 @@
+# Scenario: an extension that registers two types with the same name must be
+# rejected at INSTALL EXTENSION time. Fixture: vsql_dup_type_test registers
+# DUP_TYPE twice.
+
+call mtr.add_suppression("Failed to load VEF extension");
+call mtr.add_suppression("already exists");
+
+--echo # INSTALL fails: duplicate type name within one extension.
+--error ER_VILLAGESQL_GENERIC_ERROR
+INSTALL EXTENSION vsql_dup_type_test;
+
+--echo # Verify extension was NOT installed.
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS
+WHERE extension_name = 'vsql_dup_type_test';
+
+--echo # Verify the error log names the duplicate.
+--perl
+use strict;
+my $error_log = $ENV{'MYSQLTEST_VARDIR'} . "/log/mysqld.1.err";
+open(FILE, "$error_log") or die("Unable to open error log: $error_log");
+my $found = 0;
+while (<FILE>) {
+  if (/already exists/) {
+    $found = 1;
+  }
+}
+close(FILE);
+if (!$found) {
+  die "Expected 'already exists' rejection message in error log";
+}
+print "Found duplicate rejection message in error log\n";
+EOF

--- a/mysql-test/suite/villagesql/extension/t/extension_empty_int_to_params.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_empty_int_to_params.test
@@ -1,0 +1,22 @@
+# Scenario: a parameterized type whose int_to_params reports success but leaves
+# the parameter map empty. The TYPE(N) shorthand then canonicalizes to an empty
+# parameter string, which PT_custom_type::create_with_length rejects ("Invalid
+# parameter string") before resolve_params is ever consulted. The explicit
+# TYPE('key=value') form still works because it supplies the parameter directly.
+#
+# Fixture: vsql_test_only exposes EMPTY_PARAMS_TYPE, whose int_to_params adds no
+# parameters.
+
+INSTALL EXTENSION vsql_test_only;
+
+--echo # TYPE(N): int_to_params leaves the map empty -> empty parameter string
+--echo # -> rejected at parse time.
+--error ER_PARSE_ERROR
+CREATE TABLE t (id INT PRIMARY KEY, v EMPTY_PARAMS_TYPE(4));
+
+--echo # The explicit parameter string supplies 'length' directly and succeeds.
+CREATE TABLE t (id INT PRIMARY KEY, v EMPTY_PARAMS_TYPE('length=4'));
+SHOW CREATE TABLE t;
+DROP TABLE t;
+
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/t/extension_intrinsic_default.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_intrinsic_default.test
@@ -1,0 +1,32 @@
+# Scenario: intrinsic default values work end-to-end. A NOT NULL custom-type
+# column receiving NULL under INSERT IGNORE is filled with the type's intrinsic
+# default.
+#
+# Fixture: vsql_test_only exposes DEFAULT_STR_TYPE (intrinsic_default_str "(7)"),
+# DEFAULT_VDF_TYPE (intrinsic_default VDF returning "(9)"), and
+# DEFAULT_PARAM_TYPE (parameterized, intrinsic_default_str "(5)").
+
+INSTALL EXTENSION vsql_test_only;
+
+--echo # intrinsic_default_str: NULL under IGNORE becomes the literal default.
+CREATE TABLE t_str (id INT PRIMARY KEY, v DEFAULT_STR_TYPE NOT NULL);
+INSERT IGNORE INTO t_str VALUES (1, NULL);
+INSERT INTO t_str VALUES (2, '(42)');
+SELECT id, v FROM t_str ORDER BY id;
+DROP TABLE t_str;
+
+--echo # intrinsic_default VDF: NULL under IGNORE becomes the VDF-computed default.
+CREATE TABLE t_vdf (id INT PRIMARY KEY, v DEFAULT_VDF_TYPE NOT NULL);
+INSERT IGNORE INTO t_vdf VALUES (1, NULL);
+INSERT INTO t_vdf VALUES (2, '(42)');
+SELECT id, v FROM t_vdf ORDER BY id;
+DROP TABLE t_vdf;
+
+--echo # Parameterized type
+CREATE TABLE t_param (id INT PRIMARY KEY, v DEFAULT_PARAM_TYPE(3) NOT NULL);
+INSERT IGNORE INTO t_param VALUES (1, NULL);
+INSERT INTO t_param VALUES (2, '(42)');
+SELECT id, v FROM t_param ORDER BY id;
+DROP TABLE t_param;
+
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/t/extension_intrinsic_default_errors.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_intrinsic_default_errors.test
@@ -1,0 +1,20 @@
+# Scenario: intrinsic-default runtime error path.
+#
+# A type whose intrinsic default encodes to the wrong number of bytes is
+# rejected . Fixture: vsql_test_only exposes BAD_DEFAULT_LEN_TYPE,
+# whose intrinsic_default_str "SHORT" encodes to 2 bytes instead of
+# the declared persisted_length (4).
+#
+
+INSTALL EXTENSION vsql_test_only;
+
+--echo # A type whose intrinsic default encodes to the wrong length is rejected
+--echo # when the column's TypeContext is created.
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE TABLE t (id INT PRIMARY KEY, v BAD_DEFAULT_LEN_TYPE);
+
+--echo # No table was created.
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 't';
+
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/t/extension_length_bounds.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_length_bounds.test
@@ -1,0 +1,17 @@
+# Scenario: a parameterized type whose resolve_params resolves a persisted_length
+# larger than the declared max_persisted_length is rejected at DDL time.
+#
+# Fixture: vsql_test_only exposes OVERSIZED_PARAM_TYPE, whose resolve_params
+# returns 2 * max_persisted_length.
+
+INSTALL EXTENSION vsql_test_only;
+
+--echo # Parameterized type resolving beyond max_persisted_length -> DDL error.
+--error ER_PARSE_ERROR
+CREATE TABLE t (id INT PRIMARY KEY, v OVERSIZED_PARAM_TYPE(4));
+
+--echo # No table was created.
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 't';
+
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/t/extension_length_no_upper_bound.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_length_no_upper_bound.test
@@ -1,0 +1,23 @@
+# Scenario: A type may declare a storage size larger than MySQL's maximum column width;
+# it registers fine, but CREATE TABLE is rejected by MySQL's field-length limit
+# (VARBINARY caps at 65535 bytes).
+#
+# Fixture: vsql_test_only exposes HUGE_FIELD (fixed persisted_length 70000) and
+# HUGE_VAR (variable-length, max_persisted_length 70000).
+
+INSTALL EXTENSION vsql_test_only;
+
+--echo # A fixed type with an over-large persisted_length installs fine, but
+--echo # CREATE TABLE is rejected by MySQL's column-length limit.
+--error ER_TOO_BIG_FIELDLENGTH
+CREATE TABLE t (id INT PRIMARY KEY, v HUGE_FIELD);
+
+--echo # Same for a variable-length type with an over-large max_persisted_length.
+--error ER_TOO_BIG_FIELDLENGTH
+CREATE TABLE t (id INT PRIMARY KEY, v HUGE_VAR);
+
+--echo # No table was created.
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 't';
+
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/t/extension_param_key_handling.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_param_key_handling.test
@@ -1,0 +1,45 @@
+# Scenario: how unrecognized parameter keys are handled. The set of valid
+# parameter keys is entirely defined by the extension's resolve_params callback;
+# the server treats the parameter string as opaque. This test documents the two
+# reachable behaviors:
+#
+#   * A lenient resolve_params silently ignores an unknown key supplied in the
+#     parameter string (LENIENT_PARAM_TYPE). Because the unknown key cannot be
+#     reproduced by int_to_params, SHOW CREATE TABLE prints the long form.
+#   * A strict resolve_params rejects an unknown key (STRICT_PARAM_TYPE).
+#   * When int_to_params itself emits an extra key alongside the real one
+#     (EXTRA_KEY_PARAM_TYPE), the TYPE(N) form still round-trips through
+#     SHOW CREATE TABLE because int_to_params(N) reproduces the exact parameter
+#     set.
+#
+# Fixture: vsql_test_only exposes LENIENT_PARAM_TYPE, STRICT_PARAM_TYPE, and
+# EXTRA_KEY_PARAM_TYPE.
+
+INSTALL EXTENSION vsql_test_only;
+
+--echo # Lenient type: an unknown key in the parameter string is accepted and
+--echo # silently ignored by resolve_params.
+CREATE TABLE t_lenient (id INT PRIMARY KEY, v LENIENT_PARAM_TYPE('length=3,bogus=9'));
+--echo # The unknown key is preserved in the canonical parameters, so the long
+--echo # form is shown.
+SHOW CREATE TABLE t_lenient;
+DROP TABLE t_lenient;
+
+--echo # Strict type: an unknown key in the parameter string is rejected.
+--error ER_PARSE_ERROR
+CREATE TABLE t_strict (id INT PRIMARY KEY, v STRICT_PARAM_TYPE('length=4,bogus=1'));
+
+--echo # Strict type accepts the known key, via both the string and (N) forms.
+CREATE TABLE t_strict (id INT PRIMARY KEY, v STRICT_PARAM_TYPE('length=4'));
+SHOW CREATE TABLE t_strict;
+DROP TABLE t_strict;
+CREATE TABLE t_strict (id INT PRIMARY KEY, v STRICT_PARAM_TYPE(4));
+SHOW CREATE TABLE t_strict;
+DROP TABLE t_strict;
+
+--echo # int_to_params emits an extra 'bogus' key. SHOW CREATE doesn't show it.
+CREATE TABLE t_extra (id INT PRIMARY KEY, v EXTRA_KEY_PARAM_TYPE(3));
+SHOW CREATE TABLE t_extra;
+DROP TABLE t_extra;
+
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/t/extension_resolve_params_invalid_sizes.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_resolve_params_invalid_sizes.test
@@ -1,0 +1,39 @@
+# Scenario: resolve_params must resolve a persisted_length consistent with the
+# type's length kind. A fixed-length type must resolve to a concrete positive
+# footprint; a variable-length type sizes storage per value and must leave
+# persisted_length <= 0. PT_custom_type enforces both at DDL time.
+#
+# Fixtures (all in vsql_test_only):
+#   BAD_LEN_PARAM_TYPE  - fixed-length; resolve_params returns persisted_length
+#                         = -1 (must be > 0).
+#   VAR_SETS_PERSISTED  - variable-length; resolve_params returns a positive
+#                         persisted_length (must stay <= 0).
+#   BAD_DECODE_BUF      - resolve_params resolves a non-positive
+#                         max_decode_buffer_length (must be > 0).
+
+INSTALL EXTENSION vsql_test_only;
+
+--echo # Fixed-length, TYPE(N) shorthand: int_to_params succeeds, then
+--echo # resolve_params returns persisted_length = -1, rejected for a fixed type.
+--error ER_PARSE_ERROR
+CREATE TABLE t (id INT PRIMARY KEY, v BAD_LEN_PARAM_TYPE(4));
+
+--echo # Explicit parameter string: same resolve_params rejection.
+--error ER_PARSE_ERROR
+CREATE TABLE t (id INT PRIMARY KEY, v BAD_LEN_PARAM_TYPE('length=4'));
+
+--echo # Variable-length: resolve_params reports a positive persisted_length,
+--echo # which is rejected (variable-length types must leave it unset).
+--error ER_PARSE_ERROR
+CREATE TABLE t (id INT PRIMARY KEY, v VAR_SETS_PERSISTED(4));
+
+--echo # resolve_params resolves a non-positive max_decode_buffer_length, which
+--echo # is rejected (it sizes the decode scratch buffer and must be > 0).
+--error ER_PARSE_ERROR
+CREATE TABLE t (id INT PRIMARY KEY, v BAD_DECODE_BUF(4));
+
+--echo # No table was created.
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 't';
+
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/t/extension_resolve_params_rewrite.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_resolve_params_rewrite.test
@@ -1,0 +1,29 @@
+# Scenario: the mutating resolve_params overload can rewrite its parameter map,
+# and the server adopts the rewritten set as the canonical parameters. Here the
+# type removes (normalizes away) an unrecognized key.
+#
+# Fixture: vsql_test_only exposes DROP_PARAM_TYPE, whose (mutating) resolve_params
+# keeps 'length' and erases every other key.
+
+INSTALL EXTENSION vsql_test_only;
+
+--echo # An unrecognized key is dropped by resolve_params; the column is created
+--echo # with the reduced canonical parameters.
+CREATE TABLE t (id INT PRIMARY KEY, v DROP_PARAM_TYPE('length=4,bogus=9'));
+
+--echo # SHOW CREATE reflects the rewritten (reduced) params, not the input.
+--echo # 'bogus' is gone; only 'length' remains, so the short (N) form prints.
+SHOW CREATE TABLE t;
+
+--echo # The column round-trips a value.
+INSERT INTO t VALUES (1, '(3)');
+SELECT id, v FROM t ORDER BY id;
+DROP TABLE t;
+
+--echo # The (N) shorthand routes through int_to_params then resolve_params and
+--echo # yields the same canonical params.
+CREATE TABLE t2 (id INT PRIMARY KEY, v DROP_PARAM_TYPE(4));
+SHOW CREATE TABLE t2;
+DROP TABLE t2;
+
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/t/extension_type_builder_build_errors.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_type_builder_build_errors.test
@@ -1,0 +1,64 @@
+# Scenario: build() static_asserts catch missing/contradictory type-builder
+# configuration at COMPILE time, so the extension fails to build. Each case
+# below builds a throwaway extension and expects the
+# build to fail. The shared stub type-ops live in std_data/type_build_common.h,
+# copied next to each source so only the make_type(...) chain differs per case.
+
+--echo # A type without from_string() fails to build.
+--let $extension_name = type_missing_from_string
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_missing_from_string.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = from_string() is required before build()
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc
+
+--echo # A type without to_string() fails to build.
+--let $extension_name = type_missing_to_string
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_missing_to_string.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = to_string() is required before build()
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc
+
+--echo # A type with int_to_params() but no resolve_params() fails to build.
+--let $extension_name = int_to_params_no_resolve
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/int_to_params_no_resolve.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = resolve_params() is required when int_to_params()
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc
+
+--echo # A parameterized type (params<P>) without resolve_params() fails to build.
+--let $extension_name = params_no_resolve
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/params_no_resolve.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = resolve_params() is required when params<P>()
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc
+
+--echo # A variable-length type without max_persisted_length() fails to build.
+--let $extension_name = var_no_max_persisted
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/var_no_max_persisted.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = variable-length types must call
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc
+
+--echo # A variable-length type that also declares persisted_length() fails to
+--echo # build (the two are mutually exclusive).
+--let $extension_name = var_with_persisted
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/var_with_persisted.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = variable-length types must not
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc
+
+--echo # A type that sets both intrinsic_default_str and intrinsic_default_vdf
+--echo # fails to build (the two are mutually exclusive).
+--let $extension_name = both_intrinsic_defaults
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/both_intrinsic_defaults.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = intrinsic_default_str() and intrinsic_default_vdf()
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc
+
+--echo # A fixed, non-parameterized type that sets max_persisted_length fails to
+--echo # build (it is only valid for variable-length or parameterized types).
+--let $extension_name = fixed_with_max
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/fixed_with_max.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = max_persisted_length() is only valid for
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc

--- a/mysql-test/suite/villagesql/std_data/both_intrinsic_defaults.cc
+++ b/mysql-test/suite/villagesql/std_data/both_intrinsic_defaults.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a type that sets BOTH intrinsic_default_str and
+// intrinsic_default_vdf (mutually exclusive). build() must static_assert
+// "intrinsic_default_str() and intrinsic_default_vdf() ...". Only the make_type
+// chain matters; the op stubs live in type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "BOTH_DEFAULTS";
+
+// Both intrinsic default sources are set; build() must reject this.
+constexpr auto BOTH_DEFAULTS = make_type<kName>()
+                                   .persisted_length(8)
+                                   .max_decode_buffer_length(16)
+                                   .from_string<&tbc::stub_encode>()
+                                   .to_string<&tbc::stub_decode>()
+                                   .compare<&tbc::stub_compare>()
+                                   .intrinsic_default_str("")
+                                   .intrinsic_default_vdf("stub_default")
+                                   .build();
+
+VEF_GENERATE_ENTRY_POINTS(
+    make_extension()
+        .type(BOTH_DEFAULTS)
+        .func(make_intrinsic_default<&tbc::stub_default>("stub_default")))

--- a/mysql-test/suite/villagesql/std_data/fixed_with_max.cc
+++ b/mysql-test/suite/villagesql/std_data/fixed_with_max.cc
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a fixed, non-parameterized type that sets
+// max_persisted_length (only valid for variable-length or parameterized types).
+// build() must static_assert "max_persisted_length() is only valid for ...".
+// Only the make_type chain matters; the op stubs live in type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "FIXED_MAX";
+
+// Fixed footprint + max_persisted_length, but neither variable-length nor
+// parameterized; build() must reject this.
+constexpr auto FIXED_MAX = make_type<kName>()
+                               .persisted_length(16)
+                               .max_decode_buffer_length(16)
+                               .max_persisted_length(8)
+                               .from_string<&tbc::stub_encode>()
+                               .to_string<&tbc::stub_decode>()
+                               .compare<&tbc::stub_compare>()
+                               .build();
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(FIXED_MAX))

--- a/mysql-test/suite/villagesql/std_data/int_to_params_no_resolve.cc
+++ b/mysql-test/suite/villagesql/std_data/int_to_params_no_resolve.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a parameterized type with int_to_params() but no
+// resolve_params(). build() must static_assert "resolve_params() is required
+// when int_to_params() is used". Only the make_type chain matters; the op
+// stubs live in type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "INT_TO_PARAMS_NO_RESOLVE";
+
+// .resolve_params<>() is deliberately omitted.
+constexpr auto INT_TO_PARAMS_NO_RESOLVE =
+    make_type<kName>()
+        .persisted_length(-1)
+        .max_decode_buffer_length(16)
+        .max_persisted_length(16)
+        .params<tbc::LenParam, &tbc::LenParam::parse,
+                &tbc::LenParam::to_strings>()
+        .int_to_params<&tbc::stub_int_to_params>()
+        .from_string<&tbc::stub_param_encode>()
+        .to_string<&tbc::stub_param_decode>()
+        .compare<&tbc::stub_param_compare>()
+        .build();
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(INT_TO_PARAMS_NO_RESOLVE))

--- a/mysql-test/suite/villagesql/std_data/params_no_resolve.cc
+++ b/mysql-test/suite/villagesql/std_data/params_no_resolve.cc
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a parameterized type declares params<P>() but no
+// resolve_params() (and no int_to_params()). A parameterized type must provide
+// a resolver, so build() must static_assert "resolve_params() is required when
+// params<P>() is used". Only the make_type chain matters; the op stubs live in
+// type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "PARAMS_NO_RESOLVE";
+
+// .resolve_params<>() is deliberately omitted.
+constexpr auto PARAMS_NO_RESOLVE =
+    make_type<kName>()
+        .max_persisted_length(16)
+        .params<tbc::LenParam, &tbc::LenParam::parse,
+                &tbc::LenParam::to_strings>()
+        .from_string<&tbc::stub_param_encode>()
+        .to_string<&tbc::stub_param_decode>()
+        .compare<&tbc::stub_param_compare>()
+        .build();
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(PARAMS_NO_RESOLVE))

--- a/mysql-test/suite/villagesql/std_data/type_build_common.h
+++ b/mysql-test/suite/villagesql/std_data/type_build_common.h
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Shared stub type-op functions for the build-error test extensions.
+// the op bodies are irrelevant to what is under test, so they are
+// defined once here.
+
+#ifndef VILLAGESQL_TEST_STD_DATA_TYPE_BUILD_COMMON_H
+#define VILLAGESQL_TEST_STD_DATA_TYPE_BUILD_COMMON_H
+
+#include <villagesql/vsql.h>
+
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <string>
+#include <string_view>
+
+namespace tbc {
+
+constexpr int64_t kStubSize = 8;
+
+// ---- Non-parameterized ops ----------------------------------------------
+inline void stub_encode(std::string_view /*from*/, vsql::CustomResult out) {
+  auto buf = out.buffer();
+  if (buf.empty()) return;
+  memset(buf.data(), 0, buf.size());
+  out.set_length(buf.size());
+}
+
+inline void stub_decode(vsql::CustomArg /*in*/, vsql::StringResult out) {
+  out.set("");
+}
+
+inline int stub_compare(vsql::CustomArg a, vsql::CustomArg b) {
+  auto va = a.value();
+  auto vb = b.value();
+  size_t n = va.size() < vb.size() ? va.size() : vb.size();
+  return memcmp(va.data(), vb.data(), n);
+}
+
+// ---- Intrinsic-default VDF ------------------------------------------------
+inline std::string stub_default(char * /*error_msg*/) { return ""; }
+
+// ---- Parameterized ('length') ops ----------------------------------------
+struct LenParam {
+  int64_t length;
+
+  static LenParam parse(const std::map<std::string, std::string> &params) {
+    auto it = params.find("length");
+    return LenParam{it == params.end() ? 0 : std::stoll(it->second)};
+  }
+
+  static void to_strings(const LenParam &p,
+                         std::map<std::string, std::string> &out) {
+    out["length"] = std::to_string(p.length);
+  }
+};
+
+inline void stub_param_encode(vsql::MaybeParams<LenParam> & /*params*/,
+                              std::string_view /*from*/,
+                              vsql::CustomResult out) {
+  auto buf = out.buffer();
+  if (buf.empty()) return;
+  out.set_length(buf.size());
+}
+
+inline void stub_param_decode(vsql::CustomArgWith<LenParam> /*in*/,
+                              vsql::StringResult out) {
+  out.set_length(0);
+}
+
+inline int stub_param_compare(vsql::CustomArgWith<LenParam>,
+                              vsql::CustomArgWith<LenParam>) {
+  return 0;
+}
+
+inline bool stub_int_to_params(int64_t value,
+                               std::map<std::string, std::string> &params,
+                               char *) {
+  params["length"] = std::to_string(value);
+  return false;
+}
+
+inline bool stub_resolve_params(const std::map<std::string, std::string> &,
+                                vsql::ResolvedTypeParams *result, char *) {
+  result->persisted_length = kStubSize;
+  result->max_decode_buffer_length = 16;
+  return false;
+}
+
+}  // namespace tbc
+
+#endif  // VILLAGESQL_TEST_STD_DATA_TYPE_BUILD_COMMON_H

--- a/mysql-test/suite/villagesql/std_data/type_missing_from_string.cc
+++ b/mysql-test/suite/villagesql/std_data/type_missing_from_string.cc
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a type that omits from_string(). build() must
+// static_assert "from_string() is required before build()". Only the make_type
+// chain matters; the op stubs live in type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "MISSING_FROM_STRING";
+
+// .from_string<>() is deliberately omitted.
+constexpr auto MISSING_FROM_STRING = make_type<kName>()
+                                         .persisted_length(8)
+                                         .max_decode_buffer_length(8)
+                                         .to_string<&tbc::stub_decode>()
+                                         .compare<&tbc::stub_compare>()
+                                         .build();
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(MISSING_FROM_STRING))

--- a/mysql-test/suite/villagesql/std_data/type_missing_to_string.cc
+++ b/mysql-test/suite/villagesql/std_data/type_missing_to_string.cc
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a type that omits to_string(). build() must static_assert
+// "to_string() is required before build()". Only the make_type chain matters;
+// the op stubs live in type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "MISSING_TO_STRING";
+
+// .to_string<>() is deliberately omitted.
+constexpr auto MISSING_TO_STRING = make_type<kName>()
+                                       .persisted_length(8)
+                                       .max_decode_buffer_length(8)
+                                       .from_string<&tbc::stub_encode>()
+                                       .compare<&tbc::stub_compare>()
+                                       .build();
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(MISSING_TO_STRING))

--- a/mysql-test/suite/villagesql/std_data/var_no_max_persisted.cc
+++ b/mysql-test/suite/villagesql/std_data/var_no_max_persisted.cc
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a variable-length type that omits max_persisted_length().
+// build() must static_assert "variable-length types must call
+// .max_persisted_length(N)". Only the make_type chain matters; the op stubs
+// live in type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "VAR_NO_MAX";
+
+// .max_persisted_length() is deliberately omitted for a variable-length type.
+constexpr auto VAR_NO_MAX = make_type<kName>()
+                                .variable_length_type()
+                                .max_decode_buffer_length(16)
+                                .from_string<&tbc::stub_encode>()
+                                .to_string<&tbc::stub_decode>()
+                                .compare<&tbc::stub_compare>()
+                                .build();
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(VAR_NO_MAX))

--- a/mysql-test/suite/villagesql/std_data/var_with_persisted.cc
+++ b/mysql-test/suite/villagesql/std_data/var_with_persisted.cc
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a variable-length type that also declares
+// persisted_length() (mutually exclusive). build() must static_assert
+// "variable-length types must not ...". Only the make_type chain matters; the
+// op stubs live in type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "VAR_WITH_PERSISTED";
+
+// variable_length_type() with persisted_length() is contradictory.
+constexpr auto VAR_WITH_PERSISTED = make_type<kName>()
+                                        .variable_length_type()
+                                        .persisted_length(16)
+                                        .max_decode_buffer_length(16)
+                                        .max_persisted_length(32)
+                                        .from_string<&tbc::stub_encode>()
+                                        .to_string<&tbc::stub_decode>()
+                                        .compare<&tbc::stub_compare>()
+                                        .build();
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(VAR_WITH_PERSISTED))

--- a/unittest/gunit/villagesql/type_builder-t.cc
+++ b/unittest/gunit/villagesql/type_builder-t.cc
@@ -68,6 +68,10 @@ static int params_compare(vsql::CustomArgWith<TestParams>,
   return 0;
 }
 static size_t params_hash(vsql::CustomArgWith<TestParams>) { return 0; }
+static bool params_resolve(const std::map<std::string, std::string> &,
+                           vsql::ResolvedTypeParams *, char *) {
+  return false;
+}
 
 static constexpr const char kPlainName[] = "TESTPLAIN";
 static constexpr const char kParamsName[] = "TESTPARAMS";
@@ -172,6 +176,7 @@ TEST_F(TypeBuilderTest, ParameterizedBuildsCorrectly) {
       vsql::make_type<kParamsName>()
           .max_persisted_length(128)
           .params<TestParams, &TestParams::parse, &TestParams::to_strings>()
+          .resolve_params<&params_resolve>()
           .from_string<&params_encode>()
           .to_string<&params_decode>()
           .compare<&params_compare>()
@@ -188,6 +193,7 @@ TEST_F(TypeBuilderTest, ParameterizedWithHash) {
       vsql::make_type<kParamsName>()
           .max_persisted_length(128)
           .params<TestParams, &TestParams::parse, &TestParams::to_strings>()
+          .resolve_params<&params_resolve>()
           .from_string<&params_encode>()
           .to_string<&params_decode>()
           .compare<&params_compare>()
@@ -204,6 +210,7 @@ TEST_F(TypeBuilderTest, ParameterizedOperationsAnyOrder) {
       vsql::make_type<kParamsName>()
           .max_persisted_length(128)
           .params<TestParams, &TestParams::parse, &TestParams::to_strings>()
+          .resolve_params<&params_resolve>()
           .compare<&params_compare>()
           .to_string<&params_decode>()
           .from_string<&params_encode>()

--- a/villagesql/sdk/include/villagesql/vsql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/type_builder.h
@@ -125,12 +125,19 @@ template <bool HasFromString = false, bool HasToString = false,
           bool HasCompare = false, typename ParamsType = void,
           bool HasIntToParams = false, bool HasResolveParams = false,
           bool HasMaxPersistedLength = false, bool HasVariableLength = false,
-          typename EFT = std::tuple<>, const char *Name = nullptr>
+          bool HasPersistedLength = false, bool HasIntrinsicDefaultStr = false,
+          bool HasIntrinsicDefaultVdf = false, typename EFT = std::tuple<>,
+          const char *Name = nullptr>
 class TypeBuilder {
  public:
-  constexpr TypeBuilder &persisted_length(int64_t len) {
-    state_.desc.vef_desc.persisted_length = len;
-    return *this;
+  constexpr auto persisted_length(int64_t len) const {
+    detail::TypeBuilderState s = state_;
+    s.desc.vef_desc.persisted_length = len;
+    return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType,
+                       HasIntToParams, HasResolveParams, HasMaxPersistedLength,
+                       HasVariableLength, /*HasPersistedLength=*/true,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf, EFT,
+                       Name>{s, embedded_funcs_};
   }
 
   constexpr TypeBuilder &max_decode_buffer_length(int64_t len) {
@@ -152,8 +159,9 @@ class TypeBuilder {
     require_atleast_min(s.desc.vef_desc.protocol, VEF_PROTOCOL_4);
     return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType,
                        HasIntToParams, HasResolveParams, HasMaxPersistedLength,
-                       /*HasVariableLength=*/true, EFT, Name>{s,
-                                                              embedded_funcs_};
+                       /*HasVariableLength=*/true, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf, EFT,
+                       Name>{s, embedded_funcs_};
   }
 
   // Upper bound on persisted_length across all valid parameterizations.
@@ -173,8 +181,9 @@ class TypeBuilder {
     require_atleast_min(s.desc.vef_desc.protocol, VEF_PROTOCOL_3);
     return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType,
                        HasIntToParams, HasResolveParams,
-                       /*HasMaxPersistedLength=*/true, HasVariableLength, EFT,
-                       Name>{s, embedded_funcs_};
+                       /*HasMaxPersistedLength=*/true, HasVariableLength,
+                       HasPersistedLength, HasIntrinsicDefaultStr,
+                       HasIntrinsicDefaultVdf, EFT, Name>{s, embedded_funcs_};
   }
 
   // -------------------------------------------------------------------------
@@ -211,7 +220,9 @@ class TypeBuilder {
     require_atleast_min(s.desc.vef_desc.protocol, VEF_PROTOCOL_3);
     return TypeBuilder<HasFromString, HasToString, HasCompare, P,
                        HasIntToParams, HasResolveParams, HasMaxPersistedLength,
-                       HasVariableLength, EFT, Name>{s, embedded_funcs_};
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf, EFT,
+                       Name>{s, embedded_funcs_};
   }
 
   // int_to_params: VDF that converts MYTYPE(N) integer to a params string.
@@ -234,8 +245,9 @@ class TypeBuilder {
     auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
     return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType, true,
                        HasResolveParams, HasMaxPersistedLength,
-                       HasVariableLength, decltype(new_embedded), Name>{
-        s, new_embedded};
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf,
+                       decltype(new_embedded), Name>{s, new_embedded};
   }
 
   // resolve_params: VDF that validates params and computes storage sizes.
@@ -272,8 +284,9 @@ class TypeBuilder {
     auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
     return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType,
                        HasIntToParams, true, HasMaxPersistedLength,
-                       HasVariableLength, decltype(new_embedded), Name>{
-        s, new_embedded};
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf,
+                       decltype(new_embedded), Name>{s, new_embedded};
   }
 
   // -------------------------------------------------------------------------
@@ -304,8 +317,9 @@ class TypeBuilder {
     auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
     return TypeBuilder<true, HasToString, HasCompare, ParamsType,
                        HasIntToParams, HasResolveParams, HasMaxPersistedLength,
-                       HasVariableLength, decltype(new_embedded), Name>{
-        s, new_embedded};
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf,
+                       decltype(new_embedded), Name>{s, new_embedded};
   }
 
   template <auto Func>
@@ -328,8 +342,9 @@ class TypeBuilder {
     auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
     return TypeBuilder<HasFromString, true, HasCompare, ParamsType,
                        HasIntToParams, HasResolveParams, HasMaxPersistedLength,
-                       HasVariableLength, decltype(new_embedded), Name>{
-        s, new_embedded};
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf,
+                       decltype(new_embedded), Name>{s, new_embedded};
   }
 
   template <auto Func>
@@ -352,8 +367,9 @@ class TypeBuilder {
     auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
     return TypeBuilder<HasFromString, HasToString, true, ParamsType,
                        HasIntToParams, HasResolveParams, HasMaxPersistedLength,
-                       HasVariableLength, decltype(new_embedded), Name>{
-        s, new_embedded};
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf,
+                       decltype(new_embedded), Name>{s, new_embedded};
   }
 
   template <auto Func>
@@ -375,8 +391,9 @@ class TypeBuilder {
     auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
     return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType,
                        HasIntToParams, HasResolveParams, HasMaxPersistedLength,
-                       HasVariableLength, decltype(new_embedded), Name>{
-        s, new_embedded};
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf,
+                       decltype(new_embedded), Name>{s, new_embedded};
   }
 
   // intrinsic_default_str: literal string representation of the default value
@@ -384,10 +401,15 @@ class TypeBuilder {
   // type). The server encodes it via the type's from_string VDF at first use of
   // the type. Use intrinsic_default_vdf() instead when the default must be
   // computed.
-  constexpr TypeBuilder &intrinsic_default_str(const char *str) {
-    state_.desc.vef_desc.intrinsic_default_str = str;
-    require_atleast_min(state_.desc.vef_desc.protocol, VEF_PROTOCOL_3);
-    return *this;
+  constexpr auto intrinsic_default_str(const char *str) const {
+    detail::TypeBuilderState s = state_;
+    s.desc.vef_desc.intrinsic_default_str = str;
+    require_atleast_min(s.desc.vef_desc.protocol, VEF_PROTOCOL_3);
+    return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType,
+                       HasIntToParams, HasResolveParams, HasMaxPersistedLength,
+                       HasVariableLength, HasPersistedLength,
+                       /*HasIntrinsicDefaultStr=*/true, HasIntrinsicDefaultVdf,
+                       EFT, Name>{s, embedded_funcs_};
   }
 
   // intrinsic_default_vdf: name of a separately-registered VDF that writes the
@@ -396,10 +418,15 @@ class TypeBuilder {
   //
   // TODO(villagesql-beta): embed intrinsic_default inline once the vsql API
   // supports auto-generating its VDF name too.
-  constexpr TypeBuilder &intrinsic_default_vdf(const char *vdf_name) {
-    state_.desc.vef_desc.intrinsic_default_vdf_name = vdf_name;
-    require_atleast_min(state_.desc.vef_desc.protocol, VEF_PROTOCOL_3);
-    return *this;
+  constexpr auto intrinsic_default_vdf(const char *vdf_name) const {
+    detail::TypeBuilderState s = state_;
+    s.desc.vef_desc.intrinsic_default_vdf_name = vdf_name;
+    require_atleast_min(s.desc.vef_desc.protocol, VEF_PROTOCOL_3);
+    return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType,
+                       HasIntToParams, HasResolveParams, HasMaxPersistedLength,
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, /*HasIntrinsicDefaultVdf=*/true,
+                       EFT, Name>{s, embedded_funcs_};
   }
 
   // -------------------------------------------------------------------------
@@ -421,6 +448,19 @@ class TypeBuilder {
                   "vsql::TypeBuilder: params<P, &parse_fn>() is required when "
                   "resolve_params() is used");
     static_assert(
+        std::is_void_v<ParamsType> || HasResolveParams,
+        "vsql::TypeBuilder: resolve_params() is required when params<P>() is "
+        "used — a parameterized type must declare a resolver; int_to_params() "
+        "is the optional TYPE(N) shorthand.");
+    static_assert(
+        !HasIntToParams || HasResolveParams,
+        "vsql::TypeBuilder: resolve_params() is required when int_to_params() "
+        "is used — int_to_params() only converts the TYPE(N) shorthand into a "
+        "parameter string, while resolve_params() is the gate that validates "
+        "the parameters and resolves the storage size. Without "
+        "resolve_params() "
+        "the type is not parameterized and the length can never be resolved.");
+    static_assert(
         std::is_void_v<ParamsType> || HasMaxPersistedLength,
         "vsql::TypeBuilder: parameterized types must call "
         ".max_persisted_length(N) before build() — required so constant-string "
@@ -431,18 +471,34 @@ class TypeBuilder {
         "vsql::TypeBuilder: variable-length types must call "
         ".max_persisted_length(N) before build() — required so the server can "
         "allocate a buffer for the backing field.");
+    static_assert(
+        !HasMaxPersistedLength || HasVariableLength || HasResolveParams,
+        "vsql::TypeBuilder: max_persisted_length() is only valid for "
+        "variable-length or parameterized types; a fixed non-parameterized "
+        "type must not set it.");
+    static_assert(
+        !(HasVariableLength && HasPersistedLength),
+        "vsql::TypeBuilder: variable-length types must not declare a "
+        "persisted_length() — their size is decided per value; declare only "
+        "max_persisted_length().");
+    static_assert(
+        !(HasIntrinsicDefaultStr && HasIntrinsicDefaultVdf),
+        "vsql::TypeBuilder: intrinsic_default_str() and "
+        "intrinsic_default_vdf() "
+        "are mutually exclusive — a type may declare at most one intrinsic "
+        "default source.");
     return TypeObject<EFT>{state_.desc, embedded_funcs_, state_.params_init_fn,
                            state_.params_to_strings_init_fn};
   }
 
   // Cross-specialization and make_type access.
-  template <bool, bool, bool, typename, bool, bool, bool, bool, typename,
-            const char *>
+  template <bool, bool, bool, typename, bool, bool, bool, bool, bool, bool,
+            bool, typename, const char *>
   friend class TypeBuilder;
 
   template <const char *N>
   friend constexpr TypeBuilder<false, false, false, void, false, false, false,
-                               false, std::tuple<>, N>
+                               false, false, false, false, std::tuple<>, N>
   make_type();
 
  private:
@@ -471,13 +527,13 @@ class TypeBuilder {
 
 template <const char *Name>
 constexpr TypeBuilder<false, false, false, void, false, false, false, false,
-                      std::tuple<>, Name>
+                      false, false, false, std::tuple<>, Name>
 make_type() {
   detail::TypeBuilderState s{};
   s.desc.vef_desc.name = Name;
   s.desc.vef_desc.protocol = VEF_PROTOCOL_1;
   return TypeBuilder<false, false, false, void, false, false, false, false,
-                     std::tuple<>, Name>{s};
+                     false, false, false, std::tuple<>, Name>{s};
 }
 
 }  // namespace vsql

--- a/villagesql/test-extensions/CMakeLists.txt
+++ b/villagesql/test-extensions/CMakeLists.txt
@@ -42,6 +42,10 @@ vsql_add_test_extension(vsql-bitfield-test             vsql_bitfield_test)
 vsql_add_test_extension(vsql-tarray-test               vsql_tarray_test)
 vsql_add_test_extension(vsql-resolve-only-test         vsql_resolve_only_test)
 
+# Bad-registration test: an extension that registers two types with the same
+# name -- rejected at INSTALL EXTENSION.
+vsql_add_test_extension(vsql-dup-type-test             vsql_dup_type_test)
+
 # update_test installable + three target variants exercise the pre-checks
 # of the extension version-update path. The VEB filename is
 # update_test-<version>.veb; the manifest inside each variant carries the

--- a/villagesql/test-extensions/vsql-dup-type-test/manifest.json
+++ b/villagesql/test-extensions/vsql-dup-type-test/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "vsql_dup_type_test",
+  "version": "0.0.1",
+  "description": "Bad-registration test: an extension that registers two types with the same name. INSTALL EXTENSION must fail.",
+  "author": "VillageSQL Community",
+  "license": "GPL-2.0"
+}

--- a/villagesql/test-extensions/vsql-dup-type-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-dup-type-test/src/extension.cc
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+// Bad-registration test extension: registers two types with the SAME name
+// ("DUP_TYPE"). The two names live in distinct NTTP constants so each type has
+// its own VDF-name buffers, but the name strings collide, so registration must
+// reject the extension at INSTALL EXTENSION time.
+
+#include <villagesql/vsql.h>
+
+#include <cstdint>
+#include <cstring>
+#include <string_view>
+
+constexpr int64_t kDupSize = 8;
+
+void dup_encode(std::string_view /*from*/, vsql::CustomResult out) {
+  auto buf = out.buffer();
+  if (buf.size() < static_cast<size_t>(kDupSize)) return;
+  memset(buf.data(), 0, kDupSize);
+  out.set_length(static_cast<size_t>(kDupSize));
+}
+
+void dup_decode(vsql::CustomArg /*in*/, vsql::StringResult out) { out.set(""); }
+
+int dup_compare(vsql::CustomArg a, vsql::CustomArg b) {
+  auto va = a.value();
+  auto vb = b.value();
+  size_t n = va.size() < vb.size() ? va.size() : vb.size();
+  return memcmp(va.data(), vb.data(), n);
+}
+
+// Two distinct NTTP constants holding the same type name.
+static constexpr const char kDupName1[] = "DUP_TYPE";
+static constexpr const char kDupName2[] = "DUP_TYPE";
+
+constexpr auto DUP_TYPE_1 = vsql::make_type<kDupName1>()
+                                .persisted_length(kDupSize)
+                                .max_decode_buffer_length(kDupSize)
+                                .from_string<&dup_encode>()
+                                .to_string<&dup_decode>()
+                                .compare<&dup_compare>()
+                                .build();
+
+constexpr auto DUP_TYPE_2 = vsql::make_type<kDupName2>()
+                                .persisted_length(kDupSize)
+                                .max_decode_buffer_length(kDupSize)
+                                .from_string<&dup_encode>()
+                                .to_string<&dup_decode>()
+                                .compare<&dup_compare>()
+                                .build();
+
+using namespace vsql;
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(DUP_TYPE_1).type(DUP_TYPE_2))

--- a/villagesql/test-extensions/vsql-test-only/src/extension.cc
+++ b/villagesql/test-extensions/vsql-test-only/src/extension.cc
@@ -71,6 +71,25 @@
 //                sizing for SQL-callable decode VDFs (e.g. T::to_string),
 //                where the output size scales with the input column's
 //                max_decode_buffer_length.
+//
+//   Parameter-validation edge-case types (see block comment further down):
+//     BAD_LEN_PARAM_TYPE(N), EMPTY_PARAMS_TYPE(N), LENIENT_PARAM_TYPE(N),
+//     STRICT_PARAM_TYPE(N), EXTRA_KEY_PARAM_TYPE(N).
+//
+//   Intrinsic-default test types (see block comment further down):
+//     DEFAULT_STR_TYPE, DEFAULT_VDF_TYPE, DEFAULT_PARAM_TYPE(N),
+//     BAD_DEFAULT_LEN_TYPE.
+//
+//   Parameter-bound and rewrite test types (see block comment further down):
+//     OVERSIZED_PARAM_TYPE(N), DROP_PARAM_TYPE(N).
+//
+//   Over-large storage-size test types (see block comment further down):
+//     HUGE_FIELD, HUGE_VAR.
+//
+//   VAR_SETS_PERSISTED(N) - variable-length type whose resolve_params wrongly
+//     reports a positive persisted_length (rejected at DDL time).
+//   BAD_DECODE_BUF(N) - resolve_params resolves a non-positive
+//     max_decode_buffer_length (rejected at DDL time).
 
 #include <villagesql/vsql.h>
 
@@ -685,6 +704,564 @@ constexpr auto PVEC =
         .compare<&pvec_compare>()
         .build();
 
+// ---- Parameter-validation edge-case types -------------------------------
+//
+// The following fixed-length parameterized types exist solely to drive the
+// error/edge branches of PT_custom_type's parameter-resolution gates. They
+// share a 4-byte storage layout and a single 'length' parameter; each varies
+// only in how its int_to_params/resolve_params callbacks (mis)behave.
+//
+//   BAD_LEN_PARAM_TYPE(N)   - resolve_params returns persisted_length = -1 for
+//   a
+//                             fixed-length type; every DDL use is rejected.
+//   EMPTY_PARAMS_TYPE(N)    - int_to_params reports success but adds no params;
+//                             the (N) form resolves to an empty parameter
+//                             string.
+//   LENIENT_PARAM_TYPE(N)   - resolve_params ignores unrecognized keys, so an
+//                             extra key in the parameter string is accepted.
+//   STRICT_PARAM_TYPE(N)    - resolve_params rejects any unrecognized key.
+//   EXTRA_KEY_PARAM_TYPE(N) - int_to_params emits an extra key alongside the
+//                             real one; used to check the (N) round-trip.
+
+constexpr int64_t kParamTestSize = 4;
+
+struct LenParam {
+  int64_t length;
+
+  static LenParam parse(const std::map<std::string, std::string> &params) {
+    auto it = params.find("length");
+    return LenParam{it == params.end() ? 0 : std::stoll(it->second)};
+  }
+
+  static void to_strings(const LenParam &p,
+                         std::map<std::string, std::string> &out) {
+    out["length"] = std::to_string(p.length);
+  }
+};
+
+// Working 4-byte codec shared by the parameter-validation types. Text form is
+// "(N)"; the empty string encodes to all-zeros so the types have a usable
+// intrinsic default and their columns can be created.
+void param_test_encode(vsql::MaybeParams<LenParam> &params,
+                       std::string_view from, vsql::CustomResult out) {
+  if (!params.is_known()) params.set(LenParam{kParamTestSize});
+  auto buf = out.buffer();
+  if (buf.size() < static_cast<size_t>(kParamTestSize)) return;
+  memset(buf.data(), 0, kParamTestSize);
+  unsigned int nn = 0;
+  if (!from.empty()) {
+    char tmp[64];
+    size_t copy = from.size() < sizeof(tmp) - 1 ? from.size() : sizeof(tmp) - 1;
+    memcpy(tmp, from.data(), copy);
+    tmp[copy] = '\0';
+    if (sscanf(tmp, "(%u)", &nn) != 1) return;  // encode failure
+  }
+  buf[0] = static_cast<unsigned char>(nn);
+  out.set_length(static_cast<size_t>(kParamTestSize));
+}
+
+void param_test_decode(vsql::CustomArgWith<LenParam> in,
+                       vsql::StringResult out) {
+  auto data = in.value();
+  if (data.size() < static_cast<size_t>(kParamTestSize)) return;
+  auto buf = out.buffer();
+  int written = snprintf(buf.data(), buf.size(), "(%u)", data[0]);
+  if (written < 0) return;
+  out.set_length(static_cast<size_t>(written));
+}
+
+int param_test_compare(vsql::CustomArgWith<LenParam>,
+                       vsql::CustomArgWith<LenParam>) {
+  return 0;
+}
+
+// BAD_LEN_PARAM_TYPE: resolve_params deliberately reports an invalid
+// persisted_length (-1) for a fixed-length type.
+bool bad_len_int_to_params(int64_t value,
+                           std::map<std::string, std::string> &params, char *) {
+  params["length"] = std::to_string(value);
+  return false;
+}
+
+bool bad_len_resolve_params(const std::map<std::string, std::string> &,
+                            vsql::ResolvedTypeParams *result, char *) {
+  result->persisted_length = -1;  // invalid for a fixed-length type
+  result->max_decode_buffer_length = 16;
+  return false;
+}
+
+// EMPTY_PARAMS_TYPE: int_to_params succeeds but adds nothing to the map.
+bool empty_int_to_params(int64_t, std::map<std::string, std::string> &,
+                         char *) {
+  return false;  // success, but params stays empty
+}
+
+bool empty_resolve_params(const std::map<std::string, std::string> &params,
+                          vsql::ResolvedTypeParams *result, char *error_msg) {
+  auto it = params.find("length");
+  if (it == params.end()) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN, "EMPTY_PARAMS_TYPE requires length");
+    return true;
+  }
+  result->persisted_length = kParamTestSize;
+  result->max_decode_buffer_length = 16;
+  return false;
+}
+
+// LENIENT_PARAM_TYPE: resolve_params reads only 'length' and silently ignores
+// any other key.
+bool lenient_int_to_params(int64_t value,
+                           std::map<std::string, std::string> &params, char *) {
+  params["length"] = std::to_string(value);
+  return false;
+}
+
+bool lenient_resolve_params(const std::map<std::string, std::string> &params,
+                            vsql::ResolvedTypeParams *result, char *error_msg) {
+  auto it = params.find("length");
+  if (it == params.end()) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "LENIENT_PARAM_TYPE requires length");
+    return true;
+  }
+  result->persisted_length = kParamTestSize;
+  result->max_decode_buffer_length = 16;
+  return false;
+}
+
+// STRICT_PARAM_TYPE: resolve_params rejects any key other than 'length'.
+bool strict_int_to_params(int64_t value,
+                          std::map<std::string, std::string> &params, char *) {
+  params["length"] = std::to_string(value);
+  return false;
+}
+
+bool strict_resolve_params(const std::map<std::string, std::string> &params,
+                           vsql::ResolvedTypeParams *result, char *error_msg) {
+  for (const auto &kv : params) {
+    if (kv.first != "length") {
+      snprintf(error_msg, VEF_MAX_ERROR_LEN,
+               "STRICT_PARAM_TYPE: unknown parameter '%s'", kv.first.c_str());
+      return true;
+    }
+  }
+  if (params.find("length") == params.end()) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN, "STRICT_PARAM_TYPE requires length");
+    return true;
+  }
+  result->persisted_length = kParamTestSize;
+  result->max_decode_buffer_length = 16;
+  return false;
+}
+
+// EXTRA_KEY_PARAM_TYPE: int_to_params emits an extra 'bogus' key alongside the
+// real 'length' key.
+bool extra_key_int_to_params(int64_t value,
+                             std::map<std::string, std::string> &params,
+                             char *) {
+  params["length"] = std::to_string(value);
+  params["bogus"] = "1";
+  return false;
+}
+
+bool extra_key_resolve_params(const std::map<std::string, std::string> &params,
+                              vsql::ResolvedTypeParams *result,
+                              char *error_msg) {
+  auto it = params.find("length");
+  if (it == params.end()) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "EXTRA_KEY_PARAM_TYPE requires length");
+    return true;
+  }
+  result->persisted_length = kParamTestSize;
+  result->max_decode_buffer_length = 16;
+  return false;
+}
+
+static constexpr const char kBadLenParamTypeName[] = "BAD_LEN_PARAM_TYPE";
+static constexpr const char kEmptyParamsTypeName[] = "EMPTY_PARAMS_TYPE";
+static constexpr const char kLenientParamTypeName[] = "LENIENT_PARAM_TYPE";
+static constexpr const char kStrictParamTypeName[] = "STRICT_PARAM_TYPE";
+static constexpr const char kExtraKeyParamTypeName[] = "EXTRA_KEY_PARAM_TYPE";
+
+constexpr auto BAD_LEN_PARAM_TYPE =
+    vsql::make_type<kBadLenParamTypeName>()
+        .persisted_length(-1)
+        .max_decode_buffer_length(16)
+        .max_persisted_length(kParamTestSize)
+        .params<LenParam, &LenParam::parse, &LenParam::to_strings>()
+        .int_to_params<&bad_len_int_to_params>()
+        .resolve_params<&bad_len_resolve_params>()
+        .from_string<&param_test_encode>()
+        .to_string<&param_test_decode>()
+        .compare<&param_test_compare>()
+        .build();
+
+constexpr auto EMPTY_PARAMS_TYPE =
+    vsql::make_type<kEmptyParamsTypeName>()
+        .persisted_length(-1)
+        .max_decode_buffer_length(16)
+        .max_persisted_length(kParamTestSize)
+        .params<LenParam, &LenParam::parse, &LenParam::to_strings>()
+        .int_to_params<&empty_int_to_params>()
+        .resolve_params<&empty_resolve_params>()
+        .from_string<&param_test_encode>()
+        .to_string<&param_test_decode>()
+        .compare<&param_test_compare>()
+        .build();
+
+constexpr auto LENIENT_PARAM_TYPE =
+    vsql::make_type<kLenientParamTypeName>()
+        .persisted_length(-1)
+        .max_decode_buffer_length(16)
+        .max_persisted_length(kParamTestSize)
+        .params<LenParam, &LenParam::parse, &LenParam::to_strings>()
+        .int_to_params<&lenient_int_to_params>()
+        .resolve_params<&lenient_resolve_params>()
+        .from_string<&param_test_encode>()
+        .to_string<&param_test_decode>()
+        .compare<&param_test_compare>()
+        .build();
+
+constexpr auto STRICT_PARAM_TYPE =
+    vsql::make_type<kStrictParamTypeName>()
+        .persisted_length(-1)
+        .max_decode_buffer_length(16)
+        .max_persisted_length(kParamTestSize)
+        .params<LenParam, &LenParam::parse, &LenParam::to_strings>()
+        .int_to_params<&strict_int_to_params>()
+        .resolve_params<&strict_resolve_params>()
+        .from_string<&param_test_encode>()
+        .to_string<&param_test_decode>()
+        .compare<&param_test_compare>()
+        .build();
+
+constexpr auto EXTRA_KEY_PARAM_TYPE =
+    vsql::make_type<kExtraKeyParamTypeName>()
+        .persisted_length(-1)
+        .max_decode_buffer_length(16)
+        .max_persisted_length(kParamTestSize)
+        .params<LenParam, &LenParam::parse, &LenParam::to_strings>()
+        .int_to_params<&extra_key_int_to_params>()
+        .resolve_params<&extra_key_resolve_params>()
+        .from_string<&param_test_encode>()
+        .to_string<&param_test_decode>()
+        .compare<&param_test_compare>()
+        .build();
+
+// ---- Intrinsic-default test types ---------------------------------------
+//
+//   DEFAULT_STR_TYPE     - fixed non-parameterized type with a valid
+//                          intrinsic_default_str.
+//   DEFAULT_VDF_TYPE     - fixed non-parameterized type whose default is
+//                          computed by an intrinsic_default VDF.
+//   DEFAULT_PARAM_TYPE(N)- parameterized type with an intrinsic_default_str,
+//                          exercising per-TypeContext default pre-encoding.
+//   BAD_DEFAULT_LEN_TYPE - intrinsic_default_str that encodes to the wrong
+//                          length, hitting the length-mismatch error.
+
+constexpr int64_t kDefaultTestSize = 4;
+
+// Non-parameterized 4-byte codec: "(N)" text form; empty string -> zero.
+void default_test_encode(std::string_view from, vsql::CustomResult out) {
+  auto buf = out.buffer();
+  if (buf.size() < static_cast<size_t>(kDefaultTestSize)) return;
+  memset(buf.data(), 0, kDefaultTestSize);
+  unsigned int nn = 0;
+  if (!from.empty()) {
+    char tmp[64];
+    size_t copy = from.size() < sizeof(tmp) - 1 ? from.size() : sizeof(tmp) - 1;
+    memcpy(tmp, from.data(), copy);
+    tmp[copy] = '\0';
+    if (sscanf(tmp, "(%u)", &nn) != 1) return;
+  }
+  buf[0] = static_cast<unsigned char>(nn);
+  out.set_length(static_cast<size_t>(kDefaultTestSize));
+}
+
+void default_test_decode(vsql::CustomArg in, vsql::StringResult out) {
+  auto data = in.value();
+  if (data.size() < static_cast<size_t>(kDefaultTestSize)) return;
+  auto buf = out.buffer();
+  int written = snprintf(buf.data(), buf.size(), "(%u)", data[0]);
+  if (written < 0) return;
+  out.set_length(static_cast<size_t>(written));
+}
+
+int default_test_compare(vsql::CustomArg a, vsql::CustomArg b) {
+  auto va = a.value();
+  auto vb = b.value();
+  size_t n = va.size() < vb.size() ? va.size() : vb.size();
+  return memcmp(va.data(), vb.data(), n);
+}
+
+// BAD_DEFAULT_LEN_TYPE encode: the magic default string "SHORT" encodes to
+// only 2 bytes, which does not match persisted_length (4).
+void bad_default_len_encode(std::string_view from, vsql::CustomResult out) {
+  auto buf = out.buffer();
+  if (from == "SHORT") {
+    if (buf.size() < 2) return;
+    buf[0] = buf[1] = 0;
+    out.set_length(2);  // wrong: expected persisted_length (4)
+    return;
+  }
+  default_test_encode(from, out);
+}
+
+// intrinsic_default VDF for DEFAULT_VDF_TYPE: computes the text form "(9)".
+std::string default_vdf_default(char * /*error_msg*/) { return "(9)"; }
+
+static constexpr const char kDefaultStrTypeName[] = "DEFAULT_STR_TYPE";
+static constexpr const char kDefaultVdfTypeName[] = "DEFAULT_VDF_TYPE";
+static constexpr const char kDefaultParamTypeName[] = "DEFAULT_PARAM_TYPE";
+static constexpr const char kBadDefaultLenTypeName[] = "BAD_DEFAULT_LEN_TYPE";
+
+constexpr auto DEFAULT_STR_TYPE = vsql::make_type<kDefaultStrTypeName>()
+                                      .persisted_length(kDefaultTestSize)
+                                      .max_decode_buffer_length(16)
+                                      .from_string<&default_test_encode>()
+                                      .to_string<&default_test_decode>()
+                                      .compare<&default_test_compare>()
+                                      .intrinsic_default_str("(7)")
+                                      .build();
+
+constexpr auto DEFAULT_VDF_TYPE =
+    vsql::make_type<kDefaultVdfTypeName>()
+        .persisted_length(kDefaultTestSize)
+        .max_decode_buffer_length(16)
+        .from_string<&default_test_encode>()
+        .to_string<&default_test_decode>()
+        .compare<&default_test_compare>()
+        .intrinsic_default_vdf("default_vdf_type_default")
+        .build();
+
+constexpr auto DEFAULT_PARAM_TYPE =
+    vsql::make_type<kDefaultParamTypeName>()
+        .persisted_length(-1)
+        .max_decode_buffer_length(16)
+        .max_persisted_length(kParamTestSize)
+        .params<LenParam, &LenParam::parse, &LenParam::to_strings>()
+        .int_to_params<&lenient_int_to_params>()
+        .resolve_params<&lenient_resolve_params>()
+        .from_string<&param_test_encode>()
+        .to_string<&param_test_decode>()
+        .compare<&param_test_compare>()
+        .intrinsic_default_str("(5)")
+        .build();
+
+constexpr auto BAD_DEFAULT_LEN_TYPE =
+    vsql::make_type<kBadDefaultLenTypeName>()
+        .persisted_length(kDefaultTestSize)
+        .max_decode_buffer_length(16)
+        .from_string<&bad_default_len_encode>()
+        .to_string<&default_test_decode>()
+        .compare<&default_test_compare>()
+        .intrinsic_default_str("SHORT")
+        .build();
+
+// ---- Parameter-bound and rewrite test types -----------------------------
+//
+//   OVERSIZED_PARAM_TYPE(N) - resolve_params resolves a persisted_length larger
+//                             than max_persisted_length; exercises the DDL-time
+//                             upper-bound check.
+//   DROP_PARAM_TYPE(N)      - uses the MUTATING resolve_params overload to
+//                             normalize its params: keeps 'length' and erases
+//                             any unrecognized key, so the server adopts the
+//                             reduced set as canonical.
+
+// OVERSIZED_PARAM_TYPE: resolves to twice its max_persisted_length.
+constexpr int64_t kOversizedResolved = kParamTestSize * 2;
+
+bool oversized_int_to_params(int64_t value,
+                             std::map<std::string, std::string> &params,
+                             char *) {
+  params["length"] = std::to_string(value);
+  return false;
+}
+
+bool oversized_resolve_params(const std::map<std::string, std::string> &params,
+                              vsql::ResolvedTypeParams *result,
+                              char *error_msg) {
+  if (params.find("length") == params.end()) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "OVERSIZED_PARAM_TYPE requires length");
+    return true;
+  }
+  result->persisted_length =
+      kOversizedResolved;  // exceeds max_persisted_length
+  result->max_decode_buffer_length = 16;
+  return false;
+}
+
+// DROP_PARAM_TYPE: mutating resolve_params that erases any key other than
+// 'length'. The (possibly reduced) map is what the server adopts as canonical.
+bool drop_int_to_params(int64_t value,
+                        std::map<std::string, std::string> &params, char *) {
+  params["length"] = std::to_string(value);
+  return false;
+}
+
+bool drop_resolve_params(std::map<std::string, std::string> &params,
+                         vsql::ResolvedTypeParams *result, char *error_msg) {
+  if (params.find("length") == params.end()) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN, "DROP_PARAM_TYPE requires length");
+    return true;
+  }
+  for (auto it = params.begin(); it != params.end();) {
+    if (it->first != "length")
+      it = params.erase(it);
+    else
+      ++it;
+  }
+  result->persisted_length = kParamTestSize;
+  result->max_decode_buffer_length = 16;
+  return false;
+}
+
+static constexpr const char kOversizedParamTypeName[] = "OVERSIZED_PARAM_TYPE";
+static constexpr const char kDropParamTypeName[] = "DROP_PARAM_TYPE";
+
+constexpr auto OVERSIZED_PARAM_TYPE =
+    vsql::make_type<kOversizedParamTypeName>()
+        .persisted_length(-1)
+        .max_decode_buffer_length(16)
+        .max_persisted_length(kParamTestSize)
+        .params<LenParam, &LenParam::parse, &LenParam::to_strings>()
+        .int_to_params<&oversized_int_to_params>()
+        .resolve_params<&oversized_resolve_params>()
+        .from_string<&param_test_encode>()
+        .to_string<&param_test_decode>()
+        .compare<&param_test_compare>()
+        .build();
+
+constexpr auto DROP_PARAM_TYPE =
+    vsql::make_type<kDropParamTypeName>()
+        .persisted_length(-1)
+        .max_decode_buffer_length(16)
+        .max_persisted_length(kParamTestSize)
+        .params<LenParam, &LenParam::parse, &LenParam::to_strings>()
+        .int_to_params<&drop_int_to_params>()
+        .resolve_params<&drop_resolve_params>()
+        .from_string<&param_test_encode>()
+        .to_string<&param_test_decode>()
+        .compare<&param_test_compare>()
+        .build();
+
+// ---- Over-large storage-size test types ---------------------------------
+//
+// Neither persisted_length nor max_persisted_length has a VEF-level upper
+// bound: the framework only checks they are positive. A type may therefore
+// declare a size larger than MySQL's maximum column width; it registers fine,
+// but CREATE TABLE is rejected by MySQL's field-length limit (VARBINARY caps at
+// 65535 bytes), not by a VEF check.
+//
+//   HUGE_FIELD - fixed persisted_length larger than the MySQL column limit.
+//   HUGE_VAR   - variable-length with an over-large max_persisted_length.
+
+constexpr int64_t kHugeFieldLen = 70000;  // exceeds MySQL's 65535 column limit
+
+// Fills the whole (persisted_length-sized) buffer so the intrinsic-default
+// pre-encode matches; the MySQL field-length rejection then happens later, at
+// field creation.
+void huge_encode(std::string_view /*from*/, vsql::CustomResult out) {
+  auto buf = out.buffer();
+  memset(buf.data(), 0, buf.size());
+  out.set_length(buf.size());
+}
+
+static constexpr const char kHugeFieldTypeName[] = "HUGE_FIELD";
+static constexpr const char kHugeVarTypeName[] = "HUGE_VAR";
+
+constexpr auto HUGE_FIELD = vsql::make_type<kHugeFieldTypeName>()
+                                .persisted_length(kHugeFieldLen)
+                                .max_decode_buffer_length(16)
+                                .from_string<&huge_encode>()
+                                .to_string<&default_test_decode>()
+                                .compare<&default_test_compare>()
+                                .build();
+
+constexpr auto HUGE_VAR = vsql::make_type<kHugeVarTypeName>()
+                              .variable_length_type()
+                              .max_persisted_length(kHugeFieldLen)
+                              .max_decode_buffer_length(16)
+                              .from_string<&huge_encode>()
+                              .to_string<&default_test_decode>()
+                              .compare<&default_test_compare>()
+                              .build();
+
+// VAR_SETS_PERSISTED: a variable-length type whose resolve_params wrongly
+// reports a positive persisted_length.
+bool var_sets_int_to_params(int64_t value,
+                            std::map<std::string, std::string> &params,
+                            char *) {
+  params["length"] = std::to_string(value);
+  return false;
+}
+
+bool var_sets_resolve_params(const std::map<std::string, std::string> &params,
+                             vsql::ResolvedTypeParams *result,
+                             char *error_msg) {
+  if (params.find("length") == params.end()) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "VAR_SETS_PERSISTED requires length");
+    return true;
+  }
+  result->persisted_length = kParamTestSize;  // wrong: must stay <= 0 here
+  result->max_decode_buffer_length = 16;
+  return false;
+}
+
+// BAD_DECODE_BUF: resolve_params resolves a valid persisted_length but a
+// non-positive max_decode_buffer_length, which must be > 0. Exercises the
+// post-resolve_params max_decode_buffer_length check.
+bool bad_decode_buf_int_to_params(int64_t value,
+                                  std::map<std::string, std::string> &params,
+                                  char *) {
+  params["length"] = std::to_string(value);
+  return false;
+}
+
+bool bad_decode_buf_resolve_params(
+    const std::map<std::string, std::string> &params,
+    vsql::ResolvedTypeParams *result, char *error_msg) {
+  if (params.find("length") == params.end()) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN, "BAD_DECODE_BUF requires length");
+    return true;
+  }
+  result->persisted_length = kParamTestSize;  // valid
+  result->max_decode_buffer_length = 0;       // invalid: must be > 0
+  return false;
+}
+
+static constexpr const char kVarSetsPersistedTypeName[] = "VAR_SETS_PERSISTED";
+static constexpr const char kBadDecodeBufTypeName[] = "BAD_DECODE_BUF";
+
+constexpr auto VAR_SETS_PERSISTED =
+    vsql::make_type<kVarSetsPersistedTypeName>()
+        .variable_length_type()
+        .max_persisted_length(kParamTestSize)
+        .max_decode_buffer_length(16)
+        .params<LenParam, &LenParam::parse, &LenParam::to_strings>()
+        .int_to_params<&var_sets_int_to_params>()
+        .resolve_params<&var_sets_resolve_params>()
+        .from_string<&param_test_encode>()
+        .to_string<&param_test_decode>()
+        .compare<&param_test_compare>()
+        .build();
+
+constexpr auto BAD_DECODE_BUF =
+    vsql::make_type<kBadDecodeBufTypeName>()
+        .persisted_length(-1)
+        .max_decode_buffer_length(16)
+        .max_persisted_length(kParamTestSize)
+        .params<LenParam, &LenParam::parse, &LenParam::to_strings>()
+        .int_to_params<&bad_decode_buf_int_to_params>()
+        .resolve_params<&bad_decode_buf_resolve_params>()
+        .from_string<&param_test_encode>()
+        .to_string<&param_test_decode>()
+        .compare<&param_test_compare>()
+        .build();
+
 using namespace vsql;
 
 VEF_GENERATE_ENTRY_POINTS(
@@ -697,6 +1274,27 @@ VEF_GENERATE_ENTRY_POINTS(
         .type(NO_DEFAULT_VAR_PARAM_TYPE)
         .type(LARGE_DECODE_TYPE)
         .type(PVEC)
+        // Parameter-validation edge-case types
+        .type(BAD_LEN_PARAM_TYPE)
+        .type(EMPTY_PARAMS_TYPE)
+        .type(LENIENT_PARAM_TYPE)
+        .type(STRICT_PARAM_TYPE)
+        .type(EXTRA_KEY_PARAM_TYPE)
+        // Intrinsic-default test types
+        .type(DEFAULT_STR_TYPE)
+        .type(DEFAULT_VDF_TYPE)
+        .type(DEFAULT_PARAM_TYPE)
+        .type(BAD_DEFAULT_LEN_TYPE)
+        // Parameter-bound and rewrite test types
+        .type(OVERSIZED_PARAM_TYPE)
+        .type(DROP_PARAM_TYPE)
+        // Over-large storage-size test types
+        .type(HUGE_FIELD)
+        .type(HUGE_VAR)
+        .type(VAR_SETS_PERSISTED)
+        .type(BAD_DECODE_BUF)
+        .func(make_intrinsic_default<&default_vdf_default>(
+            "default_vdf_type_default"))
         // Test VDF: exercises VEF_RESULT_WARNING vs VEF_RESULT_ERROR
         .func(make_func<&test_result_kind>("test_result_kind")
                   .returns(INT)

--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -155,6 +155,19 @@ class PT_custom_type : public PT_type {
       return true;
     }
 
+    // Fixed-length types must stay within the declared max_persisted_length
+    // upper bound.
+    if (!descriptor->is_variable_length() &&
+        resolved.persisted_length > descriptor->max_persisted_length()) {
+      thd->syntax_error_at(
+          pos,
+          "Type '%s' resolved a persisted_length (%" PRId64
+          ") that exceeds its declared max_persisted_length (%" PRId64 ")",
+          descriptor->qualified_base_name().c_str(), resolved.persisted_length,
+          descriptor->max_persisted_length());
+      return true;
+    }
+
     // Re-canonicalize in case resolve_params rewrote the params. from_raw
     // normalizes ordering/case; a no-op when the params were left unchanged.
     TypeParameters params = canonical_params == params_str

--- a/villagesql/types/type_function.cc
+++ b/villagesql/types/type_function.cc
@@ -123,12 +123,21 @@ bool ResolveParamsFunction::invoke(const std::string &params_str,
       strtoll(output.c_str() + comma + 1, &endptr, 10);
   // endptr now points at the terminator: '\0' for the two-field (const) form,
   // or ',' introducing the rewritten-params section for the mutating overload.
-  if (*endptr == '\0') return false;
-  if (*endptr != ',') {
+  if (*endptr != '\0' && *endptr != ',') {
     snprintf(error_msg, VEF_MAX_ERROR_LEN,
              "resolve_params VDF returned invalid max_decode_buffer_length");
     return true;
   }
+  // max_decode_buffer_length sizes the decode scratch buffer, so it must be
+  // positive for every parameterization, regardless of the type's length kind.
+  if (result->max_decode_buffer_length <= 0) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "resolve_params resolved a non-positive max_decode_buffer_length "
+             "(%lld); it must be > 0",
+             static_cast<long long>(result->max_decode_buffer_length));
+    return true;
+  }
+  if (*endptr == '\0') return false;
 
   // Rewritten-params section from the mutating overload:
   // "<byte-len>[,key=value,...]", starting just past this comma.

--- a/villagesql/veb/register.cc
+++ b/villagesql/veb/register.cc
@@ -17,6 +17,7 @@
 #include "villagesql/veb/register.h"
 
 #include <algorithm>
+#include <set>
 
 #include "sql/sql_class.h"
 #include "villagesql/include/error.h"
@@ -34,12 +35,25 @@ bool register_validated_extension(THD &thd, ValidatedRegistration validated,
   auto &victionary = VictionaryClient::instance();
   victionary.assert_write_lock_held();
 
+  // Detects a type registered more than once within this same extension batch.
+  // get_committed() below only sees already-committed descriptors, not the ones
+  // marked for insertion earlier in this loop, so a same-named duplicate inside
+  // one extension would otherwise slip through.
+  std::set<TypeDescriptorKey> seen_type_keys;
+
   for (auto &descriptor : validated.types) {
     std::string type_name = descriptor.type_name();
     std::string ext_name = descriptor.extension_name();
 
     LogVSQL(INFORMATION_LEVEL, "Registering type '%s' from extension '%s'",
             type_name.c_str(), ext_name.c_str());
+
+    if (!seen_type_keys.insert(descriptor.key()).second) {
+      error_out = "type '" + type_name + "' already exists";
+      LogVSQL(ERROR_LEVEL, "Extension '%s': %s", ext_name.c_str(),
+              error_out.c_str());
+      return true;
+    }
 
     const TypeDescriptor *existing =
         victionary.type_descriptors().get_committed(descriptor.key());


### PR DESCRIPTION
Add broad mtr coverage for custom-type parameters, intrinsic defaults, and type-builder misconfiguration, and close several validation gaps that writing the tests surfaced.

SDK — new compile-time build() static_asserts (vsql/type_builder.h):
- params \<P\>( ) requires resolve_params()
- int_to_params() requires resolve_params()
- variable-length types must not declare persisted_length()
- intrinsic_default_str() and intrinsic_default_vdf() are mutually exclusive
- max_persisted_length() is only valid for variable-length or parameterized (resolve_params) types

Server-side validation:
- pt_custom_type: at DDL time, reject a resolved persisted_length that exceeds the declared max_persisted_length
- type_function: reject a resolved, non-positive max_decode_buffer_length from resolve_params
- register: reject two types with the same name within one extension (the pre-commit check only inspected committed descriptors, not the batch)

