### PR TITLE
Self host mac github runner

### DIFF
--- a/.github/workflows/build-server-branch.yml
+++ b/.github/workflows/build-server-branch.yml
@@ -173,6 +173,8 @@ jobs:
       - name: Checkout bundled extensions
         if: env.BUILD_BUNDLED_EXTENSIONS == '1'
         run: |
+          # Self-hosted runners reuse the workspace; wipe stale extension clones
+          rm -rf "$EXTS_ROOT"
           mkdir -p "$EXTS_ROOT/sources"
           source/villagesql/bld_tools/checkout_bundled_extensions.sh \
             "$EXTS_ROOT/sources"

--- a/.github/workflows/extension-compat-suite.yml
+++ b/.github/workflows/extension-compat-suite.yml
@@ -160,6 +160,8 @@ jobs:
 
       - name: Clone extension
         run: |
+          # Self-hosted runners reuse the workspace; wipe any stale clone.
+          rm -rf extension
           CLONE_ARGS=(--depth=1)
           [[ -n "${{ matrix.branch }}" ]] && CLONE_ARGS+=(--branch "${{ matrix.branch }}")
           git clone "${CLONE_ARGS[@]}" ${{ matrix.url }} extension/

--- a/.github/workflows/release-server-branch.yml
+++ b/.github/workflows/release-server-branch.yml
@@ -67,7 +67,7 @@ jobs:
           - runner: ubuntu-24.04-arm
             platform: linux-aarch64
             os: linux
-          - runner: macos-latest
+          - runner: [self-hosted, macOS, ARM64]
             platform: macos-arm64
             os: macos
     uses: ./.github/workflows/build-server-branch.yml

--- a/scripts/villagesql_build-compat-matrix.sh
+++ b/scripts/villagesql_build-compat-matrix.sh
@@ -54,7 +54,7 @@ fi
 ALL_PLATFORMS='[
   {"platform":"linux-x86_64","runner":["self-hosted","linux","x86_64"],"os":"linux"},
   {"platform":"linux-aarch64","runner":"ubuntu-24.04-arm","os":"linux"},
-  {"platform":"macos-arm64","runner":"macos-latest","os":"macos"}
+  {"platform":"macos-arm64","runner":["self-hosted","macOS","ARM64"],"os":"macos"}
 ]'
 
 if [ -n "${PLATFORM_FILTER:-}" ]; then


### PR DESCRIPTION
## Description

  Point all macOS CI builds at the self-hosted Apple Silicon runner
  (`[self-hosted, macOS, ARM64]`) instead of GitHub-hosted `macos-latest`:

  - `scripts/villagesql_build-compat-matrix.sh`: macos-arm64 -> self-hosted (extension-compat)
  - `release-server-branch.yml`: macos-arm64 -> self-hosted

The document lists the process followed to setup the self-hosted runner: https://docs.google.com/document/d/1_KbNCpuOjlXq7bOADH9MbRxtsD8XwybW1xTH7kXq-bY/edit?usp=drive_link

  ## Related Issue

  Closes https://github.com/villagesql/villagesql-tools/issues/34

  ## How was this tested?

  Ran the runner as a non-root service on the self-hosted Mac and dispatched:

  ```bash
  gh workflow run extension-compat.yml --ref <branch> -f platform=macos-arm64

  Full matrix green: server + SDK built (brew deps installed), and all bundled
  extension suites passed
  ```

Successful workflows: 
Extension SDK Compatibility - https://github.com/villagesql/villagesql-server/actions/runs/29946035361
Release Server Branch - https://github.com/villagesql/villagesql-server/actions/runs/29949316182
