### PR TITLE
Custom Index: Fix leak in SDK C++ wrapper

### DIFF
--- a/villagesql/sdk/include/villagesql/preview/index_builder.h
+++ b/villagesql/sdk/include/villagesql/preview/index_builder.h
@@ -256,6 +256,7 @@ namespace vsql::preview_index_builder {
 
 using Arena = vsql::preview_storage::Arena;
 
+using vsql::preview_storage::detail::AllocateArenaStorage;
 using vsql::preview_storage::detail::ERROR_MSG_SIZE;
 using vsql::preview_storage::detail::tl_error_msg;
 
@@ -500,14 +501,15 @@ struct CreateWrapper {
                      vef_storage_arena_func_t arena_alloc,
                      vef_storage_ctx_t **storage, char *error_msg,
                      uint32_t error_msg_len) {
-    auto *arena = new (std::nothrow) Arena(arena_ctx, arena_alloc);
-    if (arena == nullptr) {
+    void *arena_mem = AllocateArenaStorage(arena_ctx, arena_alloc);
+    if (arena_mem == nullptr) {
       snprintf(error_msg, error_msg_len, "out of memory allocating arena");
       return true;
     }
+    auto *arena = new (arena_mem) Arena(arena_ctx, arena_alloc);
     auto *ctx = arena->construct<Index::StorageCtx<Context>>(arena);
     if (ctx == nullptr || ctx->user() == nullptr) {
-      delete arena;
+      arena->~Arena();
       snprintf(error_msg, error_msg_len,
                "out of memory allocating index storage context");
       return true;
@@ -516,7 +518,7 @@ struct CreateWrapper {
     const Index index{*index_ctx};
     bool err = F(ctx, index, space_ref, trx_ref, error_msg, error_msg_len);
     if (err) {
-      delete arena;
+      arena->~Arena();
       *storage = nullptr;
     }
     return err;
@@ -532,7 +534,7 @@ struct DropWrapper {
     Arena *arena = &ctx->arena();
     const Index index{*index_ctx};
     bool err = F(ctx, index, trx_ref, error_msg, error_msg_len);
-    delete arena;
+    arena->~Arena();
     return err;
   }
 };
@@ -545,14 +547,15 @@ struct LoadWrapper {
                      vef_storage_arena_func_t arena_alloc,
                      vef_storage_ctx_t **storage, char *error_msg,
                      uint32_t error_msg_len) {
-    auto *arena = new (std::nothrow) Arena(arena_ctx, arena_alloc);
-    if (arena == nullptr) {
+    void *arena_mem = AllocateArenaStorage(arena_ctx, arena_alloc);
+    if (arena_mem == nullptr) {
       snprintf(error_msg, error_msg_len, "out of memory allocating arena");
       return true;
     }
+    auto *arena = new (arena_mem) Arena(arena_ctx, arena_alloc);
     auto *ctx = arena->construct<Index::StorageCtx<Context>>(arena);
     if (ctx == nullptr || ctx->user() == nullptr) {
-      delete arena;
+      arena->~Arena();
       snprintf(error_msg, error_msg_len,
                "out of memory allocating index storage context");
       return true;
@@ -561,7 +564,7 @@ struct LoadWrapper {
     const Index index{*index_ctx};
     bool err = F(ctx, index, storage_ref, error_msg, error_msg_len);
     if (err) {
-      delete arena;
+      arena->~Arena();
       *storage = nullptr;
     }
     return err;

--- a/villagesql/sdk/include/villagesql/preview/storage_api.h
+++ b/villagesql/sdk/include/villagesql/preview/storage_api.h
@@ -823,6 +823,24 @@ class Arena {
   }
 };
 
+namespace detail {
+
+// Allocates storage for the Arena object itself out of the extension memory
+// arena, rather than the process heap. The object's storage is reclaimed
+// together with the rest of the extension arena.
+//
+// TODO(villagesql-indexing): Add an unload hook so ~Arena() is invoked even
+// when the extension arena is reclaimed without explicitly destroying the
+// Arena object (e.g. dict cache eviction, table close, or server shutdown).
+inline void *AllocateArenaStorage(vef_storage_arena_t *arena_ctx,
+                                  vef_storage_arena_func_t arena_alloc) {
+  // Arena's alignment is already covered by the allocator's minimum guarantee.
+  static_assert(alignof(Arena) <= VEF_STORAGE_MIN_ALLOCATOR_ALIGNMENT);
+  return arena_alloc(arena_ctx, sizeof(Arena));
+}
+
+}  // namespace detail
+
 // StorageCtx<T> wraps the persistent storage reference and a user context of
 // type T allocated from the InnoDB arena. The storage builder wrappers
 // construct it before calling the extension and delete the Arena on column

--- a/villagesql/sdk/include/villagesql/preview/storage_builder.h
+++ b/villagesql/sdk/include/villagesql/preview/storage_builder.h
@@ -219,6 +219,7 @@ namespace detail {
 template <typename UserCtx>
 using StorageCtx = vsql::preview_storage::Column::StorageCtx<UserCtx>;
 using Arena = vsql::preview_storage::Arena;
+using vsql::preview_storage::detail::AllocateArenaStorage;
 
 // Expected extension function pointer types. Each StorageBuilder setter
 // static_asserts that F exactly matches the corresponding type alias.
@@ -278,14 +279,15 @@ struct CreateWrapper {
                      vef_storage_arena_func_t arena_alloc,
                      vef_storage_ctx_t **storage, char *error_msg,
                      uint32_t error_msg_len) {
-    auto *arena = new (std::nothrow) Arena(arena_ctx, arena_alloc);
-    if (arena == nullptr) {
+    void *arena_mem = AllocateArenaStorage(arena_ctx, arena_alloc);
+    if (arena_mem == nullptr) {
       snprintf(error_msg, error_msg_len, "out of memory allocating arena");
       return true;
     }
+    auto *arena = new (arena_mem) Arena(arena_ctx, arena_alloc);
     auto *ctx = arena->construct<StorageCtx<UserCtx>>(arena);
     if (ctx == nullptr || ctx->user() == nullptr) {
-      delete arena;
+      arena->~Arena();
       snprintf(error_msg, error_msg_len,
                "out of memory allocating storage context");
       return true;
@@ -293,7 +295,7 @@ struct CreateWrapper {
     *storage = reinterpret_cast<vef_storage_ctx_t *>(ctx);
     bool err = F(ctx, space_ref, trx_ref, col_len, error_msg, error_msg_len);
     if (err) {
-      delete arena;
+      arena->~Arena();
       *storage = nullptr;
     }
     return err;
@@ -307,7 +309,7 @@ struct DropWrapper {
     auto *ctx = reinterpret_cast<StorageCtx<UserCtx> *>(storage);
     Arena *arena = &ctx->arena();
     bool err = F(ctx, trx_ref, error_msg, error_msg_len);
-    delete arena;
+    arena->~Arena();
     return err;
   }
 };
@@ -319,14 +321,15 @@ struct LoadWrapper {
                      vef_storage_arena_func_t arena_alloc,
                      vef_storage_ctx_t **storage, char *error_msg,
                      uint32_t error_msg_len) {
-    auto *arena = new (std::nothrow) Arena(arena_ctx, arena_alloc);
-    if (arena == nullptr) {
+    void *arena_mem = AllocateArenaStorage(arena_ctx, arena_alloc);
+    if (arena_mem == nullptr) {
       snprintf(error_msg, error_msg_len, "out of memory allocating arena");
       return true;
     }
+    auto *arena = new (arena_mem) Arena(arena_ctx, arena_alloc);
     auto *ctx = arena->construct<StorageCtx<UserCtx>>(arena);
     if (ctx == nullptr || ctx->user() == nullptr) {
-      delete arena;
+      arena->~Arena();
       snprintf(error_msg, error_msg_len,
                "out of memory allocating storage context");
       return true;
@@ -334,7 +337,7 @@ struct LoadWrapper {
     *storage = reinterpret_cast<vef_storage_ctx_t *>(ctx);
     bool err = F(ctx, storage_ref, error_msg, error_msg_len);
     if (err) {
-      delete arena;
+      arena->~Arena();
       *storage = nullptr;
     }
     return err;


### PR DESCRIPTION
Allocate the Arena object itself from the extension arena instead of the process heap. Its storage is reclaimed together with the rest of the extension arena, avoiding a memory leak.

Part of #822