### PR TITLE
Fix setup_linux_build_env.sh refs

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -22,7 +22,7 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install build dependencies using setup script
-COPY scripts/setup_linux_build_env.sh /tmp/
+COPY villagesql/bld_tools/setup_linux_build_env.sh /tmp/
 RUN /tmp/setup_linux_build_env.sh && rm -rf /var/lib/apt/lists/* && rm /tmp/setup_linux_build_env.sh
 
 # Set environment variables

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -25,7 +25,7 @@ FROM ubuntu:24.04 AS builder
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install build dependencies
-COPY scripts/setup_linux_build_env.sh /tmp/
+COPY villagesql/bld_tools/setup_linux_build_env.sh /tmp/
 RUN /tmp/setup_linux_build_env.sh && rm -rf /var/lib/apt/lists/*
 
 # Copy source tree (excluding docker/ so script changes don't invalidate the


### PR DESCRIPTION
## Description

Removes references to `scripts/setup_linux_build_env.sh` in favor of the current location under `villagesql/bld_tools/ `.

This is preparation for the removal of `scripts/setup_linux_build_env.sh` in a separate PR.  A separate PR for the deletion makes it simple to revert if unexpected reference arise.

## Related Issue

Part of the Cleanup release-dev-server #595 effort.

## How was this tested?

Both Docker builds seemed to work fine
```
$ docker buildx build \
--platform linux/amd64  -f docker/dev/Dockerfile  --build-arg VSQL_DEV_ABI=ON \
-t test-tag  /Users/leeca/Projects/vsql/git/villagesql-server_2

$ docker buildx build \
--platform linux/amd64  -f docker/server/Dockerfile  --build-arg VSQL_DEV_ABI=ON \
-t test-tag  /Users/leeca/Projects/vsql/git/villagesql-server_2
```