### PR TITLE
auth: IDENTIFIED BY bug

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-auth/r/auth_identified_by.result
+++ b/mysql-test/suite/villagesql/extension/vsql-auth/r/auth_identified_by.result
@@ -1,0 +1,8 @@
+INSTALL EXTENSION vsql_auth_test;
+CREATE USER by_ok IDENTIFIED WITH vsql_auth_test;
+DROP USER by_ok;
+CREATE USER by_bad IDENTIFIED WITH vsql_auth_test BY 'pw';
+ERROR HY000: The password hash doesn't have the expected format.
+DROP USER by_bad;
+ERROR HY000: Operation DROP USER failed for 'by_bad'@'%'
+UNINSTALL EXTENSION vsql_auth_test;

--- a/mysql-test/suite/villagesql/extension/vsql-auth/t/auth_identified_by.test
+++ b/mysql-test/suite/villagesql/extension/vsql-auth/t/auth_identified_by.test
@@ -1,0 +1,22 @@
+# CREATE USER ... IDENTIFIED WITH vsql_auth_test BY '<pw>' must be REJECTED.
+#
+# IDENTIFIED BY '...' supplies a password for the method to turn into a stored
+# credential (what a MySQL plugin does via generate_authentication_string()).
+# The vsql_auth_test extension does not implement the BY clause, so the server
+# rejects it with ER_PASSWORD_FORMAT rather than silently storing the string as
+# the auth string. auth_basic.test only covers plain IDENTIFIED WITH (no BY/AS),
+# so this path was never exercised -- this test closes that gap.
+
+INSTALL EXTENSION vsql_auth_test;
+
+# Plain IDENTIFIED WITH is the valid bind form -> accepted.
+CREATE USER by_ok IDENTIFIED WITH vsql_auth_test;
+DROP USER by_ok;
+
+# The BY clause is rejected, and no account is created.
+--error ER_PASSWORD_FORMAT
+CREATE USER by_bad IDENTIFIED WITH vsql_auth_test BY 'pw';
+--error ER_CANNOT_USER
+DROP USER by_bad;
+
+UNINSTALL EXTENSION vsql_auth_test;

--- a/sql/auth/sql_user.cc
+++ b/sql/auth/sql_user.cc
@@ -1650,17 +1650,17 @@ bool set_and_validate_user_attributes(
   plugin = my_plugin_lock_by_name(nullptr, Str->first_factor_auth_info.plugin,
                                   MYSQL_AUTHENTICATION_PLUGIN);
 
-  // VillageSQL: an unknown plugin name may be a VEF extension auth method;
-  // accept it the same way an installed plugin name is accepted.
-  if (!plugin && villagesql::services::auth_method_exists(
-                     {Str->first_factor_auth_info.plugin.str,
-                      Str->first_factor_auth_info.plugin.length})) {
-    what_to_set.m_what = NONE_ATTR;
-    return false;
-  }
-
   /* check if plugin is loaded */
   if (!plugin) {
+    // VillageSQL: an unknown plugin name may be a VEF extension auth method;
+    // let the VEF layer decide whether to accept the account.
+    if (auto handled = villagesql::services::handle_vef_user_bind(
+            {Str->first_factor_auth_info.plugin.str,
+             Str->first_factor_auth_info.plugin.length},
+            Str->first_factor_auth_info.uses_identified_by_clause)) {
+      what_to_set.m_what = NONE_ATTR;
+      return *handled;
+    }
     what_to_set.m_what = NONE_ATTR;
     my_error(ER_PLUGIN_IS_NOT_LOADED, MYF(0),
              Str->first_factor_auth_info.plugin.str);

--- a/villagesql/services/preview/auth.cc
+++ b/villagesql/services/preview/auth.cc
@@ -209,16 +209,27 @@ const vef_auth_cc_t *find_auth_method(std::string_view method_name) {
   return nullptr;
 }
 
-bool auth_method_exists(std::string_view method_name) {
-  return find_auth_method(method_name) != nullptr;
-}
-
 std::optional<bool> handle_vef_user_bind(std::string_view method_name,
                                          bool uses_identified_by_clause) {
-  if (!auth_method_exists(method_name)) return std::nullopt;
+  // Existence check only -- the returned pointer is compared, not dereferenced,
+  // so no AuthMethodRef is needed (g_mu inside find_auth_method makes the
+  // search race-free; nothing here uses the method after the lock is dropped).
+  if (find_auth_method(method_name) == nullptr) return std::nullopt;
   if (uses_identified_by_clause) {
-    // IDENTIFIED BY '...' asks the (non-existent) plugin to hash a password;
-    // meaningless for a VEF method. Reject rather than silently ignore.
+    // IDENTIFIED BY '...' supplies a password for the method to turn into a
+    // stored credential -- the job a MySQL plugin does via
+    // generate_authentication_string(). No VEF method today declares such
+    // credential handling, so reject rather than silently store the string as
+    // the auth string.
+    //
+    // TODO(villagesql-beta): make this a per-method capability, not a blanket
+    // reject. Whether BY is valid depends on the method's own content (does it
+    // declare a credential hook, mirroring st_mysql_auth's
+    // AUTH_FLAG_USES_INTERNAL_STORAGE + generate_authentication_string?), so
+    // the decision belongs where the method's cc is actually inspected --
+    // which, unlike this existence check, must hold an AuthMethodRef across the
+    // inspection (the extension may be uninstalled mid-statement). An API-key
+    // method that provides the hook would then accept BY and hash the key.
     my_error(ER_PASSWORD_FORMAT, MYF(0));
     return true;
   }

--- a/villagesql/services/preview/auth.h
+++ b/villagesql/services/preview/auth.h
@@ -77,10 +77,6 @@ class AuthMethodRef {
 // than reaching into the registry internals above -- mirroring how
 // sql/sql_audit.cc calls on_statement_postexecute() directly.
 
-// Existence check, used by CREATE USER validation to accept a VEF auth-method
-// name the same way an installed plugin name is accepted.
-bool auth_method_exists(std::string_view method_name);
-
 // Handle a CREATE USER ... IDENTIFIED WITH <method_name> [BY '...'] whose name
 // is not a loaded MySQL auth plugin, deciding whether it names a VEF extension
 // auth method.


### PR DESCRIPTION
IDENTIFIED WITH 'auth method' BY 'password'. only makes sense for some auth extensions, do not accept BY for now, no needed for our current work. Supporting it needs extending the ABI, no current plans to implement such an extension 
