### PR TITLE
Add automation, granular permissions

### DIFF
--- a/.github/workflows/prow-commands.yml
+++ b/.github/workflows/prow-commands.yml
@@ -1,0 +1,29 @@
+name: Prow github actions
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jpmcb/prow-github-actions@v2.0.0
+        with:
+          prow-commands: |
+            /assign
+            /unassign
+            /approve
+            /retitle
+            /area
+            /kind
+            /priority
+            /remove
+            /lgtm
+            /close
+            /reopen
+            /lock
+            /milestone
+            /hold
+            /cc
+            /uncc
+          github-token: '${{ secrets.PROW_TOKEN }}'

--- a/.github/workflows/prow-commands.yml
+++ b/.github/workflows/prow-commands.yml
@@ -7,7 +7,7 @@ jobs:
   execute:
     runs-on: ubuntu-latest
     steps:
-      - uses: jpmcb/prow-github-actions@v2.0.0
+      - uses: jpmcb/prow-github-actions@c44ac3a57d67639e39e4a4988b52049ef45b80dd # v2.0.0
         with:
           prow-commands: |
             /assign

--- a/.prowlabels.yaml
+++ b/.prowlabels.yaml
@@ -1,0 +1,22 @@
+area:
+  - extention
+  - hook
+  - indexing
+  - release
+  - server
+  - vef
+
+kind:
+  - bug
+  - cleanup
+  - documentation
+  - epic
+  - feature
+  - regression
+  - test
+
+priority:
+  - backlog
+  - critical-urgent
+  - important-longerm
+  - important-soon

--- a/.prowlabels.yaml
+++ b/.prowlabels.yaml
@@ -1,5 +1,5 @@
 area:
-  - extention
+  - extension
   - hook
   - indexing
   - release

--- a/.prowlabels.yaml
+++ b/.prowlabels.yaml
@@ -18,5 +18,5 @@ kind:
 priority:
   - backlog
   - critical-urgent
-  - important-longerm
+  - important-longterm
   - important-soon

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,11 @@
+# GitHub usernames of people who may apply /lgtm
+reviewers:
+  - malone-at-work
+  - tomas-villagesql
+  - leeca-vsql
+  - robgolebiowski-vsql
+  - villagestevers
+
+# GitHub usernames of people who may apply /approve
+approvers:
+  - villagestevers


### PR DESCRIPTION
## Description

This PR adds Prow-like automation via GitHub Actions. Slash commands are supported, as well as more granular permissions setting for the LGTM and Approve labels. Automatic squash + merge is possible, but not currently enabled. Available commands documented here: https://github.com/jpmcb/prow-github-actions/blob/main/docs/commands.md

## Related Issue

N/A

## How was this tested?

N/A

## Checklist

- [X] I have signed the CLA
- [X] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [X] I have added or updated tests as appropriate
- [X] My changes maintain compatibility with upstream MySQL 8.4
