### PR TITLE
reject duplicate VDF names in extenssion

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_duplicate_vdf.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_duplicate_vdf.result
@@ -1,0 +1,11 @@
+call mtr.add_suppression("Failed to load VEF extension");
+call mtr.add_suppression("already exists");
+Creating extension dup_vdf using SDK...
+Created dup_vdf.veb
+# INSTALL fails: duplicate VDF name within one extension.
+INSTALL EXTENSION dup_vdf;
+ERROR HY000: Failed to install extension 'dup_vdf': VDF 'DUP_VDF' already exists
+# Verify extension was NOT installed.
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS
+WHERE extension_name = 'dup_vdf';
+EXTENSION_NAME	EXTENSION_VERSION

--- a/mysql-test/suite/villagesql/extension/t/extension_duplicate_vdf.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_duplicate_vdf.test
@@ -1,0 +1,18 @@
+# Scenario: an extension that registers two VDFs with the same name must be
+# rejected at INSTALL EXTENSION time. The extension (std_data/dup_vdf.cc)
+# registers DUP_VDF twice; it is built on the fly and installed here.
+
+call mtr.add_suppression("Failed to load VEF extension");
+call mtr.add_suppression("already exists");
+
+--let $extension_name = dup_vdf
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/dup_vdf.cc
+--source include/villagesql/create_extension_sdk.inc
+
+--echo # INSTALL fails: duplicate VDF name within one extension.
+--error ER_VILLAGESQL_GENERIC_ERROR
+INSTALL EXTENSION dup_vdf;
+
+--echo # Verify extension was NOT installed.
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS
+WHERE extension_name = 'dup_vdf';

--- a/mysql-test/suite/villagesql/std_data/dup_vdf.cc
+++ b/mysql-test/suite/villagesql/std_data/dup_vdf.cc
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Bad-registration test: an extension that registers two VDFs with the SAME
+// name ("DUP_VDF"). Registration must reject the extension at INSTALL EXTENSION
+// time. The impl bodies are irrelevant -- registration fails on the duplicate
+// before any function is ever called.
+
+#include <villagesql/vsql.h>
+
+using namespace vsql;
+
+static void dup_impl_1(vsql::IntArg a, vsql::IntResult out) {
+  if (a.is_null()) {
+    out.set_null();
+    return;
+  }
+  out.set(a.value());
+}
+
+static void dup_impl_2(vsql::IntArg a, vsql::IntResult out) {
+  if (a.is_null()) {
+    out.set_null();
+    return;
+  }
+  out.set(a.value());
+}
+
+VEF_GENERATE_ENTRY_POINTS(
+    make_extension()
+        .func(make_func<&dup_impl_1>("DUP_VDF").returns(INT).param(INT).build())
+        .func(
+            make_func<&dup_impl_2>("DUP_VDF").returns(INT).param(INT).build()))

--- a/villagesql/veb/register.cc
+++ b/villagesql/veb/register.cc
@@ -76,12 +76,25 @@ bool register_validated_extension(THD &thd, ValidatedRegistration validated,
             type_name.c_str());
   }
 
+  // Detects a VDF registered more than once within this same extension batch.
+  // get_committed() below only sees already-committed descriptors, not the ones
+  // marked for insertion earlier in this loop, so a same-named duplicate inside
+  // one extension would otherwise slip through.
+  std::set<FuncKey> seen_func_keys;
+
   for (auto &descriptor : validated.funcs) {
     std::string func_name = descriptor.function_name();
     std::string ext_name = descriptor.extension_name();
 
     LogVSQL(INFORMATION_LEVEL, "Registering VDF '%s' from extension '%s'",
             func_name.c_str(), ext_name.c_str());
+
+    if (!seen_func_keys.insert(descriptor.key()).second) {
+      error_out = "VDF '" + func_name + "' already exists";
+      LogVSQL(ERROR_LEVEL, "Extension '%s': %s", ext_name.c_str(),
+              error_out.c_str());
+      return true;
+    }
 
     const FuncDescriptor *existing =
         victionary.funcs().get_committed(descriptor.key());


### PR DESCRIPTION
Guard the loop with an in-batch std::set<FuncKey> of seen keys, mirroring the equivalent fix for custom type names.

Closes #843