### PR TITLE
type-builder invariants at compile time

### DIFF
--- a/mysql-test/include/villagesql/create_extension_sdk_expect_build_failure.inc
+++ b/mysql-test/include/villagesql/create_extension_sdk_expect_build_failure.inc
@@ -43,6 +43,13 @@ if (!$extension_version)
 
 --exec cp $extension_source $ext_build_dir/src/extension.cc
 
+# Optionally place a shared companion header next to extension.cc so the source
+# can #include it.
+if ($extension_common_header)
+{
+  --exec cp $extension_common_header $ext_build_dir/src/
+}
+
 --exec printf '%s' '{"name": "$extension_name", "version": "$extension_version"}' > $ext_build_dir/manifest.json
 
 --let $cmake_template = $MYSQL_TEST_DIR/suite/villagesql/data/extension_creator/CMakeLists.txt.template
@@ -72,4 +79,5 @@ if ($build_failure_grep)
 --let $extension_name =
 --let $extension_version =
 --let $extension_source =
+--let $extension_common_header =
 --let $build_failure_grep =

--- a/mysql-test/suite/villagesql/extension/r/extension_type_builder_build_errors.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_type_builder_build_errors.result
@@ -1,0 +1,27 @@
+# A type without from_string() fails to build.
+Attempting to build type_missing_from_string (expecting build failure)...
+Build failed as expected.
+# A type without to_string() fails to build.
+Attempting to build type_missing_to_string (expecting build failure)...
+Build failed as expected.
+# A type with int_to_params() but no resolve_params() fails to build.
+Attempting to build int_to_params_no_resolve (expecting build failure)...
+Build failed as expected.
+# A parameterized type (params<P>) without resolve_params() fails to build.
+Attempting to build params_no_resolve (expecting build failure)...
+Build failed as expected.
+# A variable-length type without max_persisted_length() fails to build.
+Attempting to build var_no_max_persisted (expecting build failure)...
+Build failed as expected.
+# A variable-length type that also declares persisted_length() fails to
+# build (the two are mutually exclusive).
+Attempting to build var_with_persisted (expecting build failure)...
+Build failed as expected.
+# A type that sets both intrinsic_default_str and intrinsic_default_vdf
+# fails to build (the two are mutually exclusive).
+Attempting to build both_intrinsic_defaults (expecting build failure)...
+Build failed as expected.
+# A fixed, non-parameterized type that sets max_persisted_length fails to
+# build (it is only valid for variable-length or parameterized types).
+Attempting to build fixed_with_max (expecting build failure)...
+Build failed as expected.

--- a/mysql-test/suite/villagesql/extension/t/extension_type_builder_build_errors.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_type_builder_build_errors.test
@@ -1,0 +1,64 @@
+# Scenario: build() static_asserts catch missing/contradictory type-builder
+# configuration at COMPILE time, so the extension fails to build. Each case
+# below builds a throwaway extension and expects the
+# build to fail. The shared stub type-ops live in std_data/type_build_common.h,
+# copied next to each source so only the make_type(...) chain differs per case.
+
+--echo # A type without from_string() fails to build.
+--let $extension_name = type_missing_from_string
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_missing_from_string.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = from_string() is required before build()
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc
+
+--echo # A type without to_string() fails to build.
+--let $extension_name = type_missing_to_string
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_missing_to_string.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = to_string() is required before build()
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc
+
+--echo # A type with int_to_params() but no resolve_params() fails to build.
+--let $extension_name = int_to_params_no_resolve
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/int_to_params_no_resolve.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = resolve_params() is required when int_to_params()
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc
+
+--echo # A parameterized type (params<P>) without resolve_params() fails to build.
+--let $extension_name = params_no_resolve
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/params_no_resolve.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = resolve_params() is required when params<P>()
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc
+
+--echo # A variable-length type without max_persisted_length() fails to build.
+--let $extension_name = var_no_max_persisted
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/var_no_max_persisted.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = variable-length types must call
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc
+
+--echo # A variable-length type that also declares persisted_length() fails to
+--echo # build (the two are mutually exclusive).
+--let $extension_name = var_with_persisted
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/var_with_persisted.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = variable-length types must not
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc
+
+--echo # A type that sets both intrinsic_default_str and intrinsic_default_vdf
+--echo # fails to build (the two are mutually exclusive).
+--let $extension_name = both_intrinsic_defaults
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/both_intrinsic_defaults.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = intrinsic_default_str() and intrinsic_default_vdf()
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc
+
+--echo # A fixed, non-parameterized type that sets max_persisted_length fails to
+--echo # build (it is only valid for variable-length or parameterized types).
+--let $extension_name = fixed_with_max
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/fixed_with_max.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--let $build_failure_grep = max_persisted_length() is only valid for
+--source include/villagesql/create_extension_sdk_expect_build_failure.inc

--- a/mysql-test/suite/villagesql/std_data/both_intrinsic_defaults.cc
+++ b/mysql-test/suite/villagesql/std_data/both_intrinsic_defaults.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a type that sets BOTH intrinsic_default_str and
+// intrinsic_default_vdf (mutually exclusive). build() must static_assert
+// "intrinsic_default_str() and intrinsic_default_vdf() ...". Only the make_type
+// chain matters; the op stubs live in type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "BOTH_DEFAULTS";
+
+// Both intrinsic default sources are set; build() must reject this.
+constexpr auto BOTH_DEFAULTS = make_type<kName>()
+                                   .persisted_length(8)
+                                   .max_decode_buffer_length(16)
+                                   .from_string<&tbc::stub_encode>()
+                                   .to_string<&tbc::stub_decode>()
+                                   .compare<&tbc::stub_compare>()
+                                   .intrinsic_default_str("")
+                                   .intrinsic_default_vdf("stub_default")
+                                   .build();
+
+VEF_GENERATE_ENTRY_POINTS(
+    make_extension()
+        .type(BOTH_DEFAULTS)
+        .func(make_intrinsic_default<&tbc::stub_default>("stub_default")))

--- a/mysql-test/suite/villagesql/std_data/fixed_with_max.cc
+++ b/mysql-test/suite/villagesql/std_data/fixed_with_max.cc
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a fixed, non-parameterized type that sets
+// max_persisted_length (only valid for variable-length or parameterized types).
+// build() must static_assert "max_persisted_length() is only valid for ...".
+// Only the make_type chain matters; the op stubs live in type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "FIXED_MAX";
+
+// Fixed footprint + max_persisted_length, but neither variable-length nor
+// parameterized; build() must reject this.
+constexpr auto FIXED_MAX = make_type<kName>()
+                               .persisted_length(16)
+                               .max_decode_buffer_length(16)
+                               .max_persisted_length(8)
+                               .from_string<&tbc::stub_encode>()
+                               .to_string<&tbc::stub_decode>()
+                               .compare<&tbc::stub_compare>()
+                               .build();
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(FIXED_MAX))

--- a/mysql-test/suite/villagesql/std_data/int_to_params_no_resolve.cc
+++ b/mysql-test/suite/villagesql/std_data/int_to_params_no_resolve.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a parameterized type with int_to_params() but no
+// resolve_params(). build() must static_assert "resolve_params() is required
+// when int_to_params() is used". Only the make_type chain matters; the op
+// stubs live in type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "INT_TO_PARAMS_NO_RESOLVE";
+
+// .resolve_params<>() is deliberately omitted.
+constexpr auto INT_TO_PARAMS_NO_RESOLVE =
+    make_type<kName>()
+        .persisted_length(-1)
+        .max_decode_buffer_length(16)
+        .max_persisted_length(16)
+        .params<tbc::LenParam, &tbc::LenParam::parse,
+                &tbc::LenParam::to_strings>()
+        .int_to_params<&tbc::stub_int_to_params>()
+        .from_string<&tbc::stub_param_encode>()
+        .to_string<&tbc::stub_param_decode>()
+        .compare<&tbc::stub_param_compare>()
+        .build();
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(INT_TO_PARAMS_NO_RESOLVE))

--- a/mysql-test/suite/villagesql/std_data/params_no_resolve.cc
+++ b/mysql-test/suite/villagesql/std_data/params_no_resolve.cc
@@ -1,0 +1,39 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a parameterized type declares params<P>() but no
+// resolve_params() (and no int_to_params()). A parameterized type must provide
+// a resolver, so build() must static_assert "resolve_params() is required when
+// params<P>() is used". Only the make_type chain matters; the op stubs live in
+// type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "PARAMS_NO_RESOLVE";
+
+// .resolve_params<>() is deliberately omitted.
+constexpr auto PARAMS_NO_RESOLVE =
+    make_type<kName>()
+        .max_persisted_length(16)
+        .params<tbc::LenParam, &tbc::LenParam::parse,
+                &tbc::LenParam::to_strings>()
+        .from_string<&tbc::stub_param_encode>()
+        .to_string<&tbc::stub_param_decode>()
+        .compare<&tbc::stub_param_compare>()
+        .build();
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(PARAMS_NO_RESOLVE))

--- a/mysql-test/suite/villagesql/std_data/type_build_common.h
+++ b/mysql-test/suite/villagesql/std_data/type_build_common.h
@@ -1,0 +1,106 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Shared stub type-op functions for the build-error test extensions.
+// the op bodies are irrelevant to what is under test, so they are
+// defined once here.
+
+#ifndef VILLAGESQL_TEST_STD_DATA_TYPE_BUILD_COMMON_H
+#define VILLAGESQL_TEST_STD_DATA_TYPE_BUILD_COMMON_H
+
+#include <villagesql/vsql.h>
+
+#include <cstdint>
+#include <cstring>
+#include <map>
+#include <string>
+#include <string_view>
+
+namespace tbc {
+
+constexpr int64_t kStubSize = 8;
+
+// ---- Non-parameterized ops ----------------------------------------------
+inline void stub_encode(std::string_view /*from*/, vsql::CustomResult out) {
+  auto buf = out.buffer();
+  if (buf.empty()) return;
+  memset(buf.data(), 0, buf.size());
+  out.set_length(buf.size());
+}
+
+inline void stub_decode(vsql::CustomArg /*in*/, vsql::StringResult out) {
+  out.set("");
+}
+
+inline int stub_compare(vsql::CustomArg a, vsql::CustomArg b) {
+  auto va = a.value();
+  auto vb = b.value();
+  size_t n = va.size() < vb.size() ? va.size() : vb.size();
+  return memcmp(va.data(), vb.data(), n);
+}
+
+// ---- Intrinsic-default VDF ------------------------------------------------
+inline std::string stub_default(char * /*error_msg*/) { return ""; }
+
+// ---- Parameterized ('length') ops ----------------------------------------
+struct LenParam {
+  int64_t length;
+
+  static LenParam parse(const std::map<std::string, std::string> &params) {
+    auto it = params.find("length");
+    return LenParam{it == params.end() ? 0 : std::stoll(it->second)};
+  }
+
+  static void to_strings(const LenParam &p,
+                         std::map<std::string, std::string> &out) {
+    out["length"] = std::to_string(p.length);
+  }
+};
+
+inline void stub_param_encode(vsql::MaybeParams<LenParam> & /*params*/,
+                              std::string_view /*from*/,
+                              vsql::CustomResult out) {
+  auto buf = out.buffer();
+  if (buf.empty()) return;
+  out.set_length(buf.size());
+}
+
+inline void stub_param_decode(vsql::CustomArgWith<LenParam> /*in*/,
+                              vsql::StringResult out) {
+  out.set_length(0);
+}
+
+inline int stub_param_compare(vsql::CustomArgWith<LenParam>,
+                              vsql::CustomArgWith<LenParam>) {
+  return 0;
+}
+
+inline bool stub_int_to_params(int64_t value,
+                               std::map<std::string, std::string> &params,
+                               char *) {
+  params["length"] = std::to_string(value);
+  return false;
+}
+
+inline bool stub_resolve_params(const std::map<std::string, std::string> &,
+                                vsql::ResolvedTypeParams *result, char *) {
+  result->persisted_length = kStubSize;
+  result->max_decode_buffer_length = 16;
+  return false;
+}
+
+}  // namespace tbc
+
+#endif  // VILLAGESQL_TEST_STD_DATA_TYPE_BUILD_COMMON_H

--- a/mysql-test/suite/villagesql/std_data/type_missing_from_string.cc
+++ b/mysql-test/suite/villagesql/std_data/type_missing_from_string.cc
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a type that omits from_string(). build() must
+// static_assert "from_string() is required before build()". Only the make_type
+// chain matters; the op stubs live in type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "MISSING_FROM_STRING";
+
+// .from_string<>() is deliberately omitted.
+constexpr auto MISSING_FROM_STRING = make_type<kName>()
+                                         .persisted_length(8)
+                                         .max_decode_buffer_length(8)
+                                         .to_string<&tbc::stub_decode>()
+                                         .compare<&tbc::stub_compare>()
+                                         .build();
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(MISSING_FROM_STRING))

--- a/mysql-test/suite/villagesql/std_data/type_missing_to_string.cc
+++ b/mysql-test/suite/villagesql/std_data/type_missing_to_string.cc
@@ -1,0 +1,34 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a type that omits to_string(). build() must static_assert
+// "to_string() is required before build()". Only the make_type chain matters;
+// the op stubs live in type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "MISSING_TO_STRING";
+
+// .to_string<>() is deliberately omitted.
+constexpr auto MISSING_TO_STRING = make_type<kName>()
+                                       .persisted_length(8)
+                                       .max_decode_buffer_length(8)
+                                       .from_string<&tbc::stub_encode>()
+                                       .compare<&tbc::stub_compare>()
+                                       .build();
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(MISSING_TO_STRING))

--- a/mysql-test/suite/villagesql/std_data/var_no_max_persisted.cc
+++ b/mysql-test/suite/villagesql/std_data/var_no_max_persisted.cc
@@ -1,0 +1,36 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a variable-length type that omits max_persisted_length().
+// build() must static_assert "variable-length types must call
+// .max_persisted_length(N)". Only the make_type chain matters; the op stubs
+// live in type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "VAR_NO_MAX";
+
+// .max_persisted_length() is deliberately omitted for a variable-length type.
+constexpr auto VAR_NO_MAX = make_type<kName>()
+                                .variable_length_type()
+                                .max_decode_buffer_length(16)
+                                .from_string<&tbc::stub_encode>()
+                                .to_string<&tbc::stub_decode>()
+                                .compare<&tbc::stub_compare>()
+                                .build();
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(VAR_NO_MAX))

--- a/mysql-test/suite/villagesql/std_data/var_with_persisted.cc
+++ b/mysql-test/suite/villagesql/std_data/var_with_persisted.cc
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Build-error test: a variable-length type that also declares
+// persisted_length() (mutually exclusive). build() must static_assert
+// "variable-length types must not ...". Only the make_type chain matters; the
+// op stubs live in type_build_common.h.
+
+#include "type_build_common.h"
+
+using namespace vsql;
+
+static constexpr const char kName[] = "VAR_WITH_PERSISTED";
+
+// variable_length_type() with persisted_length() is contradictory.
+constexpr auto VAR_WITH_PERSISTED = make_type<kName>()
+                                        .variable_length_type()
+                                        .persisted_length(16)
+                                        .max_decode_buffer_length(16)
+                                        .max_persisted_length(32)
+                                        .from_string<&tbc::stub_encode>()
+                                        .to_string<&tbc::stub_decode>()
+                                        .compare<&tbc::stub_compare>()
+                                        .build();
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().type(VAR_WITH_PERSISTED))

--- a/unittest/gunit/villagesql/type_builder-t.cc
+++ b/unittest/gunit/villagesql/type_builder-t.cc
@@ -68,6 +68,10 @@ static int params_compare(vsql::CustomArgWith<TestParams>,
   return 0;
 }
 static size_t params_hash(vsql::CustomArgWith<TestParams>) { return 0; }
+static bool params_resolve(const std::map<std::string, std::string> &,
+                           vsql::ResolvedTypeParams *, char *) {
+  return false;
+}
 
 static constexpr const char kPlainName[] = "TESTPLAIN";
 static constexpr const char kParamsName[] = "TESTPARAMS";
@@ -172,6 +176,7 @@ TEST_F(TypeBuilderTest, ParameterizedBuildsCorrectly) {
       vsql::make_type<kParamsName>()
           .max_persisted_length(128)
           .params<TestParams, &TestParams::parse, &TestParams::to_strings>()
+          .resolve_params<&params_resolve>()
           .from_string<&params_encode>()
           .to_string<&params_decode>()
           .compare<&params_compare>()
@@ -188,6 +193,7 @@ TEST_F(TypeBuilderTest, ParameterizedWithHash) {
       vsql::make_type<kParamsName>()
           .max_persisted_length(128)
           .params<TestParams, &TestParams::parse, &TestParams::to_strings>()
+          .resolve_params<&params_resolve>()
           .from_string<&params_encode>()
           .to_string<&params_decode>()
           .compare<&params_compare>()
@@ -204,6 +210,7 @@ TEST_F(TypeBuilderTest, ParameterizedOperationsAnyOrder) {
       vsql::make_type<kParamsName>()
           .max_persisted_length(128)
           .params<TestParams, &TestParams::parse, &TestParams::to_strings>()
+          .resolve_params<&params_resolve>()
           .compare<&params_compare>()
           .to_string<&params_decode>()
           .from_string<&params_encode>()

--- a/villagesql/sdk/include/villagesql/vsql/type_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/type_builder.h
@@ -125,12 +125,19 @@ template <bool HasFromString = false, bool HasToString = false,
           bool HasCompare = false, typename ParamsType = void,
           bool HasIntToParams = false, bool HasResolveParams = false,
           bool HasMaxPersistedLength = false, bool HasVariableLength = false,
-          typename EFT = std::tuple<>, const char *Name = nullptr>
+          bool HasPersistedLength = false, bool HasIntrinsicDefaultStr = false,
+          bool HasIntrinsicDefaultVdf = false, typename EFT = std::tuple<>,
+          const char *Name = nullptr>
 class TypeBuilder {
  public:
-  constexpr TypeBuilder &persisted_length(int64_t len) {
-    state_.desc.vef_desc.persisted_length = len;
-    return *this;
+  constexpr auto persisted_length(int64_t len) const {
+    detail::TypeBuilderState s = state_;
+    s.desc.vef_desc.persisted_length = len;
+    return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType,
+                       HasIntToParams, HasResolveParams, HasMaxPersistedLength,
+                       HasVariableLength, /*HasPersistedLength=*/true,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf, EFT,
+                       Name>{s, embedded_funcs_};
   }
 
   constexpr TypeBuilder &max_decode_buffer_length(int64_t len) {
@@ -152,8 +159,9 @@ class TypeBuilder {
     require_atleast_min(s.desc.vef_desc.protocol, VEF_PROTOCOL_4);
     return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType,
                        HasIntToParams, HasResolveParams, HasMaxPersistedLength,
-                       /*HasVariableLength=*/true, EFT, Name>{s,
-                                                              embedded_funcs_};
+                       /*HasVariableLength=*/true, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf, EFT,
+                       Name>{s, embedded_funcs_};
   }
 
   // Upper bound on persisted_length across all valid parameterizations.
@@ -173,8 +181,9 @@ class TypeBuilder {
     require_atleast_min(s.desc.vef_desc.protocol, VEF_PROTOCOL_3);
     return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType,
                        HasIntToParams, HasResolveParams,
-                       /*HasMaxPersistedLength=*/true, HasVariableLength, EFT,
-                       Name>{s, embedded_funcs_};
+                       /*HasMaxPersistedLength=*/true, HasVariableLength,
+                       HasPersistedLength, HasIntrinsicDefaultStr,
+                       HasIntrinsicDefaultVdf, EFT, Name>{s, embedded_funcs_};
   }
 
   // -------------------------------------------------------------------------
@@ -211,7 +220,9 @@ class TypeBuilder {
     require_atleast_min(s.desc.vef_desc.protocol, VEF_PROTOCOL_3);
     return TypeBuilder<HasFromString, HasToString, HasCompare, P,
                        HasIntToParams, HasResolveParams, HasMaxPersistedLength,
-                       HasVariableLength, EFT, Name>{s, embedded_funcs_};
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf, EFT,
+                       Name>{s, embedded_funcs_};
   }
 
   // int_to_params: VDF that converts MYTYPE(N) integer to a params string.
@@ -234,8 +245,9 @@ class TypeBuilder {
     auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
     return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType, true,
                        HasResolveParams, HasMaxPersistedLength,
-                       HasVariableLength, decltype(new_embedded), Name>{
-        s, new_embedded};
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf,
+                       decltype(new_embedded), Name>{s, new_embedded};
   }
 
   // resolve_params: VDF that validates params and computes storage sizes.
@@ -272,8 +284,9 @@ class TypeBuilder {
     auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
     return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType,
                        HasIntToParams, true, HasMaxPersistedLength,
-                       HasVariableLength, decltype(new_embedded), Name>{
-        s, new_embedded};
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf,
+                       decltype(new_embedded), Name>{s, new_embedded};
   }
 
   // -------------------------------------------------------------------------
@@ -304,8 +317,9 @@ class TypeBuilder {
     auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
     return TypeBuilder<true, HasToString, HasCompare, ParamsType,
                        HasIntToParams, HasResolveParams, HasMaxPersistedLength,
-                       HasVariableLength, decltype(new_embedded), Name>{
-        s, new_embedded};
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf,
+                       decltype(new_embedded), Name>{s, new_embedded};
   }
 
   template <auto Func>
@@ -328,8 +342,9 @@ class TypeBuilder {
     auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
     return TypeBuilder<HasFromString, true, HasCompare, ParamsType,
                        HasIntToParams, HasResolveParams, HasMaxPersistedLength,
-                       HasVariableLength, decltype(new_embedded), Name>{
-        s, new_embedded};
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf,
+                       decltype(new_embedded), Name>{s, new_embedded};
   }
 
   template <auto Func>
@@ -352,8 +367,9 @@ class TypeBuilder {
     auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
     return TypeBuilder<HasFromString, HasToString, true, ParamsType,
                        HasIntToParams, HasResolveParams, HasMaxPersistedLength,
-                       HasVariableLength, decltype(new_embedded), Name>{
-        s, new_embedded};
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf,
+                       decltype(new_embedded), Name>{s, new_embedded};
   }
 
   template <auto Func>
@@ -375,8 +391,9 @@ class TypeBuilder {
     auto new_embedded = std::tuple_cat(embedded_funcs_, std::make_tuple(inner));
     return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType,
                        HasIntToParams, HasResolveParams, HasMaxPersistedLength,
-                       HasVariableLength, decltype(new_embedded), Name>{
-        s, new_embedded};
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, HasIntrinsicDefaultVdf,
+                       decltype(new_embedded), Name>{s, new_embedded};
   }
 
   // intrinsic_default_str: literal string representation of the default value
@@ -384,10 +401,15 @@ class TypeBuilder {
   // type). The server encodes it via the type's from_string VDF at first use of
   // the type. Use intrinsic_default_vdf() instead when the default must be
   // computed.
-  constexpr TypeBuilder &intrinsic_default_str(const char *str) {
-    state_.desc.vef_desc.intrinsic_default_str = str;
-    require_atleast_min(state_.desc.vef_desc.protocol, VEF_PROTOCOL_3);
-    return *this;
+  constexpr auto intrinsic_default_str(const char *str) const {
+    detail::TypeBuilderState s = state_;
+    s.desc.vef_desc.intrinsic_default_str = str;
+    require_atleast_min(s.desc.vef_desc.protocol, VEF_PROTOCOL_3);
+    return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType,
+                       HasIntToParams, HasResolveParams, HasMaxPersistedLength,
+                       HasVariableLength, HasPersistedLength,
+                       /*HasIntrinsicDefaultStr=*/true, HasIntrinsicDefaultVdf,
+                       EFT, Name>{s, embedded_funcs_};
   }
 
   // intrinsic_default_vdf: name of a separately-registered VDF that writes the
@@ -396,10 +418,15 @@ class TypeBuilder {
   //
   // TODO(villagesql-beta): embed intrinsic_default inline once the vsql API
   // supports auto-generating its VDF name too.
-  constexpr TypeBuilder &intrinsic_default_vdf(const char *vdf_name) {
-    state_.desc.vef_desc.intrinsic_default_vdf_name = vdf_name;
-    require_atleast_min(state_.desc.vef_desc.protocol, VEF_PROTOCOL_3);
-    return *this;
+  constexpr auto intrinsic_default_vdf(const char *vdf_name) const {
+    detail::TypeBuilderState s = state_;
+    s.desc.vef_desc.intrinsic_default_vdf_name = vdf_name;
+    require_atleast_min(s.desc.vef_desc.protocol, VEF_PROTOCOL_3);
+    return TypeBuilder<HasFromString, HasToString, HasCompare, ParamsType,
+                       HasIntToParams, HasResolveParams, HasMaxPersistedLength,
+                       HasVariableLength, HasPersistedLength,
+                       HasIntrinsicDefaultStr, /*HasIntrinsicDefaultVdf=*/true,
+                       EFT, Name>{s, embedded_funcs_};
   }
 
   // -------------------------------------------------------------------------
@@ -421,6 +448,19 @@ class TypeBuilder {
                   "vsql::TypeBuilder: params<P, &parse_fn>() is required when "
                   "resolve_params() is used");
     static_assert(
+        std::is_void_v<ParamsType> || HasResolveParams,
+        "vsql::TypeBuilder: resolve_params() is required when params<P>() is "
+        "used — a parameterized type must declare a resolver; int_to_params() "
+        "is the optional TYPE(N) shorthand.");
+    static_assert(
+        !HasIntToParams || HasResolveParams,
+        "vsql::TypeBuilder: resolve_params() is required when int_to_params() "
+        "is used — int_to_params() only converts the TYPE(N) shorthand into a "
+        "parameter string, while resolve_params() is the gate that validates "
+        "the parameters and resolves the storage size. Without "
+        "resolve_params() "
+        "the type is not parameterized and the length can never be resolved.");
+    static_assert(
         std::is_void_v<ParamsType> || HasMaxPersistedLength,
         "vsql::TypeBuilder: parameterized types must call "
         ".max_persisted_length(N) before build() — required so constant-string "
@@ -431,18 +471,34 @@ class TypeBuilder {
         "vsql::TypeBuilder: variable-length types must call "
         ".max_persisted_length(N) before build() — required so the server can "
         "allocate a buffer for the backing field.");
+    static_assert(
+        !HasMaxPersistedLength || HasVariableLength || HasResolveParams,
+        "vsql::TypeBuilder: max_persisted_length() is only valid for "
+        "variable-length or parameterized types; a fixed non-parameterized "
+        "type must not set it.");
+    static_assert(
+        !(HasVariableLength && HasPersistedLength),
+        "vsql::TypeBuilder: variable-length types must not declare a "
+        "persisted_length() — their size is decided per value; declare only "
+        "max_persisted_length().");
+    static_assert(
+        !(HasIntrinsicDefaultStr && HasIntrinsicDefaultVdf),
+        "vsql::TypeBuilder: intrinsic_default_str() and "
+        "intrinsic_default_vdf() "
+        "are mutually exclusive — a type may declare at most one intrinsic "
+        "default source.");
     return TypeObject<EFT>{state_.desc, embedded_funcs_, state_.params_init_fn,
                            state_.params_to_strings_init_fn};
   }
 
   // Cross-specialization and make_type access.
-  template <bool, bool, bool, typename, bool, bool, bool, bool, typename,
-            const char *>
+  template <bool, bool, bool, typename, bool, bool, bool, bool, bool, bool,
+            bool, typename, const char *>
   friend class TypeBuilder;
 
   template <const char *N>
   friend constexpr TypeBuilder<false, false, false, void, false, false, false,
-                               false, std::tuple<>, N>
+                               false, false, false, false, std::tuple<>, N>
   make_type();
 
  private:
@@ -471,13 +527,13 @@ class TypeBuilder {
 
 template <const char *Name>
 constexpr TypeBuilder<false, false, false, void, false, false, false, false,
-                      std::tuple<>, Name>
+                      false, false, false, std::tuple<>, Name>
 make_type() {
   detail::TypeBuilderState s{};
   s.desc.vef_desc.name = Name;
   s.desc.vef_desc.protocol = VEF_PROTOCOL_1;
   return TypeBuilder<false, false, false, void, false, false, false, false,
-                     std::tuple<>, Name>{s};
+                     false, false, false, std::tuple<>, Name>{s};
 }
 
 }  // namespace vsql


### PR DESCRIPTION
Add build() static_asserts to the vsql type builder so misconfigured custom types fail to compile instead of at INSTALL/DDL time:
- params\<P\>() requires resolve_params()
- int_to_params() requires resolve_params()
- variable-length types must not declare persisted_length()
- max_persisted_length() is only valid for variable-length or parameterized types
- intrinsic_default_str() and intrinsic_default_vdf() are mutually exclusive

https://github.com/villagesql/villagesql-server/issues/837
