### PR TITLE
Fix compilation error in release mode

### DIFF
--- a/storage/innobase/villagesql/custom_index.cc
+++ b/storage/innobase/villagesql/custom_index.cc
@@ -328,8 +328,9 @@ dberr_t Custom_index::insert(dict_index_t *index, trx_id_t trx_id,
       ut_a(pos != ULINT_UNDEFINED);
       pkey_columns[i] = to_col_data(dtuple_get_nth_field(entry, pos));
     }
-  } else
+  } else {
     ut_ad(intf.storage_props & VEF_INDEX_STORAGE_HAS_COLUMN_REF);
+  }
 
   for (uint32_t i = 0; i < num_key_columns; i++) {
     key_columns[i] = to_col_data(dtuple_get_nth_field(entry, i));


### PR DESCRIPTION
The release build fails with -Werror=empty-body because the added ut_ad() assertion is inside an else branch. When assertions are disabled, ut_ad() expands away and leaves an empty else body.

Wrap the assertion in braces to avoid the empty body warning and match the existing idiom used in InnoDB.

Part of #386