### PR TITLE
Report inputs in RSB workflow

### DIFF
--- a/.github/workflows/release-server-branch.yml
+++ b/.github/workflows/release-server-branch.yml
@@ -30,6 +30,7 @@ on:
         description: 'Git tag, branch, or SHA to build from (e.g. 0.0.4 or main).'
         required: true
         type: string
+        default: 'main'
       release_tag:
         description: 'GitHub Release to attach artifacts to. Defaults to "ref". Leave blank to skip upload (useful for test builds — artifacts are still available for download from the Actions run page).'
         required: false
@@ -45,6 +46,16 @@ permissions:
   contents: read
 
 jobs:
+  report-parameters:
+    name: Report Parameters
+    runs-on: self-hosted
+    steps:
+    - name: Report Parameters
+      run: |
+        echo "Git Rev: ${{ inputs.ref }}"
+        echo "Release Tag: ${{ inputs.release_tag }}"
+        echo "Release Build: ${{ inputs.release_build }}"
+
   build:
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Description

Adds clear reporting of the input parameters for the Release Server Branch (RSB) workflow.

Also add main as the default ref / "commitish" as for the workflow_dispatch UX.

## Related Issue

Part of the Cleanup release-dev-server https://github.com/villagesql/villagesql-server/issues/595 effort.
