### PR TITLE
Retire script build-ci and test-ci

### DIFF
--- a/DOCKER.md
+++ b/DOCKER.md
@@ -73,7 +73,7 @@ docker volume rm villagesql-build villagesql-ccache
 ```bash
 # Use the CI build script (recommended - automatically includes CMAKE_EXTRA_FLAGS)
 cd /source
-PARALLEL_JOBS=4 ./scripts/build-ci.sh
+PARALLEL_JOBS=4 ./villagesql/bld_tools/build_ci.sh
 
 # Or manual build (standard release)
 cd /build

--- a/scripts/build-ci.sh
+++ b/scripts/build-ci.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-# Copyright (c) 2026 VillageSQL Contributors
-# Configure and build the VillageSQL server for CI.
-
-# Delegate to the reference implementation in the villagesql/bld_tools directory
-SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SOURCE_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
-
-"$SOURCE_DIR/villagesql/bld_tools/build_ci.sh" "$@"

--- a/scripts/test-ci.sh
+++ b/scripts/test-ci.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-# VillageSQL CI Test Script
-
-# Delegate to the reference implementation in the villagesql/bld_tools directory
-SCRIPTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SOURCE_DIR="$(cd "$SCRIPTS_DIR/.." && pwd)"
-
-"$SOURCE_DIR/villagesql/bld_tools/test_ci.sh" "$@"


### PR DESCRIPTION
## Description

Delete the original `scripts/build-ci.sh` and `scripts/test-ci.sh` now that the `villagesql/bld_tools/` versions are doing the job.

## Related Issue

Part of the Cleanup release-dev-server #595 effort.