### PR TITLE
Drop redundant unit test make

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -75,18 +75,11 @@ jobs:
 
     - name: Build VillageSQL
       working-directory: ./source
-      run: |
-        ./villagesql/bld_tools/build_ci.sh
-
-        # Include the extra tests
-        cd "$BUILD_DIR"
-        make "-j$PARALLEL_JOBS" abi_v1_check-t abi_v2_check-t \
-          custom_indexes-t semver-t type_descriptor-t type_builder-t \
-          type_context-t validate-t victionary_client-t
-
       env:
         PARALLEL_JOBS: 16
         BUILD_TYPE: ${{ inputs.build-type }}
+      run: |
+        ./villagesql/bld_tools/build_ci.sh
 
     - name: Run standard tests (unit, integration with only suite village)
       uses: ./source/.github/actions/run-tests


### PR DESCRIPTION
## Description

Additional research into `build_ci` revealed that these tests are always included via the `villagesql-unit-tests` target.  Building them again is harmless but redundant, so don't.

## Related Issue

Part of the [Server]: Overhaul CI #819 effort.
