### PR TITLE
vef: remove the word 'wrapper' from doc

### DIFF
--- a/mysql-test/suite/villagesql/extension/t/extension_vdf_signature_missing_result.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_vdf_signature_missing_result.test
@@ -1,6 +1,6 @@
-# Test that make_func catches a missing typed result wrapper at build time.
+# Test that make_func catches a missing typed result at build time.
 
 --let $extension_name = vdf_signature_missing_result
 --let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/vdf_signature_missing_result.cc
---let $build_failure_grep = make_func: C++ function must have one typed result wrapper
+--let $build_failure_grep = make_func: C++ function must have one typed result value
 --source include/villagesql/create_extension_sdk_expect_build_failure.inc

--- a/mysql-test/suite/villagesql/extension/t/extension_vdf_signature_nonvoid_result.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_vdf_signature_nonvoid_result.test
@@ -1,5 +1,5 @@
 # Test that make_func catches functions that return a value while also using
-# the typed result wrapper output parameter.
+# the typed result output parameter.
 
 --let $extension_name = vdf_signature_nonvoid_result
 --let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/vdf_signature_nonvoid_result.cc

--- a/villagesql/sdk/include/villagesql/vsql/extension_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/extension_builder.h
@@ -31,10 +31,9 @@ namespace vsql {
 // call site.
 using namespace func_builder;
 
-// ExtensionBuilder is the vsql-API extension builder. It is a standalone type
-// (not a wrapper around villagesql::extension_builder::ExtensionBuilder) so it
-// can evolve independently. It satisfies the same duck-typed interface required
-// by VEF_GENERATE_ENTRY_POINTS.
+// ExtensionBuilder is used to define the functionality exported by and
+// capabilities required by a VillageSQL extension. The output of the builder
+// is passed to VEF_GENERATE_ENTRY_POINTS.
 template <typename FuncTuple, typename TypeTuple,
           typename RequiredCapabilityTuple = std::tuple<>,
           void (*InitFn)() = nullptr, void (*DeinitFn)() = nullptr>

--- a/villagesql/sdk/include/villagesql/vsql/extension_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/extension_builder.h
@@ -31,10 +31,9 @@ namespace vsql {
 // call site.
 using namespace func_builder;
 
-// ExtensionBuilder is the vsql-API extension builder. It is a standalone type
-// (not a wrapper around villagesql::extension_builder::ExtensionBuilder) so it
-// can evolve independently. It satisfies the same duck-typed interface required
-// by VEF_GENERATE_ENTRY_POINTS.
+// ExtensionBuilder is used to define the functionality exported by and
+// capabilities required by a VillageSQL extension. The output of the builder
+// is passed to VEF_GENERATE_ENTRY_POINTS.
 template <typename FuncTuple, typename TypeTuple,
           typename RequiredCapabilityTuple = std::tuple<>>
 struct ExtensionBuilder {

--- a/villagesql/sdk/include/villagesql/vsql/func_builder.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_builder.h
@@ -19,13 +19,8 @@
 // New-style (vsql) function builder.
 //
 // This file provides the typed C++ function registration API. Functions must
-// use typed argument and result wrappers (IntArg, RealArg, StringArg,
-// CustomArg, etc.) rather than raw ABI types (vef_context_t*, vef_invalue_t*,
-// vef_vdf_result_t*).
-//
-// Raw vef_vdf_func_t function pointers and the deprecated vef_context_t* first
-// parameter style are rejected at compile time. Use villagesql/func_builder.h
-// (the v1 API) if you need to register raw ABI functions.
+// use typed arguments and results (IntArg, RealArg, StringArg,
+// CustomArg, etc.).
 //
 // For full usage documentation see villagesql/vsql.h.
 
@@ -113,7 +108,7 @@ using TypeEncodeFunc = void (*)(std::string_view from, CustomResult out);
 // MaybeParams<P> so that the type can be correctly carried through the rest
 // of the SQL statement.
 //
-// The result wrapper is plain CustomResult (not CustomResultWith<P>) because
+// The result is plain CustomResult (not CustomResultWith<P>) because
 // params come from the MaybeParams<P>& argument.
 template <typename P>
 using TypeEncodeWithParamsFunc = void (*)(MaybeParams<P> &,
@@ -121,7 +116,7 @@ using TypeEncodeWithParamsFunc = void (*)(MaybeParams<P> &,
 
 // Decode: custom -> string. The function reports its outcome by calling
 // out.set_length(n), out.set(sv), out.set_null(), out.warning(msg), or
-// out.error(msg). If none is called the wrapper falls back to a default
+// out.error(msg). If none is called then the result falls back to a default
 // "failed to decode value" ERROR.
 using TypeDecodeFunc = void (*)(CustomArg in, StringResult out);
 // Parameterized variant: params come from the CustomArgWith<P> input.
@@ -230,7 +225,7 @@ class FuncBuilder {
   }
 
   // Declare a varargs VDF. The function signature must be
-  //   void(vsql::VarArgs, ResultWrapper)
+  //   void(vsql::VarArgs, TypedResult)
   // The prerun hook is responsible for validating argument count and types.
   // Mutually exclusive with .no_params() / .param(TYPE).
   constexpr FuncBuilder<Func, 0, ParamMode::kVarargs, HasPrerun> varargs()
@@ -326,7 +321,7 @@ class FuncBuilder {
     using ReturnType = typename detail::FuncReturnType<decltype(Func)>::type;
     static_assert(std::is_void_v<ReturnType>,
                   "make_func: C++ function must return void and set the SQL "
-                  "result through the final typed result wrapper parameter");
+                  "result through the final typed result parameter");
 
     // Detect state-style signatures: first parameter is `void*` or any
     // lvalue reference (State& / const State&). Aggregate result-shape
@@ -348,9 +343,9 @@ class FuncBuilder {
       meta.is_varargs = true;
     } else if constexpr (has_state_param) {
       // Shapes:
-      //   void(State&, TypedArgs..., ResultWrapper)     — typed state, mutable
-      //   void(const State&, TypedArgs..., ResultWrapper) — typed state, const
-      //   void(void*, TypedArgs..., ResultWrapper)      — raw state
+      //   void(State&, TypedArgs..., TypedResult)     — typed state, mutable
+      //   void(const State&, TypedArgs..., TypedResult) — typed state, const
+      //   void(void*, TypedArgs..., TypedResult)      — raw state
       static_assert(HasPrerun,
                     "VDF declares state (State& or void*) but no prerun is "
                     "configured. user_data would be nullptr at every call. "
@@ -359,7 +354,7 @@ class FuncBuilder {
       static_assert(std::tuple_size_v<AllParams> == NumParams + 2,
                     "make_func: state-style VDF must have one State (or "
                     "void*) parameter, then the declared SQL parameters, "
-                    "then a typed result wrapper");
+                    "then a typed result");
       // TODO(villagesql-beta): also run args/result shape and runtime
       // signature checks (declared .param/.returns vs C++ wrappers) for
       // state-style VDFs. Today these run only for stateless shapes.
@@ -379,20 +374,19 @@ class FuncBuilder {
       }
     } else {
       using Shape = detail::func_signature_shape<AllParams, NumParams>;
-      static_assert(
-          std::tuple_size_v<AllParams> == NumParams + 1,
-          "make_func: C++ function must have one typed result wrapper "
-          "after the declared SQL parameters; check the number of "
-          ".param(TYPE) calls");
+      static_assert(std::tuple_size_v<AllParams> == NumParams + 1,
+                    "make_func: C++ function must have one typed result value "
+                    "after the declared SQL parameters; check the number of "
+                    ".param(TYPE) calls");
       static_assert(
           std::tuple_size_v<AllParams> != NumParams + 1 || Shape::args_ok,
           "make_func: every C++ function parameter before the result "
-          "must be a typed argument wrapper such as IntArg, RealArg, "
-          "StringArg, CustomArg, or CustomArgWith<P>");
+          "must be a typed argument such as IntArg, RealArg, StringArg, "
+          "CustomArg, or CustomArgWith<P>");
       static_assert(
           std::tuple_size_v<AllParams> != NumParams + 1 || Shape::result_ok,
           "make_func: final C++ function parameter must be a typed "
-          "result wrapper such as IntResult, RealResult, StringResult, "
+          "result such as IntResult, RealResult, StringResult, "
           "CustomResult, or CustomResultWith<P>");
       if constexpr (std::tuple_size_v<AllParams> == NumParams + 1 &&
                     Shape::args_ok && Shape::result_ok) {
@@ -571,7 +565,7 @@ class AggFuncBuilder {
         std::tuple_size_v<Params> != NumParams + 1 ||
             detail::accumulate_signature_shape<Params, NumParams>::args_ok,
         "accumulate: every C++ parameter after State& must be a typed argument "
-        "wrapper such as IntArg, RealArg, StringArg, CustomArg, or "
+        "such as IntArg, RealArg, StringArg, CustomArg, or "
         "CustomArgWith<P>");
     AggFuncBuilder<State, Func, NumParams, HasClear, true> next;
     next.name_ = name_;
@@ -598,7 +592,7 @@ class AggFuncBuilder {
     using UniquePTuple = typename detail::unique_params_types<AllParams>::type;
 
     detail::FuncWithMetadata meta{};
-    // void(const State&, ResultWrapper).
+    // void(const State&, TypedResult).
     using ResultWrapper = std::tuple_element_t<1, AllParams>;
     meta.f =
         &detail::AggResultWithOutputWrapper<State, ResultWrapper, Func>::invoke;
@@ -655,8 +649,8 @@ class AggFuncBuilder {
 // make_aggregate_func<State, &result_fn>("name")
 //
 // Entry point for aggregate VDFs. State is the per-group accumulation type.
-// The result function must be: void(const State&, ResultWrapper)
-// where ResultWrapper is one of IntResult, RealResult, StringResult,
+// The result function must be: void(const State&, TypedResult)
+// where TypedResult is one of IntResult, RealResult, StringResult,
 // CustomResult, or CustomResultWith<P>.
 //
 // prerun/postrun are auto-generated: prerun allocates State via
@@ -669,7 +663,7 @@ constexpr AggFuncBuilder<State, Func, 0> make_aggregate_func(const char *name) {
       std::is_void_v<ReturnType> &&
           detail::is_agg_result_for_state<State, AllParams>::value,
       "make_aggregate_func: result function must be "
-      "void(const State&, ResultWrapper) where ResultWrapper is IntResult, "
+      "void(const State&, TypedResult) where TypedResult is IntResult, "
       "RealResult, StringResult, CustomResult, or CustomResultWith<P>");
   AggFuncBuilder<State, Func, 0> builder;
   builder.name_ = name;

--- a/villagesql/sdk/include/villagesql/vsql/func_types.h
+++ b/villagesql/sdk/include/villagesql/vsql/func_types.h
@@ -16,8 +16,6 @@
 #ifndef VILLAGESQL_VSQL_FUNC_TYPES_H
 #define VILLAGESQL_VSQL_FUNC_TYPES_H
 
-// Typed wrappers for VDF function parameters and results.
-//
 // These types let extension authors write VDF functions in idiomatic C++
 // without accessing the raw ABI structs (vef_invalue_t, vef_vdf_result_t)
 // directly. The func_builder framework automatically converts to/from the
@@ -48,7 +46,7 @@
 //     out.set_length(src.size());
 //   }
 //
-// Result methods available on all result wrappers:
+// Result methods available on all result types:
 //   set / set_length / set_null  — produce the SQL output value
 //   warning(msg)  — emit a diagnostic note but still return a value
 //   error(msg)    — abort the current statement with an error; no value
@@ -77,7 +75,7 @@
 namespace vsql {
 
 // =============================================================================
-// Input argument wrappers
+// Input argument types
 // =============================================================================
 
 class IntArg {
@@ -110,8 +108,8 @@ class StringArg {
   const vef_invalue_t *v_;
 };
 
-// CustomArg: input wrapper for non-parameterized custom type arguments.
-// For parameterized types (e.g., TVECTOR(N)), use CustomArgWith<P> instead.
+// CustomArg: input type for non-parameterized custom type arguments.  For
+// parameterized types (e.g., TVECTOR(N)), use CustomArgWith<P> instead.
 class CustomArg {
  public:
   explicit CustomArg(const vef_invalue_t *v) : v_(v) {}
@@ -124,10 +122,10 @@ class CustomArg {
   const vef_invalue_t *v_;
 };
 
-// CustomArgWith<P>: input wrapper for parameterized custom type arguments.
-// Use instead of CustomArg when the VDF needs to access the type parameters
-// (e.g., the dimension of a TVECTOR(N) column). Requires the parse function
-// to be registered via .params<P, &parse_fn>() in the type builder.
+// CustomArgWith<P>: input type for parameterized custom type arguments.  Use
+// instead of CustomArg when the VDF needs to access the type parameters (e.g.,
+// the dimension of a TVECTOR(N) column). Requires the parse function to be
+// registered via .params<P, &parse_fn>() in the type builder.
 //
 // The parse result is memoized per unique canonical params string, so parsing
 // runs at most once per type instantiation.
@@ -152,7 +150,7 @@ class CustomArgWith {
 };
 
 // =============================================================================
-// Result wrappers
+// Result types
 // =============================================================================
 
 class IntResult {
@@ -251,7 +249,7 @@ class StringResult {
   vef_vdf_result_t *r_;
 };
 
-// CustomResult: result wrapper for non-parameterized custom type outputs.
+// CustomResult: result type for non-parameterized custom type outputs.
 // For parameterized types (e.g., TVECTOR(N)), use CustomResultWith<P> instead.
 class CustomResult {
  public:
@@ -282,7 +280,7 @@ class CustomResult {
   vef_vdf_result_t *r_;
 };
 
-// CustomResultWith<P>: result wrapper for parameterized custom type outputs.
+// CustomResultWith<P>: result type for parameterized custom type outputs.
 // Use instead of CustomResult when the VDF needs to access the type parameters
 // (e.g., the dimension of a TVECTOR(N) column). Requires the parse function
 // to be registered via .params<P, &parse_fn>() in the type builder.

--- a/villagesql/sdk/include/villagesql/vsql/pre_post_run.h
+++ b/villagesql/sdk/include/villagesql/vsql/pre_post_run.h
@@ -16,11 +16,10 @@
 #ifndef VILLAGESQL_VSQL_PRE_POST_RUN_H
 #define VILLAGESQL_VSQL_PRE_POST_RUN_H
 
-// Typed wrappers for the per-statement lifecycle hooks (prerun and postrun).
+// Per-statement lifecycle hooks (prerun and postrun).
 //
 // Extension authors register hooks via .prerun<&fn>() / .postrun<&fn>() on
-// the func builder. Only the typed signatures are accepted; the SDK
-// installs wrappers that adapt to the raw ABI:
+// the func builder.
 //
 //   prerun:  void(PrerunArgs, PrerunResult)
 //   postrun: void(PostrunArgs)
@@ -32,11 +31,6 @@
 // State lifetime is explicit: if prerun stores a pointer via set_user_data,
 // postrun is responsible for freeing it. PostrunArgs::delete_state<T>() is
 // the typed convenience for the common case of `new T{}` + `delete`.
-//
-// vef_postrun_result_t is currently empty in the ABI, so there is no
-// PostrunResult wrapper. If/when the result struct gains fields, a typed
-// wrapper class will be added and the postrun signature will become
-// `void(PostrunArgs, PostrunResult)`.
 //
 // TODO(villagesql-beta): add a typed-state mechanism (working name
 // `.state<T>()` on FuncBuilder) so extensions can declare a per-statement

--- a/villagesql/sdk/include/villagesql/vsql/var_args.h
+++ b/villagesql/sdk/include/villagesql/vsql/var_args.h
@@ -16,8 +16,6 @@
 #ifndef VILLAGESQL_VSQL_VAR_ARGS_H
 #define VILLAGESQL_VSQL_VAR_ARGS_H
 
-// Typed wrappers for varargs VDFs.
-//
 // A varargs VDF is declared at registration time with .varargs() on the
 // func builder and takes a vsql::VarArgs argument in place of the usual
 // fixed-arity IntArg/StringArg/CustomArg parameters. The body inspects


### PR DESCRIPTION
## Description

Clean up the C++ SDK documentation, primarily removing the term 'wrapper' as the extension author doesn't know/care that these are wrapping anything.

## Related Issue

N/A

## How was this tested?

N/A

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
