### PR TITLE
LSAN: update lsan.supp

### DIFF
--- a/mysql-test/lsan.supp
+++ b/mysql-test/lsan.supp
@@ -74,3 +74,13 @@ leak:ndb_select_all
 leak:ndb_select_count
 leak:ndb_show_tables
 leak:ndb_sign_keys
+
+# VillageSQL: benign one-time leaks in third-party helper binaries that the
+# extension MTR suites spawn under --sanitize. safe_process LD_PRELOADs libasan
+# into every child, so uninstrumented helpers get leak-checked at exit; these
+# are not server or extension code. Suppress by helper-binary path only (never
+# by libcurl/libcrypto, which the server and http/ai extensions also use).
+# python3: vsql-http echo_server.py — CPython module init (e.g. PyInit__datetime)
+leak:/usr/bin/python3
+# curl: vsql-rest tests pipe curl output — libcurl/OpenSSL one-time init
+leak:/usr/bin/curl


### PR DESCRIPTION
Skip some third-party tools that show up as leaks because they are uninstrumented and spawned under asan/lsan.

#822

villint-ignore: mysql-test/lsan.supp

