### PR TITLE
VillageSQL coverage tooling

### DIFF
--- a/cmake/fastcov.cmake
+++ b/cmake/fastcov.cmake
@@ -133,6 +133,14 @@ FOREACH(FASTCOV_EXCLUDE
     ${GMOCK_INCLUDE_DIRS}
     "${CMAKE_SOURCE_DIR}/extra/rapidjson"
     "${CMAKE_SOURCE_DIR}/extra/xxhash"
+    # libarchive is vendored by VillageSQL (for .veb bundle handling); it is
+    # third-party code, so exclude it from coverage like the other extra/ libs.
+    "${CMAKE_SOURCE_DIR}/extra/libarchive"
+    # Test code is not product code.
+    "${CMAKE_SOURCE_DIR}/unittest/gunit/villagesql"
+    "${CMAKE_SOURCE_DIR}/villagesql/test-extensions"
+    # stable_sdk is the frozen stable ABI
+    "${CMAKE_SOURCE_DIR}/villagesql/stable_sdk"
     )
   LIST(APPEND FASTCOV_EXCLUDE_LIST "${FASTCOV_EXCLUDE}")
 ENDFOREACH()
@@ -155,3 +163,75 @@ ADD_CUSTOM_TARGET(fastcov-html
   COMMENT "Running genhtml -o code_coverage report.info"
   VERBATIM
   )
+
+# VillageSQL differential ("diff") coverage.
+#
+# Restricts coverage to lines added or changed since VillageSQL forked from
+# upstream MySQL. scripts/villagesql_delta_coverage.py filters the report.info
+# produced by fastcov-report down to those lines (upstream code excluded; new
+# files in full, modified files by changed line), then genhtml renders the
+# familiar navigable report scoped to the VillageSQL delta.
+#
+# make fastcov-clean
+# <run some tests>
+# make fastcov-report
+# make fastcov-diff
+# open in browser:  ${CMAKE_BINARY_DIR}/coverage-delta/index.html
+
+FIND_PROGRAM(PYTHON3_EXECUTABLE NAMES python3)
+
+# The base is the upstream MySQL release that HEAD is built on -- the tree
+# VillageSQL layered its changes onto. HEAD tracks a specific MySQL version
+# (VillageSQL periodically merges the matching "mysql-X.Y.Z" upstream tag), so
+# diffing against that tag isolates the VillageSQL delta: upstream code is
+# byte-identical in both trees and drops out. Do NOT use the fork point: the
+# tree has since absorbed several upstream patch releases (8.4.8 -> 8.4.10),
+# and diffing that far back would misattribute all that upstream drift to
+# VillageSQL. Computed once and cached; override with
+# -DVILLAGESQL_COVERAGE_BASE=<ref> if needed.
+IF(NOT VILLAGESQL_COVERAGE_BASE AND GIT_EXECUTABLE)
+  SET(UPSTREAM_MYSQL_TAG
+    "mysql-${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}")
+  EXECUTE_PROCESS(
+    COMMAND ${GIT_EXECUTABLE} -C ${CMAKE_SOURCE_DIR}
+            rev-parse --verify --quiet "${UPSTREAM_MYSQL_TAG}^{commit}"
+    OUTPUT_VARIABLE UPSTREAM_MYSQL_COMMIT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE GIT_REVPARSE_RESULT
+    ERROR_QUIET
+    )
+  IF(GIT_REVPARSE_RESULT EQUAL 0 AND UPSTREAM_MYSQL_COMMIT)
+    SET(VILLAGESQL_COVERAGE_BASE "${UPSTREAM_MYSQL_COMMIT}"
+      CACHE STRING "Base commit for VillageSQL differential coverage")
+  ELSE()
+    MESSAGE(STATUS "Upstream tag ${UPSTREAM_MYSQL_TAG} not found; "
+      "set -DVILLAGESQL_COVERAGE_BASE=<ref> for 'make fastcov-diff'")
+  ENDIF()
+ENDIF()
+
+IF(NOT PYTHON3_EXECUTABLE)
+  MESSAGE(STATUS "python3 not found; 'make fastcov-diff' unavailable")
+ELSEIF(NOT VILLAGESQL_COVERAGE_BASE)
+  MESSAGE(STATUS "Could not determine upstream MySQL base; "
+    "'make fastcov-diff' unavailable (set -DVILLAGESQL_COVERAGE_BASE=<ref>)")
+ELSE()
+  # Filter report.info to the VillageSQL delta, then render with genhtml. The
+  # filter script resolves git paths against the source tree (--repo).
+  ADD_CUSTOM_TARGET(fastcov-diff
+    COMMAND ${PYTHON3_EXECUTABLE}
+            ${CMAKE_SOURCE_DIR}/scripts/villagesql_delta_coverage.py
+            ${CMAKE_BINARY_DIR}/report.info ${VILLAGESQL_COVERAGE_BASE}
+            ${CMAKE_BINARY_DIR}/delta.info --repo ${CMAKE_SOURCE_DIR}
+    # --prefix strips the common source root so directories show relative
+    # (villagesql/schema, sql/dd/impl, ...). The delta report contains only
+    # in-source paths, so a single --prefix cleanly applies to all of them.
+    COMMAND genhtml ${CMAKE_BINARY_DIR}/delta.info
+            --output-directory ${CMAKE_BINARY_DIR}/coverage-delta
+            --prefix ${CMAKE_SOURCE_DIR} --legend
+            --title "VillageSQL delta coverage"
+    COMMENT
+      "VillageSQL delta coverage since ${VILLAGESQL_COVERAGE_BASE} "
+      "-> coverage-delta/index.html"
+    VERBATIM
+    )
+ENDIF()

--- a/scripts/villagesql_coverage.sh
+++ b/scripts/villagesql_coverage.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# Copyright (c) 2026 VillageSQL Contributors
+# Collect VillageSQL coverage.
+#
+# By default it does NOT run the upstream MySQL regression: the delta is
+# VillageSQL-authored code (new villagesql/* plus custom-type branches added to
+# core files), which the in-tree villagesql/extension tests exercise.
+#
+# Usage: villagesql_coverage.sh <build_dir> [server_mtr_args...]
+#
+#   <build_dir>:       A gcov-instrumented build (configured with ENABLE_GCOV=1).
+#                      mysqld must exist at runtime_output_directory/mysqld.
+#   [server_mtr_args]: Optional. If given, ALSO runs the upstream MySQL
+#                      regression with these args (e.g. "--suite=all") to
+#                      exercise VillageSQL's edits to core files that the
+#                      villagesql suite alone doesn't reach. Omit for a
+#                      delta-focused run (villagesql suite + unit tests).
+#
+# Coverage accumulates into the build's .gcda files (the absolute paths baked
+# into the instrumented mysqld), so every test phase below adds to one dataset
+# between 'fastcov-clean' and 'fastcov-report'.
+#
+# Prerequisites:
+#   - Tools: git, cmake, perl, python3, lcov (genhtml).
+#   - Run as a NON-root user (mysqld refuses to run as root). That user needs
+#     write access to the build dir (for .gcda) and the source tree's
+#     mysql-test/ (mtr writes its var/ there).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/vsql_script_utils.sh"
+
+BUILD_DIR="${1:?Usage: $0 <build_dir> [server_mtr_args...]}"
+shift || true
+SERVER_MTR_ARGS=("$@")
+
+[[ -d "$BUILD_DIR" ]] || die "Build dir not found: $BUILD_DIR"
+BUILD_DIR="$(cd "$BUILD_DIR" && pwd)"
+
+# mysqld refuses to run as root; the whole flow must run unprivileged.
+[[ "${EUID:-$(id -u)}" -ne 0 ]] || die "Do not run as root (mysqld refuses it). Run as the 'mtr' user."
+
+MYSQLD="$BUILD_DIR/runtime_output_directory/mysqld"
+MTR="$SOURCE_DIR/mysql-test/mysql-test-run.pl"
+
+[[ -x "$MYSQLD" ]] || die "mysqld not found at $MYSQLD (is this a gcov build?)"
+[[ -f "$MTR" ]]    || die "mysql-test-run.pl not found at $MTR"
+for tool in git cmake perl python3 genhtml; do
+    command -v "$tool" >/dev/null 2>&1 || die "required tool not found: $tool"
+done
+
+# Test phases may fail individual tests without invalidating the coverage they
+# produced, so run them soft: log, record, and continue rather than abort.
+WARNINGS=()
+soft() {
+    local label="$1"; shift
+    log_step "$label"
+    local rc=0
+    "$@" || rc=$?
+    if (( rc != 0 )); then
+        log_warn "$label exited rc=$rc; continuing (coverage still captured)"
+        WARNINGS+=("$label (rc=$rc)")
+    fi
+}
+
+# mtr must be invoked from its own dir; MTR_BINDIR points it at THIS build so the
+# instrumented mysqld runs and .gcda lands in $BUILD_DIR.
+run_mtr() {
+    ( cd "$SOURCE_DIR/mysql-test" && MTR_BINDIR="$BUILD_DIR" perl mysql-test-run.pl "$@" )
+}
+
+# --- 1. Zero coverage counters ------------------------------------------------
+log_step "Zeroing coverage counters (fastcov-clean)"
+make -C "$BUILD_DIR" fastcov-clean || die "fastcov-clean failed"
+
+# --- 2. Optional upstream MySQL regression (opt-in via server_mtr_args) -------
+# Off by default: it adds little to the VillageSQL delta (see header) while
+# costing hours. Provide server args to opt in. --max-test-fail=0 keeps it from
+# aborting early when a few tests fail (the coverage they produced is still
+# collected).
+if (( ${#SERVER_MTR_ARGS[@]} )); then
+    soft "Upstream MySQL regression (${SERVER_MTR_ARGS[*]})" run_mtr \
+        --parallel=auto --force --max-test-fail=0 "${SERVER_MTR_ARGS[@]}"
+else
+    log_info "Skipping upstream MySQL regression (delta-focused run; pass server mtr args to include it)"
+fi
+
+# --- 3. In-tree villagesql suite + unit tests ---------------------------------
+# The villagesql suite installs the in-tree (instrumented) test extensions, so
+# this is what produces the villagesql/sdk (dev) coverage folded into the delta.
+soft "In-tree villagesql suite" run_mtr \
+    --do-suite=villagesql --nounit-tests --parallel=auto --force
+soft "villagesql unit tests" ctest --test-dir "$BUILD_DIR" -L villagesql
+
+# --- 4. Delta report ----------------------------------------------------------
+# Only the delta report is generated. The full code_coverage/ report (a slow
+# genhtml pass over the whole tree) isn't needed for the delta and isn't the
+# goal here; run 'make fastcov-html' manually if you ever want it.
+log_step "Generating delta coverage report"
+make -C "$BUILD_DIR" fastcov-report || die "fastcov-report failed"
+soft "fastcov-diff (delta report)" make -C "$BUILD_DIR" fastcov-diff
+
+echo ""
+log_step "Coverage run complete"
+log_info "Delta report: $BUILD_DIR/coverage-delta/index.html"
+if (( ${#WARNINGS[@]} )); then
+    log_warn "Phases with non-zero exit (coverage still collected):"
+    for w in "${WARNINGS[@]}"; do log_warn "  - $w"; done
+fi

--- a/scripts/villagesql_delta_coverage.py
+++ b/scripts/villagesql_delta_coverage.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 VillageSQL Contributors
+"""VillageSQL differential ("delta") coverage filter.
+
+Reduces an lcov coverage report to only the lines added or changed since
+VillageSQL forked from upstream MySQL, so ordinary genhtml renders a familiar
+navigable report scoped to VillageSQL-authored code rather than the inherited
+MySQL tree.
+
+The delta is `git diff <base_ref>..HEAD`, a snapshot comparison: it captures
+every VillageSQL change present in HEAD regardless of when it was authored, and
+excludes upstream code that is byte-identical in both trees. Use the upstream
+release tag HEAD is built on (e.g. mysql-8.4.10) as <base_ref> -- diffing
+against the fork point instead would misattribute later upstream patch releases
+that VillageSQL has since merged in.
+
+lcov tracefiles label each source file with an SF: (Source File) line and each
+executable line with a DA: (line Data -- "DA:<line>,<hits>") entry. Only lines
+with a DA: entry are considered; comments, blank lines, declarations, and
+uninstantiated templates never produce one (the compiler emits no code, hence
+no coverage data). SF: paths are kept absolute so genhtml can read the real
+source files.
+
+Usage:
+  villagesql_delta_coverage.py <report.info> <base_ref> <out.info> [--repo DIR]
+
+--repo defaults to the top level of the git repository containing this script.
+Feed <out.info> to genhtml to produce the scoped report.
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+# Source extensions worth intersecting with coverage; everything else in the
+# diff (docs, CMake, .test/.result) has no DA: data and would be dropped anyway.
+SOURCE_GLOBS = ["*.cc", "*.cpp", "*.c", "*.h", "*.hpp", "*.ic"]
+
+_HUNK = re.compile(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@")
+
+
+def repo_toplevel():
+    # Resolve from the script's own directory, this script lives in the repo.
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    return subprocess.run(
+        ["git", "-C", script_dir, "rev-parse", "--show-toplevel"],
+        capture_output=True, text=True, check=True).stdout.strip()
+
+
+def changed_lines(base, repo):
+    """Map repo-relative path -> set of line numbers added/changed vs base."""
+    out = subprocess.run(
+        ["git", "-C", repo, "diff", f"{base}..HEAD", "--unified=0",
+         "--no-color", "--", *SOURCE_GLOBS],
+        capture_output=True, text=True, check=True).stdout
+    changed, cur = defaultdict(set), None
+    for line in out.splitlines():
+        if line.startswith("+++ b/"):
+            cur = line[6:]
+        elif line.startswith("+++ /dev/null"):
+            cur = None
+        elif cur and line.startswith("@@"):
+            m = _HUNK.match(line)
+            if m:
+                start = int(m.group(1))
+                count = int(m.group(2)) if m.group(2) is not None else 1
+                changed[cur].update(range(start, start + count))
+    return changed
+
+
+def to_relpath(sf_path, repo):
+    """Repo-relative path for an lcov SF: path, or None if outside the repo."""
+    prefix = repo.rstrip("/") + "/"
+    return sf_path[len(prefix):] if sf_path.startswith(prefix) else None
+
+
+# Dev-SDK headers compiled into (instrumented) extensions record coverage under
+# the packaged include-dev path, which is a byte-identical copy of the source
+# tree's villagesql/sdk/include. Remap those SF: paths back onto the source so
+# they attribute to villagesql/sdk and merge with the unit tests' native
+# coverage of the same headers, rather than being dropped as non-repo paths.
+_SDK_REMAP = re.compile(r"^.*/villagesql-extension-sdk-[^/]*/include-dev/")
+
+
+def remap_sf(sf_abs, repo):
+    return _SDK_REMAP.sub(repo.rstrip("/") + "/villagesql/sdk/include/", sf_abs)
+
+
+def iter_records(info_path):
+    """Yield (sf_line, [(line, hits), ...]) for each record in an lcov file."""
+    sf, da = None, []
+    with open(info_path) as f:
+        for line in f:
+            if line.startswith("SF:"):
+                sf, da = line.rstrip("\n"), []
+            elif line.startswith("DA:"):
+                ln, hits = line[3:].split(",")[:2]
+                da.append((int(ln), int(hits)))
+            elif line.startswith("end_of_record"):
+                if sf is not None:
+                    yield sf, da
+                sf, da = None, []
+
+
+def filter_to_delta(report, base_ref, out_path, repo):
+    changed = changed_lines(base_ref, repo)
+    # Accumulate hits per delta line, keyed by repo-relative path, SUMMING
+    # across records. Summing merges coverage of the same source produced by
+    # different builds -- notably the villagesql/sdk headers exercised both by
+    # the instrumented tests and by the instrumented extensions (remapped from
+    # include-dev).
+    merged = {}  # relpath -> {line: summed_hits}
+    for sf, da in iter_records(report):
+        rel = to_relpath(remap_sf(sf[3:], repo), repo)
+        if rel not in changed:
+            continue
+        acc = merged.setdefault(rel, {})
+        for ln, hits in da:
+            if ln in changed[rel]:
+                acc[ln] = acc.get(ln, 0) + hits
+
+    kept = 0
+    with open(out_path, "w") as out:
+        for rel in sorted(merged):
+            acc = merged[rel]
+            if not acc:
+                continue
+            out.write("TN:\n")
+            # SF: absolute in the source tree so genhtml can read the source.
+            out.write(f"SF:{repo.rstrip('/')}/{rel}\n")
+            for ln in sorted(acc):
+                out.write(f"DA:{ln},{acc[ln]}\n")
+            out.write(f"LF:{len(acc)}\n")
+            out.write(f"LH:{sum(1 for h in acc.values() if h > 0)}\n")
+            out.write("end_of_record\n")
+            kept += 1
+    sys.stderr.write(f"kept {kept} files with delta line coverage\n")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Filter an lcov report down to the VillageSQL delta.")
+    parser.add_argument("report", help="input lcov .info (e.g. report.info)")
+    parser.add_argument("base_ref", help="upstream base git ref, e.g. a tag")
+    parser.add_argument("out", help="output lcov .info scoped to the delta")
+    parser.add_argument("--repo", default=None,
+                        help="repo top level (default: git toplevel)")
+    args = parser.parse_args()
+    repo = args.repo or repo_toplevel()
+    filter_to_delta(args.report, args.base_ref, args.out, repo)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/unittest/gunit/CMakeLists.txt
+++ b/unittest/gunit/CMakeLists.txt
@@ -68,6 +68,7 @@ ENDIF()
 ADD_LIBRARY(gunit_small STATIC
   benchmark.cc
   fake_costmodel.cc
+  fake_custom_type_compare.cc
   gunit_test_main.cc
   skip_trailing.cc
   strnxfrm.cc

--- a/unittest/gunit/fake_custom_type_compare.cc
+++ b/unittest/gunit/fake_custom_type_compare.cc
@@ -1,0 +1,49 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <cstring>
+
+#include "my_inttypes.h"
+
+// Fake villagesql::CustomMemCompare for the gunit_small unit tests.
+//
+// The real implementation lives in villagesql/ and pulls in the full
+// Item / TypeContext machinery, which the lightweight gunit_small tests
+// deliberately do not link (they link only fakes plus sqlgunitlib). sql/
+// filesort_utils.cc, compiled into sqlgunitlib, references this symbol through
+// sql/cmp_varlen_keys.h, so a definition must exist in the gunit_small closure.
+//
+// gunit_small tests never construct a custom TypeContext, so the real function
+// would always take its memcmp fallback path. This fake reproduces exactly that
+// path: it does NOT apply the reverse flag, because for plain memcmp the sort
+// direction is already encoded in the key layout (see util.h). Tests that need
+// real custom-type comparison (unittest/gunit/villagesql) link
+// server_unittest_library instead and get the real implementation.
+//
+// This mirrors the fake_costmodel.cc / fake_table.cc pattern, but with a live
+// body rather than assert(false): unlike those link-only stubs, this symbol is
+// actually called during sort comparisons.
+
+class Item;
+
+namespace villagesql {
+
+int CustomMemCompare(const Item *, const uchar *data1, size_t,
+                     const uchar *data2, size_t, size_t min_len, bool) {
+  return memcmp(data1, data2, min_len);
+}
+
+}  // namespace villagesql

--- a/unittest/gunit/villagesql/CMakeLists.txt
+++ b/unittest/gunit/villagesql/CMakeLists.txt
@@ -34,6 +34,11 @@ SET(VILLAGESQL_UNIT_TESTS
 # duplicate symbol issues with system_charset_info on macOS. The macOS dynamic
 # linker uses two-level namespace, which causes the test and server_unittest_library
 # to have separate copies of the symbol when both define it.
+#
+# ADD_TEST registers the ctest test in all builds (so villagesql-unit-tests and
+# "ctest -L villagesql" work). ADD_GCOV_TEST additionally clears EXCLUDE_FROM_ALL
+# under ENABLE_GCOV so these tests are built by "make all" and folded into the
+# standard gcov coverage sweep, matching the gunit small/server tests.
 MACRO(ADD_VILLAGESQL_TEST test_name)
   MYSQL_ADD_EXECUTABLE(${test_name}
     ${test_name}.cc
@@ -43,6 +48,7 @@ MACRO(ADD_VILLAGESQL_TEST test_name)
     SKIP_INSTALL
     DEPENDENCIES ${GTEST_LIBRARIES}
     ADD_TEST ${test_name}
+    ADD_GCOV_TEST ${test_name}
   )
 
   TARGET_INCLUDE_DIRECTORIES(${test_name} PRIVATE

--- a/villagesql/cmake/VsqlExtension.cmake
+++ b/villagesql/cmake/VsqlExtension.cmake
@@ -108,6 +108,24 @@ macro(vsql_add_test_extension DIR_NAME VEB_NAME)
   set(_ext_copy_target copy_${VEB_NAME}${_ext_target_suffix}_veb)
   set(_ext_veb_target ${VEB_NAME}${_ext_target_suffix}_veb)
 
+  # Under gcov, instrument the extension .so so that installing it during mtr
+  # produces coverage of the SDK headers it compiles in. The .gcno/.gcda live
+  # in this ExternalProject's BINARY_DIR (under the main build tree), so
+  # fastcov-report collects them; villagesql_delta_coverage.py then remaps the
+  # packaged include-dev path back onto villagesql/sdk and folds it into the
+  # delta. The .so writes .gcda to this baked-in build path at runtime, so the
+  # build dir must remain writable by whoever runs mtr.
+  set(_ext_cov_args "")
+  if(ENABLE_GCOV)
+    # EXE_LINKER_FLAGS is needed too: CMake's compiler check links a test
+    # executable, which must resolve the gcov symbols pulled in by --coverage.
+    set(_ext_cov_args
+      "-DCMAKE_CXX_FLAGS=--coverage"
+      "-DCMAKE_C_FLAGS=--coverage"
+      "-DCMAKE_SHARED_LINKER_FLAGS=--coverage"
+      "-DCMAKE_EXE_LINKER_FLAGS=--coverage")
+  endif()
+
   ExternalProject_Add(${_ext_proj_target}
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/test-extensions/shared
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/test-extensions/${DIR_NAME}-shared-build
@@ -119,6 +137,7 @@ macro(vsql_add_test_extension DIR_NAME VEB_NAME)
       "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
       "-DEXTENSION_NAME=${VEB_NAME}"
       "-DEXTENSION_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test-extensions/${DIR_NAME}"
+      ${_ext_cov_args}
     DEPENDS sdk
     BUILD_ALWAYS ON
     INSTALL_COMMAND ""


### PR DESCRIPTION
Enable gcov for VillageSQL and add a "delta" coverage report that scopes results to VillageSQL-authored code (changes since the upstream MySQL tag HEAD is built on) rather than the whole inherited MySQL tree.

Build/test under gcov:
- unittest/gunit/fake_custom_type_compare.cc, unittest/gunit/CMakeLists.txt: add a memcmp-only fake of villagesql::CustomMemCompare to gunit_small. Under gcov the individual small-test executables are built (ADD_GCOV_TEST clears EXCLUDE_FROM_ALL) and filesort_utils.cc (in sqlgunitlib) references that symbol via cmp_varlen_keys.h; the fake resolves it without linking the server into the lightweight test closure. Fixes the gcov link failure.
- unittest/gunit/villagesql/CMakeLists.txt: ADD_GCOV_TEST so the villagesql unit tests build and run in the standard gcov flow.
- villagesql/cmake/VsqlExtension.cmake: build the in-tree test extensions with --coverage under ENABLE_GCOV, so installing them during mtr exercises the dev SDK headers they compile in.

Delta coverage:
- scripts/villagesql_delta_coverage.py: filter an lcov report to lines changed vs a base ref (git diff base..HEAD) for a genhtml report scoped to the VillageSQL delta. Remaps the packaged include-dev SDK paths onto villagesql/sdk/include and sums hits, so extension- and unit-test-driven SDK coverage merge rather than clobber.
- cmake/fastcov.cmake: add a fastcov-diff target (runs the filter + genhtml, paths relative to the source root). Auto-detect the base as the mysql-<MAJOR>.<MINOR>.<PATCH> upstream tag HEAD tracks (overridable with -DVILLAGESQL_COVERAGE_BASE). Exclude non-product code: vendored extra/libarchive, test code (unittest/gunit/villagesql, villagesql/test-extensions), and the frozen villagesql/stable_sdk. Upstream fastcov-clean/report/html targets are left unchanged.
- scripts/villagesql_coverage.sh: orchestrate one accumulated run against the gcov build -- in-tree villagesql suite + villagesql unit tests -> delta report. The upstream MySQL regression is opt-in, and only the delta report is generated (run 'make fastcov-html' for the full report).

Closes https://github.com/villagesql/villagesql-server/issues/813