### PR TITLE
UBSAN: don't use pointers in constexprs

### DIFF
--- a/villagesql/sdk/include/villagesql/detail/func_builder.h
+++ b/villagesql/sdk/include/villagesql/detail/func_builder.h
@@ -52,10 +52,6 @@ constexpr vef_type_t to_vef_type(const char *name) {
   return vef_type_t{VEF_TYPE_CUSTOM, name};
 }
 
-// Deliberately unimplemented — produces a compile error with a descriptive
-// name when build() detects an invalid aggregate configuration.
-void config_error__aggregate_must_set_both_clear_and_accumulate();
-
 // Auto-generated prerun/postrun for aggregate state management.
 template <typename State>
 void auto_prerun(vef_context_t *, vef_prerun_args_t *,

--- a/villagesql/sdk/include/villagesql/preview/storage_builder.h
+++ b/villagesql/sdk/include/villagesql/preview/storage_builder.h
@@ -414,6 +414,7 @@ class StorageBuilder {
                   "create: expected bool(*)(StorageCtx<UserCtx>*, Space::Ref, "
                   "Segment::TrxRef, uint32_t col_len, char*, uint32_t)");
     intf_.create = detail::CreateWrapper<F, UserCtx>::invoke;
+    registered_ |= kCreate;
     return *this;
   }
 
@@ -424,6 +425,7 @@ class StorageBuilder {
         "drop: expected bool(*)(StorageCtx<UserCtx>*, Segment::TrxRef, "
         "char*, uint32_t)");
     intf_.drop = detail::DropWrapper<F, UserCtx>::invoke;
+    registered_ |= kDrop;
     return *this;
   }
 
@@ -434,6 +436,7 @@ class StorageBuilder {
         "load: expected bool(*)(StorageCtx<UserCtx>*, Column::StorageRef, "
         "char*, uint32_t)");
     intf_.load = detail::LoadWrapper<F, UserCtx>::invoke;
+    registered_ |= kLoad;
     return *this;
   }
 
@@ -444,6 +447,7 @@ class StorageBuilder {
                   "Segment::TrxRef, Column::Data, Column::Data, Column::Ref*, "
                   "char*, uint32_t)");
     intf_.insert = detail::InsertWrapper<F, UserCtx>::invoke;
+    registered_ |= kInsert;
     return *this;
   }
 
@@ -455,6 +459,7 @@ class StorageBuilder {
         "Column::Ref, Column::Data*, Column::Data*, Segment::TrxRef*, "
         "bool*, char*, uint32_t)");
     intf_.select = detail::SelectWrapper<F, UserCtx>::invoke;
+    registered_ |= kSelect;
     return *this;
   }
 
@@ -465,6 +470,7 @@ class StorageBuilder {
         "mark_delete: expected bool(*)(StorageCtx<UserCtx>*, MtrCtx::Ref, "
         "Segment::TrxRef, Column::Ref, bool delete_mark, char*, uint32_t)");
     intf_.mark_delete = detail::MarkDeleteWrapper<F, UserCtx>::invoke;
+    registered_ |= kMarkDelete;
     return *this;
   }
 
@@ -474,12 +480,15 @@ class StorageBuilder {
                   "purge: expected bool(*)(StorageCtx<UserCtx>*, MtrCtx::Ref, "
                   "Segment::TrxRef, Column::Ref, char*, uint32_t)");
     intf_.purge = detail::PurgeWrapper<F, UserCtx>::invoke;
+    registered_ |= kPurge;
     return *this;
   }
 
   constexpr TypeStorageDescriptor build() const {
-    if (!intf_.create || !intf_.drop || !intf_.load || !intf_.insert ||
-        !intf_.select || !intf_.mark_delete || !intf_.purge) {
+    // Track registration with a bitmask rather than testing the wrapper
+    // pointers for null: under -fsanitize a function-pointer-to-null compare
+    // is not a constant expression, which breaks this constexpr builder.
+    if (registered_ != kAllRegistered) {
       // Calling a non-constexpr function here causes a compile-time error
       // when build() is evaluated in a constant expression. The function name
       // appears verbatim in the compiler diagnostic.
@@ -492,8 +501,19 @@ class StorageBuilder {
   }
 
  private:
+  static constexpr unsigned kCreate = 1u << 0;
+  static constexpr unsigned kDrop = 1u << 1;
+  static constexpr unsigned kLoad = 1u << 2;
+  static constexpr unsigned kInsert = 1u << 3;
+  static constexpr unsigned kSelect = 1u << 4;
+  static constexpr unsigned kMarkDelete = 1u << 5;
+  static constexpr unsigned kPurge = 1u << 6;
+  static constexpr unsigned kAllRegistered =
+      kCreate | kDrop | kLoad | kInsert | kSelect | kMarkDelete | kPurge;
+
   const char *type_name_;
   vef_type_storage_intf_t intf_;
+  unsigned registered_ = 0;
 };
 
 // Entry point for creating a StorageBuilder.

--- a/villagesql/sdk/include/villagesql/preview/storage_builder.h
+++ b/villagesql/sdk/include/villagesql/preview/storage_builder.h
@@ -395,112 +395,10 @@ struct PurgeWrapper {
 
 }  // namespace detail
 
-// Non-constexpr: its name appears verbatim in the compiler error when
-// build() is evaluated at compile time with missing interface registrations.
-void StorageBuilder_all_column_storage_interfaces_must_be_registered();
-
-template <typename UserCtx>
+template <typename UserCtx, unsigned Registered = 0>
 class StorageBuilder {
- public:
-  constexpr explicit StorageBuilder(const char *type_name)
-      : type_name_(type_name), intf_{} {}
-
-  // Each setter static_asserts that F exactly matches the expected function
-  // pointer type (detail::CreateFn<UserCtx>, etc.), rejecting wrong signatures,
-  // lambdas, and member function pointers at compile time.
-  template <auto F>
-  constexpr StorageBuilder &create() {
-    static_assert(std::is_same_v<decltype(F), detail::CreateFn<UserCtx>>,
-                  "create: expected bool(*)(StorageCtx<UserCtx>*, Space::Ref, "
-                  "Segment::TrxRef, uint32_t col_len, char*, uint32_t)");
-    intf_.create = detail::CreateWrapper<F, UserCtx>::invoke;
-    registered_ |= kCreate;
-    return *this;
-  }
-
-  template <auto F>
-  constexpr StorageBuilder &drop() {
-    static_assert(
-        std::is_same_v<decltype(F), detail::DropFn<UserCtx>>,
-        "drop: expected bool(*)(StorageCtx<UserCtx>*, Segment::TrxRef, "
-        "char*, uint32_t)");
-    intf_.drop = detail::DropWrapper<F, UserCtx>::invoke;
-    registered_ |= kDrop;
-    return *this;
-  }
-
-  template <auto F>
-  constexpr StorageBuilder &load() {
-    static_assert(
-        std::is_same_v<decltype(F), detail::LoadFn<UserCtx>>,
-        "load: expected bool(*)(StorageCtx<UserCtx>*, Column::StorageRef, "
-        "char*, uint32_t)");
-    intf_.load = detail::LoadWrapper<F, UserCtx>::invoke;
-    registered_ |= kLoad;
-    return *this;
-  }
-
-  template <auto F>
-  constexpr StorageBuilder &insert() {
-    static_assert(std::is_same_v<decltype(F), detail::InsertFn<UserCtx>>,
-                  "insert: expected bool(*)(StorageCtx<UserCtx>*, MtrCtx::Ref, "
-                  "Segment::TrxRef, Column::Data, Column::Data, Column::Ref*, "
-                  "char*, uint32_t)");
-    intf_.insert = detail::InsertWrapper<F, UserCtx>::invoke;
-    registered_ |= kInsert;
-    return *this;
-  }
-
-  template <auto F>
-  constexpr StorageBuilder &select() {
-    static_assert(
-        std::is_same_v<decltype(F), detail::SelectFn<UserCtx>>,
-        "select: expected bool(*)(StorageCtx<UserCtx>*, MtrCtx::Ref, "
-        "Column::Ref, Column::Data*, Column::Data*, Segment::TrxRef*, "
-        "bool*, char*, uint32_t)");
-    intf_.select = detail::SelectWrapper<F, UserCtx>::invoke;
-    registered_ |= kSelect;
-    return *this;
-  }
-
-  template <auto F>
-  constexpr StorageBuilder &mark_delete() {
-    static_assert(
-        std::is_same_v<decltype(F), detail::MarkDeleteFn<UserCtx>>,
-        "mark_delete: expected bool(*)(StorageCtx<UserCtx>*, MtrCtx::Ref, "
-        "Segment::TrxRef, Column::Ref, bool delete_mark, char*, uint32_t)");
-    intf_.mark_delete = detail::MarkDeleteWrapper<F, UserCtx>::invoke;
-    registered_ |= kMarkDelete;
-    return *this;
-  }
-
-  template <auto F>
-  constexpr StorageBuilder &purge() {
-    static_assert(std::is_same_v<decltype(F), detail::PurgeFn<UserCtx>>,
-                  "purge: expected bool(*)(StorageCtx<UserCtx>*, MtrCtx::Ref, "
-                  "Segment::TrxRef, Column::Ref, char*, uint32_t)");
-    intf_.purge = detail::PurgeWrapper<F, UserCtx>::invoke;
-    registered_ |= kPurge;
-    return *this;
-  }
-
-  constexpr TypeStorageDescriptor build() const {
-    // Track registration with a bitmask rather than testing the wrapper
-    // pointers for null: under -fsanitize a function-pointer-to-null compare
-    // is not a constant expression, which breaks this constexpr builder.
-    if (registered_ != kAllRegistered) {
-      // Calling a non-constexpr function here causes a compile-time error
-      // when build() is evaluated in a constant expression. The function name
-      // appears verbatim in the compiler diagnostic.
-      StorageBuilder_all_column_storage_interfaces_must_be_registered();
-    }
-    vef_type_storage_intf_t result = intf_;
-    result.version = VEF_STORAGE_TYPE_INTF_VERSION;
-    result.type_name = type_name_;
-    return TypeStorageDescriptor{result};
-  }
-
- private:
+  // Interface registration bits, accumulated in the Registered template
+  // argument so build() can static_assert that every interface was set.
   static constexpr unsigned kCreate = 1u << 0;
   static constexpr unsigned kDrop = 1u << 1;
   static constexpr unsigned kLoad = 1u << 2;
@@ -511,9 +409,115 @@ class StorageBuilder {
   static constexpr unsigned kAllRegistered =
       kCreate | kDrop | kLoad | kInsert | kSelect | kMarkDelete | kPurge;
 
+ public:
+  constexpr explicit StorageBuilder(const char *type_name)
+      : type_name_(type_name), intf_{} {}
+
+  // Each setter static_asserts that F exactly matches the expected function
+  // pointer type (detail::CreateFn<UserCtx>, etc.), rejecting wrong signatures,
+  // lambdas, and member function pointers at compile time. Each returns a
+  // builder whose Registered mask records the interface, so build() can
+  // static_assert that all interfaces were registered.
+  template <auto F>
+  constexpr StorageBuilder<UserCtx, Registered | kCreate> create() const {
+    static_assert(std::is_same_v<decltype(F), detail::CreateFn<UserCtx>>,
+                  "create: expected bool(*)(StorageCtx<UserCtx>*, Space::Ref, "
+                  "Segment::TrxRef, uint32_t col_len, char*, uint32_t)");
+    StorageBuilder<UserCtx, Registered | kCreate> next{type_name_};
+    next.intf_ = intf_;
+    next.intf_.create = detail::CreateWrapper<F, UserCtx>::invoke;
+    return next;
+  }
+
+  template <auto F>
+  constexpr StorageBuilder<UserCtx, Registered | kDrop> drop() const {
+    static_assert(
+        std::is_same_v<decltype(F), detail::DropFn<UserCtx>>,
+        "drop: expected bool(*)(StorageCtx<UserCtx>*, Segment::TrxRef, "
+        "char*, uint32_t)");
+    StorageBuilder<UserCtx, Registered | kDrop> next{type_name_};
+    next.intf_ = intf_;
+    next.intf_.drop = detail::DropWrapper<F, UserCtx>::invoke;
+    return next;
+  }
+
+  template <auto F>
+  constexpr StorageBuilder<UserCtx, Registered | kLoad> load() const {
+    static_assert(
+        std::is_same_v<decltype(F), detail::LoadFn<UserCtx>>,
+        "load: expected bool(*)(StorageCtx<UserCtx>*, Column::StorageRef, "
+        "char*, uint32_t)");
+    StorageBuilder<UserCtx, Registered | kLoad> next{type_name_};
+    next.intf_ = intf_;
+    next.intf_.load = detail::LoadWrapper<F, UserCtx>::invoke;
+    return next;
+  }
+
+  template <auto F>
+  constexpr StorageBuilder<UserCtx, Registered | kInsert> insert() const {
+    static_assert(std::is_same_v<decltype(F), detail::InsertFn<UserCtx>>,
+                  "insert: expected bool(*)(StorageCtx<UserCtx>*, MtrCtx::Ref, "
+                  "Segment::TrxRef, Column::Data, Column::Data, Column::Ref*, "
+                  "char*, uint32_t)");
+    StorageBuilder<UserCtx, Registered | kInsert> next{type_name_};
+    next.intf_ = intf_;
+    next.intf_.insert = detail::InsertWrapper<F, UserCtx>::invoke;
+    return next;
+  }
+
+  template <auto F>
+  constexpr StorageBuilder<UserCtx, Registered | kSelect> select() const {
+    static_assert(
+        std::is_same_v<decltype(F), detail::SelectFn<UserCtx>>,
+        "select: expected bool(*)(StorageCtx<UserCtx>*, MtrCtx::Ref, "
+        "Column::Ref, Column::Data*, Column::Data*, Segment::TrxRef*, "
+        "bool*, char*, uint32_t)");
+    StorageBuilder<UserCtx, Registered | kSelect> next{type_name_};
+    next.intf_ = intf_;
+    next.intf_.select = detail::SelectWrapper<F, UserCtx>::invoke;
+    return next;
+  }
+
+  template <auto F>
+  constexpr StorageBuilder<UserCtx, Registered | kMarkDelete> mark_delete()
+      const {
+    static_assert(
+        std::is_same_v<decltype(F), detail::MarkDeleteFn<UserCtx>>,
+        "mark_delete: expected bool(*)(StorageCtx<UserCtx>*, MtrCtx::Ref, "
+        "Segment::TrxRef, Column::Ref, bool delete_mark, char*, uint32_t)");
+    StorageBuilder<UserCtx, Registered | kMarkDelete> next{type_name_};
+    next.intf_ = intf_;
+    next.intf_.mark_delete = detail::MarkDeleteWrapper<F, UserCtx>::invoke;
+    return next;
+  }
+
+  template <auto F>
+  constexpr StorageBuilder<UserCtx, Registered | kPurge> purge() const {
+    static_assert(std::is_same_v<decltype(F), detail::PurgeFn<UserCtx>>,
+                  "purge: expected bool(*)(StorageCtx<UserCtx>*, MtrCtx::Ref, "
+                  "Segment::TrxRef, Column::Ref, char*, uint32_t)");
+    StorageBuilder<UserCtx, Registered | kPurge> next{type_name_};
+    next.intf_ = intf_;
+    next.intf_.purge = detail::PurgeWrapper<F, UserCtx>::invoke;
+    return next;
+  }
+
+  constexpr TypeStorageDescriptor build() const {
+    static_assert(Registered == kAllRegistered,
+                  "all column storage interfaces must be registered: create, "
+                  "drop, load, insert, select, mark_delete, and purge");
+    vef_type_storage_intf_t result = intf_;
+    result.version = VEF_STORAGE_TYPE_INTF_VERSION;
+    result.type_name = type_name_;
+    return TypeStorageDescriptor{result};
+  }
+
+ private:
+  template <typename U, unsigned R>
+  friend class StorageBuilder;
+
   const char *type_name_;
   vef_type_storage_intf_t intf_;
-  unsigned registered_ = 0;
 };
 
 // Entry point for creating a StorageBuilder.

--- a/villagesql/sdk/include/villagesql/vsql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_builder.h
@@ -458,25 +458,25 @@ class FuncBuilder {
 // The State type is explicit, and clear/accumulate signatures are validated
 // against State at compile time.
 
-template <typename State, auto Func, size_t NumParams>
+template <typename State, auto Func, size_t NumParams, bool HasClear = false,
+          bool HasAccumulate = false>
 class AggFuncBuilder {
  public:
-  constexpr AggFuncBuilder<State, Func, NumParams> &returns(const char *t) {
+  constexpr AggFuncBuilder<State, Func, NumParams, HasClear, HasAccumulate> &
+  returns(const char *t) {
     return_type_ = t;
     return *this;
   }
 
-  constexpr AggFuncBuilder<State, Func, NumParams + 1> param(
-      const char *t) const {
-    AggFuncBuilder<State, Func, NumParams + 1> next;
+  constexpr AggFuncBuilder<State, Func, NumParams + 1, HasClear, HasAccumulate>
+  param(const char *t) const {
+    AggFuncBuilder<State, Func, NumParams + 1, HasClear, HasAccumulate> next;
     next.name_ = name_;
     next.return_type_ = return_type_;
     next.buffer_size_ = buffer_size_;
     next.max_result_length_ = max_result_length_;
     next.clear_ = clear_;
     next.accumulate_ = accumulate_;
-    next.has_clear_ = has_clear_;
-    next.has_accumulate_ = has_accumulate_;
     next.deterministic_ = deterministic_;
     for (size_t i = 0; i < NumParams; ++i) {
       next.param_types_[i] = param_types_[i];
@@ -485,7 +485,8 @@ class AggFuncBuilder {
     return next;
   }
 
-  constexpr AggFuncBuilder<State, Func, NumParams> &buffer_size(size_t s) {
+  constexpr AggFuncBuilder<State, Func, NumParams, HasClear, HasAccumulate> &
+  buffer_size(size_t s) {
     buffer_size_ = s;
     return *this;
   }
@@ -500,8 +501,8 @@ class AggFuncBuilder {
   // Only valid for a STRING return type. Call .returns(STRING) before this so
   // the return type is known here: a non-STRING return (or an undeclared one)
   // is rejected at build time rather than silently ignored.
-  constexpr AggFuncBuilder<State, Func, NumParams> &max_result_length(
-      size_t n) {
+  constexpr AggFuncBuilder<State, Func, NumParams, HasClear, HasAccumulate> &
+  max_result_length(size_t n) {
     if (return_type_ == nullptr) {
       detail::call_returns_before_max_result_length();
     } else if (detail::to_vef_type(return_type_).id != VEF_TYPE_STRING) {
@@ -511,16 +512,18 @@ class AggFuncBuilder {
     return *this;
   }
 
-  constexpr AggFuncBuilder<State, Func, NumParams> &deterministic(
-      bool d = true) {
+  constexpr AggFuncBuilder<State, Func, NumParams, HasClear, HasAccumulate> &
+  deterministic(bool d = true) {
     deterministic_ = d;
     return *this;
   }
 
   // void(State&) — first parameter must match the State type declared in
-  // make_aggregate_func<State, ...>.
+  // make_aggregate_func<State, ...>. Sets HasClear on the returned builder so
+  // build() can static_assert that both clear and accumulate were configured.
   template <auto Fn>
-  constexpr AggFuncBuilder<State, Func, NumParams> &clear() {
+  constexpr AggFuncBuilder<State, Func, NumParams, true, HasAccumulate> clear()
+      const {
     using Params = typename detail::FuncParamTypes<decltype(Fn)>::type;
     using ReturnType = typename detail::FuncReturnType<decltype(Fn)>::type;
     using DeducedState =
@@ -530,16 +533,27 @@ class AggFuncBuilder {
     static_assert(std::is_same_v<DeducedState, State>,
                   "clear: first parameter must be State& matching the "
                   "make_aggregate_func State type");
-    clear_ = &detail::agg_clear_wrapper<State, Fn>;
-    has_clear_ = true;
-    return *this;
+    AggFuncBuilder<State, Func, NumParams, true, HasAccumulate> next;
+    next.name_ = name_;
+    next.return_type_ = return_type_;
+    next.buffer_size_ = buffer_size_;
+    next.max_result_length_ = max_result_length_;
+    next.clear_ = &detail::agg_clear_wrapper<State, Fn>;
+    next.accumulate_ = accumulate_;
+    next.deterministic_ = deterministic_;
+    for (size_t i = 0; i < NumParams; ++i) {
+      next.param_types_[i] = param_types_[i];
+    }
+    return next;
   }
 
   // void(State&, TypedArgs...) — first parameter must match State; remaining
   // parameters must match the SQL param count declared via .param(TYPE)
-  // calls. Call .accumulate() after all .param(TYPE) calls.
+  // calls. Call .accumulate() after all .param(TYPE) calls. Sets HasAccumulate
+  // on the returned builder (see clear()).
   template <auto Fn>
-  constexpr AggFuncBuilder<State, Func, NumParams> &accumulate() {
+  constexpr AggFuncBuilder<State, Func, NumParams, HasClear, true> accumulate()
+      const {
     using Params = typename detail::FuncParamTypes<decltype(Fn)>::type;
     using ReturnType = typename detail::FuncReturnType<decltype(Fn)>::type;
     using DeducedState =
@@ -559,20 +573,26 @@ class AggFuncBuilder {
         "accumulate: every C++ parameter after State& must be a typed argument "
         "wrapper such as IntArg, RealArg, StringArg, CustomArg, or "
         "CustomArgWith<P>");
-    accumulate_ = &detail::AggAccumulateWrapper<State, Fn, NumParams>::invoke;
-    has_accumulate_ = true;
-    return *this;
+    AggFuncBuilder<State, Func, NumParams, HasClear, true> next;
+    next.name_ = name_;
+    next.return_type_ = return_type_;
+    next.buffer_size_ = buffer_size_;
+    next.max_result_length_ = max_result_length_;
+    next.clear_ = clear_;
+    next.accumulate_ =
+        &detail::AggAccumulateWrapper<State, Fn, NumParams>::invoke;
+    next.deterministic_ = deterministic_;
+    for (size_t i = 0; i < NumParams; ++i) {
+      next.param_types_[i] = param_types_[i];
+    }
+    return next;
   }
 
   constexpr detail::StaticFuncDesc<NumParams> build() const {
     static_assert(NumParams <= kMaxParams,
                   "Too many parameters (max is kMaxParams)");
-    // Track set-ness with bools rather than comparing the wrapper pointers to
-    // null: under -fsanitize a function-pointer-to-null compare is not a
-    // constant expression, which breaks this constexpr builder.
-    if (has_clear_ != has_accumulate_) {
-      detail::config_error__aggregate_must_set_both_clear_and_accumulate();
-    }
+    static_assert(HasClear && HasAccumulate,
+                  "aggregate must set both .clear<>() and .accumulate<>()");
 
     using AllParams = typename detail::FuncParamTypes<decltype(Func)>::type;
     using UniquePTuple = typename detail::unique_params_types<AllParams>::type;
@@ -610,9 +630,7 @@ class AggFuncBuilder {
         max_result_length_(0),
         deterministic_(false),
         clear_(nullptr),
-        accumulate_(nullptr),
-        has_clear_(false),
-        has_accumulate_(false) {}
+        accumulate_(nullptr) {}
 
   const char *name_;
   const char *return_type_;
@@ -622,10 +640,8 @@ class AggFuncBuilder {
   bool deterministic_;
   vef_vdf_clear_func_t clear_;
   vef_vdf_accumulate_func_t accumulate_;
-  bool has_clear_;
-  bool has_accumulate_;
 
-  template <typename S, auto F, size_t M>
+  template <typename S, auto F, size_t M, bool C, bool A>
   friend class AggFuncBuilder;
 
   template <typename S, auto F>

--- a/villagesql/sdk/include/villagesql/vsql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_builder.h
@@ -475,6 +475,8 @@ class AggFuncBuilder {
     next.max_result_length_ = max_result_length_;
     next.clear_ = clear_;
     next.accumulate_ = accumulate_;
+    next.has_clear_ = has_clear_;
+    next.has_accumulate_ = has_accumulate_;
     next.deterministic_ = deterministic_;
     for (size_t i = 0; i < NumParams; ++i) {
       next.param_types_[i] = param_types_[i];
@@ -529,6 +531,7 @@ class AggFuncBuilder {
                   "clear: first parameter must be State& matching the "
                   "make_aggregate_func State type");
     clear_ = &detail::agg_clear_wrapper<State, Fn>;
+    has_clear_ = true;
     return *this;
   }
 
@@ -557,13 +560,17 @@ class AggFuncBuilder {
         "wrapper such as IntArg, RealArg, StringArg, CustomArg, or "
         "CustomArgWith<P>");
     accumulate_ = &detail::AggAccumulateWrapper<State, Fn, NumParams>::invoke;
+    has_accumulate_ = true;
     return *this;
   }
 
   constexpr detail::StaticFuncDesc<NumParams> build() const {
     static_assert(NumParams <= kMaxParams,
                   "Too many parameters (max is kMaxParams)");
-    if ((clear_ == nullptr) != (accumulate_ == nullptr)) {
+    // Track set-ness with bools rather than comparing the wrapper pointers to
+    // null: under -fsanitize a function-pointer-to-null compare is not a
+    // constant expression, which breaks this constexpr builder.
+    if (has_clear_ != has_accumulate_) {
       detail::config_error__aggregate_must_set_both_clear_and_accumulate();
     }
 
@@ -603,7 +610,9 @@ class AggFuncBuilder {
         max_result_length_(0),
         deterministic_(false),
         clear_(nullptr),
-        accumulate_(nullptr) {}
+        accumulate_(nullptr),
+        has_clear_(false),
+        has_accumulate_(false) {}
 
   const char *name_;
   const char *return_type_;
@@ -613,6 +622,8 @@ class AggFuncBuilder {
   bool deterministic_;
   vef_vdf_clear_func_t clear_;
   vef_vdf_accumulate_func_t accumulate_;
+  bool has_clear_;
+  bool has_accumulate_;
 
   template <typename S, auto F, size_t M>
   friend class AggFuncBuilder;


### PR DESCRIPTION
UBSAN doesn't like function pointers to nullptr. This is a problem when compiling under UBSAN, but not normally under the same (gcc) compiler.

#822
