### PR TITLE
CI: Validate single commit titles

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -52,12 +52,19 @@ jobs:
         head_sha=$(git rev-parse ${{ github.sha }}^2)
         merge_base=$(git merge-base "$base_sha" "$head_sha")
         echo "VILLINT_COMMIT=$merge_base" >> $GITHUB_ENV
+        # When the PR is a single commit, GitHub overwrites the PR title with
+        # that commit's title on merge, so it must pass title validation too.
+        commit_count=$(git rev-list --count "$merge_base..$head_sha")
+        if [ "$commit_count" -eq 1 ]; then
+          echo "SINGLE_COMMIT_TITLE=$(git log -1 --format=%s "$head_sha")" >> $GITHUB_ENV
+        fi
         # Checkout PR head so villint diffs against the actual PR changes
         git checkout "$head_sha"
 
     - name: Validate PR title
       env:
         PR_TITLE: ${{ github.event.pull_request.title }}
+        SINGLE_COMMIT_TITLE: ${{ env.SINGLE_COMMIT_TITLE }}
       run: ./scripts/validate-pr-title.sh "$PR_TITLE"
 
     - name: Install clang-format

--- a/scripts/validate-pr-title.sh
+++ b/scripts/validate-pr-title.sh
@@ -4,8 +4,15 @@
 # Validates a PR title for length and ending character.
 # Usage: validate-pr-title.sh "PR title to validate"
 #   or:  PR_TITLE="PR title" validate-pr-title.sh
+#
+# When a PR contains a single commit, GitHub overwrites the PR title with that
+# commit's title on merge, and the commit title never goes through this check.
+# Pass the single commit's title so it is validated too:
+#   validate-pr-title.sh "PR title" "single commit title"
+#   or: SINGLE_COMMIT_TITLE="commit title" validate-pr-title.sh
 
 title="${1:-$PR_TITLE}"
+single_commit_title="${2:-$SINGLE_COMMIT_TITLE}"
 
 if [ -z "$title" ]; then
   echo "Usage: validate-pr-title.sh \"PR title to validate\""
@@ -15,13 +22,26 @@ fi
 
 errors=()
 
-if [ ${#title} -gt 41 ]; then
-  errors+=("PR title is ${#title} characters long (max 41 to allow growth to 50 with gh issue numbers)")
-fi
+# Validates one title against the length and ending-punctuation rules,
+# prefixing each error with $1 (e.g. "PR title", "commit title") so the
+# failing title is clear when both are checked.
+validate_title() {
+  local label="$1" value="$2"
+  if [ ${#value} -gt 41 ]; then
+    errors+=("$label is ${#value} characters long (max 41 to allow growth to 50 with gh issue numbers)")
+  fi
+  local last_char="${value: -1}"
+  if [[ "$last_char" =~ [.,\;:!] ]]; then
+    errors+=("$label ends with '$last_char' (must not end with punctuation: . , ; : !)")
+  fi
+}
 
-last_char="${title: -1}"
-if [[ "$last_char" =~ [.,\;:!] ]]; then
-  errors+=("PR title ends with '$last_char' (must not end with punctuation: . , ; : !)")
+validate_title "PR title" "$title"
+
+# A single-commit PR merges with the commit title as the PR title, so that
+# title must satisfy the same rules.
+if [ -n "$single_commit_title" ]; then
+  validate_title "commit title for a single-commit PR (GitHub uses it as the merged PR title)" "$single_commit_title"
 fi
 
 if [ ${#errors[@]} -gt 0 ]; then
@@ -30,7 +50,10 @@ if [ ${#errors[@]} -gt 0 ]; then
     echo "  - $err"
   done
   echo ""
-  echo "Title: \"$title\""
+  echo "PR title: \"$title\""
+  if [ -n "$single_commit_title" ]; then
+    echo "Commit title: \"$single_commit_title\""
+  fi
   exit 1
 fi
 echo "PR title is valid: \"$title\""


### PR DESCRIPTION
This is a major source of long titles slipping into the repo. If we continue to get them, we can take other actions, but this seems like a good first step.

