### PR TITLE
validate the sizes from resolve_params

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_length_bounds.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_length_bounds.result
@@ -1,0 +1,10 @@
+INSTALL EXTENSION vsql_test_only;
+# Parameterized type resolving beyond max_persisted_length -> DDL error.
+CREATE TABLE t (id INT PRIMARY KEY, v OVERSIZED_PARAM_TYPE(4));
+ERROR 42000: Type 'vsql_test_only.OVERSIZED_PARAM_TYPE' resolved a persisted_length (8) that exceeds its declared max_persisted_length (4) near 'OVERSIZED_PARAM_TYPE(4))' at line 1
+# No table was created.
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 't';
+COUNT(*)
+0
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/r/extension_resolve_params_invalid_sizes.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_resolve_params_invalid_sizes.result
@@ -1,0 +1,22 @@
+INSTALL EXTENSION vsql_test_only;
+# Fixed-length, TYPE(N) shorthand: int_to_params succeeds, then
+# resolve_params returns persisted_length = -1, rejected for a fixed type.
+CREATE TABLE t (id INT PRIMARY KEY, v BAD_LEN_PARAM_TYPE(4));
+ERROR 42000: Type 'vsql_test_only.BAD_LEN_PARAM_TYPE' resolved an invalid persisted_length (-1); fixed-length types must resolve to a concrete footprint, so persisted_length should be > 0 near 'BAD_LEN_PARAM_TYPE(4))' at line 1
+# Explicit parameter string: same resolve_params rejection.
+CREATE TABLE t (id INT PRIMARY KEY, v BAD_LEN_PARAM_TYPE('length=4'));
+ERROR 42000: Type 'vsql_test_only.BAD_LEN_PARAM_TYPE' resolved an invalid persisted_length (-1); fixed-length types must resolve to a concrete footprint, so persisted_length should be > 0 near 'BAD_LEN_PARAM_TYPE('length=4'))' at line 1
+# Variable-length: resolve_params reports a positive persisted_length,
+# which is rejected (variable-length types must leave it unset).
+CREATE TABLE t (id INT PRIMARY KEY, v VAR_SETS_PERSISTED(4));
+ERROR 42000: Variable-length type 'vsql_test_only.VAR_SETS_PERSISTED' resolved an unexpected fixed persisted_length (4); variable-length types size storage per value, so persisted_length should be <= 0 (stay unset) near 'VAR_SETS_PERSISTED(4))' at line 1
+# resolve_params resolves a non-positive max_decode_buffer_length, which
+# is rejected (it sizes the decode scratch buffer and must be > 0).
+CREATE TABLE t (id INT PRIMARY KEY, v BAD_DECODE_BUF(4));
+ERROR 42000: resolve_params resolved a non-positive max_decode_buffer_length (0); it must be > 0 near 'BAD_DECODE_BUF(4))' at line 1
+# No table was created.
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 't';
+COUNT(*)
+0
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/t/extension_length_bounds.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_length_bounds.test
@@ -1,0 +1,17 @@
+# Scenario: a parameterized type whose resolve_params resolves a persisted_length
+# larger than the declared max_persisted_length is rejected at DDL time.
+#
+# Fixture: vsql_test_only exposes OVERSIZED_PARAM_TYPE, whose resolve_params
+# returns 2 * max_persisted_length.
+
+INSTALL EXTENSION vsql_test_only;
+
+--echo # Parameterized type resolving beyond max_persisted_length -> DDL error.
+--error ER_PARSE_ERROR
+CREATE TABLE t (id INT PRIMARY KEY, v OVERSIZED_PARAM_TYPE(4));
+
+--echo # No table was created.
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 't';
+
+UNINSTALL EXTENSION vsql_test_only;

--- a/mysql-test/suite/villagesql/extension/t/extension_resolve_params_invalid_sizes.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_resolve_params_invalid_sizes.test
@@ -1,0 +1,39 @@
+# Scenario: resolve_params must resolve a persisted_length consistent with the
+# type's length kind. A fixed-length type must resolve to a concrete positive
+# footprint; a variable-length type sizes storage per value and must leave
+# persisted_length <= 0. PT_custom_type enforces both at DDL time.
+#
+# Fixtures (all in vsql_test_only):
+#   BAD_LEN_PARAM_TYPE  - fixed-length; resolve_params returns persisted_length
+#                         = -1 (must be > 0).
+#   VAR_SETS_PERSISTED  - variable-length; resolve_params returns a positive
+#                         persisted_length (must stay <= 0).
+#   BAD_DECODE_BUF      - resolve_params resolves a non-positive
+#                         max_decode_buffer_length (must be > 0).
+
+INSTALL EXTENSION vsql_test_only;
+
+--echo # Fixed-length, TYPE(N) shorthand: int_to_params succeeds, then
+--echo # resolve_params returns persisted_length = -1, rejected for a fixed type.
+--error ER_PARSE_ERROR
+CREATE TABLE t (id INT PRIMARY KEY, v BAD_LEN_PARAM_TYPE(4));
+
+--echo # Explicit parameter string: same resolve_params rejection.
+--error ER_PARSE_ERROR
+CREATE TABLE t (id INT PRIMARY KEY, v BAD_LEN_PARAM_TYPE('length=4'));
+
+--echo # Variable-length: resolve_params reports a positive persisted_length,
+--echo # which is rejected (variable-length types must leave it unset).
+--error ER_PARSE_ERROR
+CREATE TABLE t (id INT PRIMARY KEY, v VAR_SETS_PERSISTED(4));
+
+--echo # resolve_params resolves a non-positive max_decode_buffer_length, which
+--echo # is rejected (it sizes the decode scratch buffer and must be > 0).
+--error ER_PARSE_ERROR
+CREATE TABLE t (id INT PRIMARY KEY, v BAD_DECODE_BUF(4));
+
+--echo # No table was created.
+SELECT COUNT(*) FROM INFORMATION_SCHEMA.TABLES
+WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 't';
+
+UNINSTALL EXTENSION vsql_test_only;

--- a/villagesql/test-extensions/vsql-test-only/src/extension.cc
+++ b/villagesql/test-extensions/vsql-test-only/src/extension.cc
@@ -685,6 +685,214 @@ constexpr auto PVEC =
         .compare<&pvec_compare>()
         .build();
 
+// ---- resolve_params size-validation test types --------------------------
+//
+// Parameterized types that exercise the DDL-time checks on the sizes
+// resolve_params reports. They share a working 4-byte codec (param_test_*)
+// keyed on a LenParam.
+//
+//   OVERSIZED_PARAM_TYPE(N) - resolve_params resolves a persisted_length larger
+//                             than max_persisted_length (upper-bound check).
+//   BAD_LEN_PARAM_TYPE(N)   - fixed-length; resolve_params returns
+//                             persisted_length = -1 (must be > 0).
+//   VAR_SETS_PERSISTED(N)   - variable-length; resolve_params returns a
+//   positive
+//                             persisted_length (must stay <= 0).
+//   BAD_DECODE_BUF(N)       - resolve_params resolves a non-positive
+//                             max_decode_buffer_length (must be > 0).
+
+constexpr int64_t kParamTestSize = 4;
+
+struct LenParam {
+  int64_t length;
+
+  static LenParam parse(const std::map<std::string, std::string> &params) {
+    auto it = params.find("length");
+    return LenParam{it == params.end() ? 0 : std::stoll(it->second)};
+  }
+
+  static void to_strings(const LenParam &p,
+                         std::map<std::string, std::string> &out) {
+    out["length"] = std::to_string(p.length);
+  }
+};
+
+// Working 4-byte codec shared by the size-validation types. Text form is
+// "(N)"; the empty string encodes to all-zeros so the types have a usable
+// intrinsic default and their columns can be created.
+void param_test_encode(vsql::MaybeParams<LenParam> &params,
+                       std::string_view from, vsql::CustomResult out) {
+  if (!params.is_known()) params.set(LenParam{kParamTestSize});
+  auto buf = out.buffer();
+  if (buf.size() < static_cast<size_t>(kParamTestSize)) return;
+  memset(buf.data(), 0, kParamTestSize);
+  unsigned int nn = 0;
+  if (!from.empty()) {
+    char tmp[64];
+    size_t copy = from.size() < sizeof(tmp) - 1 ? from.size() : sizeof(tmp) - 1;
+    memcpy(tmp, from.data(), copy);
+    tmp[copy] = '\0';
+    if (sscanf(tmp, "(%u)", &nn) != 1) return;  // encode failure
+  }
+  buf[0] = static_cast<unsigned char>(nn);
+  out.set_length(static_cast<size_t>(kParamTestSize));
+}
+
+void param_test_decode(vsql::CustomArgWith<LenParam> in,
+                       vsql::StringResult out) {
+  auto data = in.value();
+  if (data.size() < static_cast<size_t>(kParamTestSize)) return;
+  auto buf = out.buffer();
+  int written = snprintf(buf.data(), buf.size(), "(%u)", data[0]);
+  if (written < 0) return;
+  out.set_length(static_cast<size_t>(written));
+}
+
+int param_test_compare(vsql::CustomArgWith<LenParam>,
+                       vsql::CustomArgWith<LenParam>) {
+  return 0;
+}
+
+// BAD_LEN_PARAM_TYPE: resolve_params deliberately reports an invalid
+// persisted_length (-1) for a fixed-length type.
+bool bad_len_int_to_params(int64_t value,
+                           std::map<std::string, std::string> &params, char *) {
+  params["length"] = std::to_string(value);
+  return false;
+}
+
+bool bad_len_resolve_params(const std::map<std::string, std::string> &,
+                            vsql::ResolvedTypeParams *result, char *) {
+  result->persisted_length = -1;  // invalid for a fixed-length type
+  result->max_decode_buffer_length = 16;
+  return false;
+}
+
+// OVERSIZED_PARAM_TYPE: resolves to twice its max_persisted_length.
+constexpr int64_t kOversizedResolved = kParamTestSize * 2;
+
+bool oversized_int_to_params(int64_t value,
+                             std::map<std::string, std::string> &params,
+                             char *) {
+  params["length"] = std::to_string(value);
+  return false;
+}
+
+bool oversized_resolve_params(const std::map<std::string, std::string> &params,
+                              vsql::ResolvedTypeParams *result,
+                              char *error_msg) {
+  if (params.find("length") == params.end()) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "OVERSIZED_PARAM_TYPE requires length");
+    return true;
+  }
+  result->persisted_length =
+      kOversizedResolved;  // exceeds max_persisted_length
+  result->max_decode_buffer_length = 16;
+  return false;
+}
+
+// VAR_SETS_PERSISTED: a variable-length type whose resolve_params wrongly
+// reports a positive persisted_length.
+bool var_sets_int_to_params(int64_t value,
+                            std::map<std::string, std::string> &params,
+                            char *) {
+  params["length"] = std::to_string(value);
+  return false;
+}
+
+bool var_sets_resolve_params(const std::map<std::string, std::string> &params,
+                             vsql::ResolvedTypeParams *result,
+                             char *error_msg) {
+  if (params.find("length") == params.end()) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "VAR_SETS_PERSISTED requires length");
+    return true;
+  }
+  result->persisted_length = kParamTestSize;  // wrong: must stay <= 0 here
+  result->max_decode_buffer_length = 16;
+  return false;
+}
+
+// BAD_DECODE_BUF: resolve_params resolves a valid persisted_length but a
+// non-positive max_decode_buffer_length, which must be > 0. Exercises the
+// post-resolve_params max_decode_buffer_length check.
+bool bad_decode_buf_int_to_params(int64_t value,
+                                  std::map<std::string, std::string> &params,
+                                  char *) {
+  params["length"] = std::to_string(value);
+  return false;
+}
+
+bool bad_decode_buf_resolve_params(
+    const std::map<std::string, std::string> &params,
+    vsql::ResolvedTypeParams *result, char *error_msg) {
+  if (params.find("length") == params.end()) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN, "BAD_DECODE_BUF requires length");
+    return true;
+  }
+  result->persisted_length = kParamTestSize;  // valid
+  result->max_decode_buffer_length = 0;       // invalid: must be > 0
+  return false;
+}
+
+static constexpr const char kBadLenParamTypeName[] = "BAD_LEN_PARAM_TYPE";
+static constexpr const char kOversizedParamTypeName[] = "OVERSIZED_PARAM_TYPE";
+static constexpr const char kVarSetsPersistedTypeName[] = "VAR_SETS_PERSISTED";
+static constexpr const char kBadDecodeBufTypeName[] = "BAD_DECODE_BUF";
+
+constexpr auto BAD_LEN_PARAM_TYPE =
+    vsql::make_type<kBadLenParamTypeName>()
+        .persisted_length(-1)
+        .max_decode_buffer_length(16)
+        .max_persisted_length(kParamTestSize)
+        .params<LenParam, &LenParam::parse, &LenParam::to_strings>()
+        .int_to_params<&bad_len_int_to_params>()
+        .resolve_params<&bad_len_resolve_params>()
+        .from_string<&param_test_encode>()
+        .to_string<&param_test_decode>()
+        .compare<&param_test_compare>()
+        .build();
+
+constexpr auto OVERSIZED_PARAM_TYPE =
+    vsql::make_type<kOversizedParamTypeName>()
+        .persisted_length(-1)
+        .max_decode_buffer_length(16)
+        .max_persisted_length(kParamTestSize)
+        .params<LenParam, &LenParam::parse, &LenParam::to_strings>()
+        .int_to_params<&oversized_int_to_params>()
+        .resolve_params<&oversized_resolve_params>()
+        .from_string<&param_test_encode>()
+        .to_string<&param_test_decode>()
+        .compare<&param_test_compare>()
+        .build();
+
+constexpr auto VAR_SETS_PERSISTED =
+    vsql::make_type<kVarSetsPersistedTypeName>()
+        .variable_length_type()
+        .max_persisted_length(kParamTestSize)
+        .max_decode_buffer_length(16)
+        .params<LenParam, &LenParam::parse, &LenParam::to_strings>()
+        .int_to_params<&var_sets_int_to_params>()
+        .resolve_params<&var_sets_resolve_params>()
+        .from_string<&param_test_encode>()
+        .to_string<&param_test_decode>()
+        .compare<&param_test_compare>()
+        .build();
+
+constexpr auto BAD_DECODE_BUF =
+    vsql::make_type<kBadDecodeBufTypeName>()
+        .persisted_length(-1)
+        .max_decode_buffer_length(16)
+        .max_persisted_length(kParamTestSize)
+        .params<LenParam, &LenParam::parse, &LenParam::to_strings>()
+        .int_to_params<&bad_decode_buf_int_to_params>()
+        .resolve_params<&bad_decode_buf_resolve_params>()
+        .from_string<&param_test_encode>()
+        .to_string<&param_test_decode>()
+        .compare<&param_test_compare>()
+        .build();
+
 using namespace vsql;
 
 VEF_GENERATE_ENTRY_POINTS(
@@ -697,6 +905,11 @@ VEF_GENERATE_ENTRY_POINTS(
         .type(NO_DEFAULT_VAR_PARAM_TYPE)
         .type(LARGE_DECODE_TYPE)
         .type(PVEC)
+        // resolve_params size-validation test types
+        .type(BAD_LEN_PARAM_TYPE)
+        .type(OVERSIZED_PARAM_TYPE)
+        .type(VAR_SETS_PERSISTED)
+        .type(BAD_DECODE_BUF)
         // Test VDF: exercises VEF_RESULT_WARNING vs VEF_RESULT_ERROR
         .func(make_func<&test_result_kind>("test_result_kind")
                   .returns(INT)

--- a/villagesql/types/pt_custom_type.h
+++ b/villagesql/types/pt_custom_type.h
@@ -155,6 +155,19 @@ class PT_custom_type : public PT_type {
       return true;
     }
 
+    // Fixed-length types must stay within the declared max_persisted_length
+    // upper bound.
+    if (!descriptor->is_variable_length() &&
+        resolved.persisted_length > descriptor->max_persisted_length()) {
+      thd->syntax_error_at(
+          pos,
+          "Type '%s' resolved a persisted_length (%" PRId64
+          ") that exceeds its declared max_persisted_length (%" PRId64 ")",
+          descriptor->qualified_base_name().c_str(), resolved.persisted_length,
+          descriptor->max_persisted_length());
+      return true;
+    }
+
     // Re-canonicalize in case resolve_params rewrote the params. from_raw
     // normalizes ordering/case; a no-op when the params were left unchanged.
     TypeParameters params = canonical_params == params_str

--- a/villagesql/types/type_function.cc
+++ b/villagesql/types/type_function.cc
@@ -123,12 +123,21 @@ bool ResolveParamsFunction::invoke(const std::string &params_str,
       strtoll(output.c_str() + comma + 1, &endptr, 10);
   // endptr now points at the terminator: '\0' for the two-field (const) form,
   // or ',' introducing the rewritten-params section for the mutating overload.
-  if (*endptr == '\0') return false;
-  if (*endptr != ',') {
+  if (*endptr != '\0' && *endptr != ',') {
     snprintf(error_msg, VEF_MAX_ERROR_LEN,
              "resolve_params VDF returned invalid max_decode_buffer_length");
     return true;
   }
+  // max_decode_buffer_length sizes the decode scratch buffer, so it must be
+  // positive for every parameterization, regardless of the type's length kind.
+  if (result->max_decode_buffer_length <= 0) {
+    snprintf(error_msg, VEF_MAX_ERROR_LEN,
+             "resolve_params resolved a non-positive max_decode_buffer_length "
+             "(%lld); it must be > 0",
+             static_cast<long long>(result->max_decode_buffer_length));
+    return true;
+  }
+  if (*endptr == '\0') return false;
 
   // Rewritten-params section from the mutating overload:
   // "<byte-len>[,key=value,...]", starting just past this comma.

--- a/villagesql/types/type_function.cc
+++ b/villagesql/types/type_function.cc
@@ -16,6 +16,7 @@
 
 #include "villagesql/types/type_function.h"
 
+#include <cinttypes>
 #include <cstdlib>
 #include <cstring>
 #include <string>
@@ -133,8 +134,8 @@ bool ResolveParamsFunction::invoke(const std::string &params_str,
   if (result->max_decode_buffer_length <= 0) {
     snprintf(error_msg, VEF_MAX_ERROR_LEN,
              "resolve_params resolved a non-positive max_decode_buffer_length "
-             "(%lld); it must be > 0",
-             static_cast<long long>(result->max_decode_buffer_length));
+             "(%" PRId64 "); it must be > 0",
+             result->max_decode_buffer_length);
     return true;
   }
   if (*endptr == '\0') return false;


### PR DESCRIPTION
Reject invalid sizes returned by a type's resolve_params callback:
- pt_custom_type (DDL time): a resolved persisted_length must not exceed the declared max_persisted_length.
- type_function: a resolved max_decode_buffer_length must be > 0 (it sizes the decode scratch buffer).

https://github.com/villagesql/villagesql-server/issues/837

