### PR TITLE
vef: cleanup README

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,6 +15,17 @@ This is VillageSQL Server, a fork of MySQL 8.4.6 LTS that adds VillageSQL Extens
 - [Adding System Tables](villagesql/schema/ADDING_SYSTEM_TABLES.md) - Guide for adding new VillageSQL system tables to victionary
 - [Error Handling](Docs/ERROR_HANDLING.md) - strategies for handling errors in VillageSQL and the boundary with MySQL
 - [CI Build Cache](.github/CI_BUILD_CACHE.md) - How CI build caching works, known issues, and diagnostics
+- [VEF SDK Overview](villagesql/sdk/README.md) - The extension SDK, protocol versions, and how to stabilize a protocol
+- [VEF API vs ABI](villagesql/sdk/API_ABI.md) - The API/ABI distinction and the rules for evolving each compatibly
+
+**When changing the VEF framework** (anything under `villagesql/sdk/`, especially
+the ABI in `villagesql/sdk/include/villagesql/abi/types.h`), update the SDK
+documentation in the same change:
+- Keep the protocol-version table in `villagesql/sdk/README.md` in sync with the
+  `vef_protocol_t` enum in `abi/types.h` (the enum is the source of truth).
+- Update `villagesql/sdk/API_ABI.md` when the API/ABI contract or its evolution
+  rules change, and the relevant `README.md` files under
+  `villagesql/sdk/include/villagesql/` (`abi/`, `preview/`).
 
 ## Key Development Commands
 

--- a/villagesql/sdk/README.md
+++ b/villagesql/sdk/README.md
@@ -37,10 +37,15 @@ server.
 
 ### Current Protocol Versions
 
-| Version          | Status         | Notes                                                                      |
-| ---------------- | -------------- | -------------------------------------------------------------------------- |
-| `VEF_PROTOCOL_1` | Stable         | Base protocol. Planned to be deprecated before beta.                       |
-| `VEF_PROTOCOL_2` | In development | Adds `deterministic` flag, VDF-based type operations, parameterized types. |
+| Version          | Status         | Notes                                                                                                                                                                                              |
+| ---------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `VEF_PROTOCOL_1` | Stable         | Base protocol (stable as of v0.0.1). Likely to be deprecated before beta.                                                                                                                        |
+| `VEF_PROTOCOL_2` | Deprecated     | Was the unstable development version before being promoted to `VEF_PROTOCOL_3`. The server rejects extensions that declare this version, and no `stable_sdk/v2` snapshot exists.                  |
+| `VEF_PROTOCOL_3` | Stable         | Stable as of v0.0.4. Adds the `deterministic` VDF attribute; VDF-based type operations (encode/decode/compare/hash and int_to_params/resolve_params name fields); a values pointer array; and the preview-capability system. |
+| `VEF_PROTOCOL_4` | In development | Adds `max_result_length` on `vef_func_desc_t` so a STRING result column can be sized to the full value instead of the argument width.                                                             |
+
+The enum in `villagesql/sdk/include/villagesql/abi/types.h` is the source of truth
+for protocol status; keep this table in sync with it.
 
 ### Changing the ABI/API
 


### PR DESCRIPTION
## Description

Cleans up the README for the SDK to reflect we are on proto v4

## Related Issue

n/a

## How was this tested?

n/a

## Checklist

- [X] I have signed the CLA
- [X] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [X] I have added or updated tests as appropriate
- [X] My changes maintain compatibility with upstream MySQL 8.4
