### PR TITLE
ASAN fix: adjust lock table list count

### DIFF
--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -199,6 +199,7 @@
 #include "template_utils.h"
 #include "thr_lock.h"
 #include "typelib.h"
+#include "villagesql/schema/util.h"
 #include "villagesql/sql/metadata_modifier.h"
 #include "villagesql/types/util.h"
 
@@ -17109,10 +17110,17 @@ bool mysql_alter_table(THD *thd, const char *new_db, const char *new_name,
   }
 
   // VillageSQL: Track custom columns and acquire necessary MDL locks.
+  // process_alter() may append VillageSQL system tables to the query-tables
+  // list; extend tables_opened so the lock_tables() calls below size their
+  // lock array for the longer next_global chain they will walk.
+  const uint tables_before = villagesql::count_global_tables(table_list);
   if (villagesql::Metadata_modifier::process_alter(thd, create_info, table_list,
                                                    alter_info)) {
     return true;
   }
+  alter_ctx.tables_opened +=
+      villagesql::count_global_tables(table_list) - tables_before;
+
   // VillageSQL: Clears villagesql_alter_custom_fields on all exit paths and
   // rolls back victionary modifications unless disarmed after a successful
   // store().

--- a/sql/sql_table.cc
+++ b/sql/sql_table.cc
@@ -199,7 +199,6 @@
 #include "template_utils.h"
 #include "thr_lock.h"
 #include "typelib.h"
-#include "villagesql/schema/util.h"
 #include "villagesql/sql/metadata_modifier.h"
 #include "villagesql/types/util.h"
 
@@ -17110,17 +17109,10 @@ bool mysql_alter_table(THD *thd, const char *new_db, const char *new_name,
   }
 
   // VillageSQL: Track custom columns and acquire necessary MDL locks.
-  // process_alter() may append VillageSQL system tables to the query-tables
-  // list; extend tables_opened so the lock_tables() calls below size their
-  // lock array for the longer next_global chain they will walk.
-  const uint tables_before = villagesql::count_global_tables(table_list);
-  if (villagesql::Metadata_modifier::process_alter(thd, create_info, table_list,
-                                                   alter_info)) {
+  if (villagesql::Metadata_modifier::process_alter(
+          thd, create_info, table_list, alter_info, &alter_ctx.tables_opened)) {
     return true;
   }
-  alter_ctx.tables_opened +=
-      villagesql::count_global_tables(table_list) - tables_before;
-
   // VillageSQL: Clears villagesql_alter_custom_fields on all exit paths and
   // rolls back victionary modifications unless disarmed after a successful
   // store().

--- a/villagesql/schema/util.cc
+++ b/villagesql/schema/util.cc
@@ -24,4 +24,10 @@ bool is_villagesql_system_table(const TABLE *table) {
   return is_villagesql_schema(table->s->db.str);
 }
 
+uint count_global_tables(const Table_ref *first) {
+  uint n = 0;
+  for (const Table_ref *tl = first; tl != nullptr; tl = tl->next_global) ++n;
+  return n;
+}
+
 }  // namespace villagesql

--- a/villagesql/schema/util.h
+++ b/villagesql/schema/util.h
@@ -21,6 +21,7 @@
 #include "villagesql/schema/schema_manager.h"
 
 struct TABLE;
+class Table_ref;
 
 namespace villagesql {
 
@@ -60,6 +61,10 @@ inline bool is_villagesql_system_table(const char *schema_name,
 // This allows INFORMATION_SCHEMA views to query villagesql tables
 // without triggering InnoDB locking assertions.
 bool is_villagesql_system_table(const TABLE *table);
+
+// Number of tables reachable through the next_global chain from `first`
+// (0 if `first` is nullptr).
+uint count_global_tables(const Table_ref *first);
 
 }  // namespace villagesql
 

--- a/villagesql/sql/metadata_modifier.cc
+++ b/villagesql/sql/metadata_modifier.cc
@@ -1066,6 +1066,7 @@ bool Metadata_modifier::add_system_tables(THD *thd, bool marked_column,
     villagesql_error("Cannot open VillageSQL system tables", MYF(0));
     return true;
   }
+  system_tables_opened_ = counter;
   return false;
 }
 
@@ -1143,12 +1144,17 @@ bool Metadata_modifier::process_create(THD *thd,
 bool Metadata_modifier::process_alter(THD *thd,
                                       const HA_CREATE_INFO *create_info,
                                       Table_ref *table_list,
-                                      const Alter_info *alter_info) {
+                                      const Alter_info *alter_info,
+                                      uint *tables_opened) {
   // Tmp tables are handles separately.
   if (!table_list || !table_list->table ||
       table_list->table->s->tmp_table != NO_TMP_TABLE) {
     return false;
   }
+
+#ifndef NDEBUG
+  const uint tables_before = count_global_tables(table_list);
+#endif
 
   Metadata_modifier custom_modifier;
 
@@ -1199,6 +1205,15 @@ bool Metadata_modifier::process_alter(THD *thd,
   if (custom_modifier.lock_and_apply(thd)) {
     return true;
   }
+
+  // Keep the caller's tables_opened count in sync with the system tables
+  // add_system_tables() appended to the query-tables list. The debug assertion
+  // verifies this internal count matches the actual growth of the next_global
+  // chain that lock_tables() will walk.
+  if (tables_opened != nullptr)
+    *tables_opened += custom_modifier.system_tables_opened_;
+  assert(count_global_tables(table_list) - tables_before ==
+         custom_modifier.system_tables_opened_);
 
   return false;
 }

--- a/villagesql/sql/metadata_modifier.h
+++ b/villagesql/sql/metadata_modifier.h
@@ -104,10 +104,14 @@ class Metadata_modifier {
   static bool process_drop(THD *thd, const TableContainer &tables);
 
   // Process custom columns for ALTER TABLE operations.
+  // If tables_opened is non-null, it is increased by the number of VillageSQL
+  // system tables appended to the query-tables list, so the caller can keep an
+  // Alter_table_ctx::tables_opened count in sync with the grown next_global
+  // chain that lock_tables() will walk.
   // Returns false on success, true on error.
   static bool process_alter(THD *thd, const HA_CREATE_INFO *create_info,
-                            Table_ref *table_list,
-                            const Alter_info *alter_info);
+                            Table_ref *table_list, const Alter_info *alter_info,
+                            uint *tables_opened = nullptr);
 
   // Process custom columns for RENAME TABLE operations.
   // table_list contains pairs of tables (old, new, old, new, ...).
@@ -224,7 +228,8 @@ class Metadata_modifier {
 
   // Add system tables for staged modifications to the query list.
   // Opens COLUMNS_TABLE_NAME only if marked_column, and INDEXES_TABLE_NAME
-  // and INDEX_COLUMNS_TABLE_NAME only if marked_index.
+  // and INDEX_COLUMNS_TABLE_NAME only if marked_index. Records the number of
+  // tables opened in system_tables_opened_.
   // Returns false on success, true on error.
   bool add_system_tables(THD *thd, bool marked_column, bool marked_index);
 
@@ -250,6 +255,8 @@ class Metadata_modifier {
   // Custom index entries staged for deletion
   std::vector<IndexEntry> to_remove_indexes_;
   std::vector<IndexColumnEntry> to_remove_index_columns_;
+  // Number of VillageSQL system tables opened by add_system_tables().
+  uint system_tables_opened_ = 0;
 };
 
 // Template implementation for process_drop


### PR DESCRIPTION
tables_opened was not being adjusted even when the list grew from our system tables being opened

#822
