### PR TITLE
UBSAN: fixes for v3 api

### DIFF
--- a/villagesql/stable_sdk/v3/include/villagesql/detail/func_builder.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/detail/func_builder.h
@@ -52,10 +52,6 @@ constexpr vef_type_t to_vef_type(const char *name) {
   return vef_type_t{VEF_TYPE_CUSTOM, name};
 }
 
-// Deliberately unimplemented — produces a compile error with a descriptive
-// name when build() detects an invalid aggregate configuration.
-void config_error__aggregate_must_set_both_clear_and_accumulate();
-
 // Auto-generated prerun/postrun for aggregate state management.
 template <typename State>
 void auto_prerun(vef_context_t *, vef_prerun_args_t *,

--- a/villagesql/stable_sdk/v3/include/villagesql/preview/storage_builder.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/preview/storage_builder.h
@@ -390,96 +390,117 @@ struct PurgeWrapper {
 
 }  // namespace detail
 
-// Non-constexpr: its name appears verbatim in the compiler error when
-// build() is evaluated at compile time with missing interface registrations.
-void StorageBuilder_all_column_storage_interfaces_must_be_registered();
-
-template <typename UserCtx>
+template <typename UserCtx, unsigned Registered = 0>
 class StorageBuilder {
+  // Interface registration bits, accumulated in the Registered template
+  // argument so build() can static_assert that every interface was set.
+  static constexpr unsigned kCreate = 1u << 0;
+  static constexpr unsigned kDrop = 1u << 1;
+  static constexpr unsigned kLoad = 1u << 2;
+  static constexpr unsigned kInsert = 1u << 3;
+  static constexpr unsigned kSelect = 1u << 4;
+  static constexpr unsigned kMarkDelete = 1u << 5;
+  static constexpr unsigned kPurge = 1u << 6;
+  static constexpr unsigned kAllRegistered =
+      kCreate | kDrop | kLoad | kInsert | kSelect | kMarkDelete | kPurge;
+
  public:
   constexpr explicit StorageBuilder(const char *type_name)
       : type_name_(type_name), intf_{} {}
 
   // Each setter static_asserts that F exactly matches the expected function
   // pointer type (detail::CreateFn<UserCtx>, etc.), rejecting wrong signatures,
-  // lambdas, and member function pointers at compile time.
+  // lambdas, and member function pointers at compile time. Each returns a
+  // builder whose Registered mask records the interface, so build() can
+  // static_assert that all interfaces were registered.
   template <auto F>
-  constexpr StorageBuilder &create() {
+  constexpr StorageBuilder<UserCtx, Registered | kCreate> create() const {
     static_assert(std::is_same_v<decltype(F), detail::CreateFn<UserCtx>>,
                   "create: expected bool(*)(StorageCtx<UserCtx>*, Space::Ref, "
                   "Segment::TrxRef, uint32_t col_len, char*, uint32_t)");
-    intf_.create = detail::CreateWrapper<F, UserCtx>::invoke;
-    return *this;
+    StorageBuilder<UserCtx, Registered | kCreate> next{type_name_};
+    next.intf_ = intf_;
+    next.intf_.create = detail::CreateWrapper<F, UserCtx>::invoke;
+    return next;
   }
 
   template <auto F>
-  constexpr StorageBuilder &drop() {
+  constexpr StorageBuilder<UserCtx, Registered | kDrop> drop() const {
     static_assert(
         std::is_same_v<decltype(F), detail::DropFn<UserCtx>>,
         "drop: expected bool(*)(StorageCtx<UserCtx>*, Segment::TrxRef, "
         "char*, uint32_t)");
-    intf_.drop = detail::DropWrapper<F, UserCtx>::invoke;
-    return *this;
+    StorageBuilder<UserCtx, Registered | kDrop> next{type_name_};
+    next.intf_ = intf_;
+    next.intf_.drop = detail::DropWrapper<F, UserCtx>::invoke;
+    return next;
   }
 
   template <auto F>
-  constexpr StorageBuilder &load() {
+  constexpr StorageBuilder<UserCtx, Registered | kLoad> load() const {
     static_assert(
         std::is_same_v<decltype(F), detail::LoadFn<UserCtx>>,
         "load: expected bool(*)(StorageCtx<UserCtx>*, Column::StorageRef, "
         "char*, uint32_t)");
-    intf_.load = detail::LoadWrapper<F, UserCtx>::invoke;
-    return *this;
+    StorageBuilder<UserCtx, Registered | kLoad> next{type_name_};
+    next.intf_ = intf_;
+    next.intf_.load = detail::LoadWrapper<F, UserCtx>::invoke;
+    return next;
   }
 
   template <auto F>
-  constexpr StorageBuilder &insert() {
+  constexpr StorageBuilder<UserCtx, Registered | kInsert> insert() const {
     static_assert(std::is_same_v<decltype(F), detail::InsertFn<UserCtx>>,
                   "insert: expected bool(*)(StorageCtx<UserCtx>*, MtrCtx::Ref, "
                   "Segment::TrxRef, Column::Data, Column::Data, Column::Ref*, "
                   "char*, uint32_t)");
-    intf_.insert = detail::InsertWrapper<F, UserCtx>::invoke;
-    return *this;
+    StorageBuilder<UserCtx, Registered | kInsert> next{type_name_};
+    next.intf_ = intf_;
+    next.intf_.insert = detail::InsertWrapper<F, UserCtx>::invoke;
+    return next;
   }
 
   template <auto F>
-  constexpr StorageBuilder &select() {
+  constexpr StorageBuilder<UserCtx, Registered | kSelect> select() const {
     static_assert(
         std::is_same_v<decltype(F), detail::SelectFn<UserCtx>>,
         "select: expected bool(*)(StorageCtx<UserCtx>*, MtrCtx::Ref, "
         "Column::Ref, Column::Data*, Column::Data*, Segment::TrxRef*, "
         "bool*, char*, uint32_t)");
-    intf_.select = detail::SelectWrapper<F, UserCtx>::invoke;
-    return *this;
+    StorageBuilder<UserCtx, Registered | kSelect> next{type_name_};
+    next.intf_ = intf_;
+    next.intf_.select = detail::SelectWrapper<F, UserCtx>::invoke;
+    return next;
   }
 
   template <auto F>
-  constexpr StorageBuilder &mark_delete() {
+  constexpr StorageBuilder<UserCtx, Registered | kMarkDelete> mark_delete()
+      const {
     static_assert(
         std::is_same_v<decltype(F), detail::MarkDeleteFn<UserCtx>>,
         "mark_delete: expected bool(*)(StorageCtx<UserCtx>*, MtrCtx::Ref, "
         "Segment::TrxRef, Column::Ref, bool delete_mark, char*, uint32_t)");
-    intf_.mark_delete = detail::MarkDeleteWrapper<F, UserCtx>::invoke;
-    return *this;
+    StorageBuilder<UserCtx, Registered | kMarkDelete> next{type_name_};
+    next.intf_ = intf_;
+    next.intf_.mark_delete = detail::MarkDeleteWrapper<F, UserCtx>::invoke;
+    return next;
   }
 
   template <auto F>
-  constexpr StorageBuilder &purge() {
+  constexpr StorageBuilder<UserCtx, Registered | kPurge> purge() const {
     static_assert(std::is_same_v<decltype(F), detail::PurgeFn<UserCtx>>,
                   "purge: expected bool(*)(StorageCtx<UserCtx>*, MtrCtx::Ref, "
                   "Segment::TrxRef, Column::Ref, char*, uint32_t)");
-    intf_.purge = detail::PurgeWrapper<F, UserCtx>::invoke;
-    return *this;
+    StorageBuilder<UserCtx, Registered | kPurge> next{type_name_};
+    next.intf_ = intf_;
+    next.intf_.purge = detail::PurgeWrapper<F, UserCtx>::invoke;
+    return next;
   }
 
   constexpr TypeStorageDescriptor build() const {
-    if (!intf_.create || !intf_.drop || !intf_.load || !intf_.insert ||
-        !intf_.select || !intf_.mark_delete || !intf_.purge) {
-      // Calling a non-constexpr function here causes a compile-time error
-      // when build() is evaluated in a constant expression. The function name
-      // appears verbatim in the compiler diagnostic.
-      StorageBuilder_all_column_storage_interfaces_must_be_registered();
-    }
+    static_assert(Registered == kAllRegistered,
+                  "all column storage interfaces must be registered: create, "
+                  "drop, load, insert, select, mark_delete, and purge");
     vef_type_storage_intf_t result = intf_;
     result.version = VEF_STORAGE_TYPE_INTF_VERSION;
     result.type_name = type_name_;
@@ -487,6 +508,9 @@ class StorageBuilder {
   }
 
  private:
+  template <typename U, unsigned R>
+  friend class StorageBuilder;
+
   const char *type_name_;
   vef_type_storage_intf_t intf_;
 };

--- a/villagesql/stable_sdk/v3/include/villagesql/vsql/func_builder.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/vsql/func_builder.h
@@ -403,17 +403,19 @@ class FuncBuilder {
 // The State type is explicit, and clear/accumulate signatures are validated
 // against State at compile time.
 
-template <typename State, auto Func, size_t NumParams>
+template <typename State, auto Func, size_t NumParams, bool HasClear = false,
+          bool HasAccumulate = false>
 class AggFuncBuilder {
  public:
-  constexpr AggFuncBuilder<State, Func, NumParams> &returns(const char *t) {
+  constexpr AggFuncBuilder<State, Func, NumParams, HasClear, HasAccumulate> &
+  returns(const char *t) {
     return_type_ = t;
     return *this;
   }
 
-  constexpr AggFuncBuilder<State, Func, NumParams + 1> param(
-      const char *t) const {
-    AggFuncBuilder<State, Func, NumParams + 1> next;
+  constexpr AggFuncBuilder<State, Func, NumParams + 1, HasClear, HasAccumulate>
+  param(const char *t) const {
+    AggFuncBuilder<State, Func, NumParams + 1, HasClear, HasAccumulate> next;
     next.name_ = name_;
     next.return_type_ = return_type_;
     next.buffer_size_ = buffer_size_;
@@ -427,21 +429,24 @@ class AggFuncBuilder {
     return next;
   }
 
-  constexpr AggFuncBuilder<State, Func, NumParams> &buffer_size(size_t s) {
+  constexpr AggFuncBuilder<State, Func, NumParams, HasClear, HasAccumulate> &
+  buffer_size(size_t s) {
     buffer_size_ = s;
     return *this;
   }
 
-  constexpr AggFuncBuilder<State, Func, NumParams> &deterministic(
-      bool d = true) {
+  constexpr AggFuncBuilder<State, Func, NumParams, HasClear, HasAccumulate> &
+  deterministic(bool d = true) {
     deterministic_ = d;
     return *this;
   }
 
   // void(State&) — first parameter must match the State type declared in
-  // make_aggregate_func<State, ...>.
+  // make_aggregate_func<State, ...>. Sets HasClear on the returned builder so
+  // build() can static_assert that both clear and accumulate were configured.
   template <auto Fn>
-  constexpr AggFuncBuilder<State, Func, NumParams> &clear() {
+  constexpr AggFuncBuilder<State, Func, NumParams, true, HasAccumulate> clear()
+      const {
     using Params = typename detail::FuncParamTypes<decltype(Fn)>::type;
     using ReturnType = typename detail::FuncReturnType<decltype(Fn)>::type;
     using DeducedState =
@@ -451,15 +456,26 @@ class AggFuncBuilder {
     static_assert(std::is_same_v<DeducedState, State>,
                   "clear: first parameter must be State& matching the "
                   "make_aggregate_func State type");
-    clear_ = &detail::agg_clear_wrapper<State, Fn>;
-    return *this;
+    AggFuncBuilder<State, Func, NumParams, true, HasAccumulate> next;
+    next.name_ = name_;
+    next.return_type_ = return_type_;
+    next.buffer_size_ = buffer_size_;
+    next.clear_ = &detail::agg_clear_wrapper<State, Fn>;
+    next.accumulate_ = accumulate_;
+    next.deterministic_ = deterministic_;
+    for (size_t i = 0; i < NumParams; ++i) {
+      next.param_types_[i] = param_types_[i];
+    }
+    return next;
   }
 
   // void(State&, TypedArgs...) — first parameter must match State; remaining
   // parameters must match the SQL param count declared via .param(TYPE)
-  // calls. Call .accumulate() after all .param(TYPE) calls.
+  // calls. Call .accumulate() after all .param(TYPE) calls. Sets HasAccumulate
+  // on the returned builder (see clear()).
   template <auto Fn>
-  constexpr AggFuncBuilder<State, Func, NumParams> &accumulate() {
+  constexpr AggFuncBuilder<State, Func, NumParams, HasClear, true> accumulate()
+      const {
     using Params = typename detail::FuncParamTypes<decltype(Fn)>::type;
     using ReturnType = typename detail::FuncReturnType<decltype(Fn)>::type;
     using DeducedState =
@@ -479,16 +495,25 @@ class AggFuncBuilder {
         "accumulate: every C++ parameter after State& must be a typed argument "
         "wrapper such as IntArg, RealArg, StringArg, CustomArg, or "
         "CustomArgWith<P>");
-    accumulate_ = &detail::AggAccumulateWrapper<State, Fn, NumParams>::invoke;
-    return *this;
+    AggFuncBuilder<State, Func, NumParams, HasClear, true> next;
+    next.name_ = name_;
+    next.return_type_ = return_type_;
+    next.buffer_size_ = buffer_size_;
+    next.clear_ = clear_;
+    next.accumulate_ =
+        &detail::AggAccumulateWrapper<State, Fn, NumParams>::invoke;
+    next.deterministic_ = deterministic_;
+    for (size_t i = 0; i < NumParams; ++i) {
+      next.param_types_[i] = param_types_[i];
+    }
+    return next;
   }
 
   constexpr detail::StaticFuncDesc<NumParams> build() const {
     static_assert(NumParams <= kMaxParams,
                   "Too many parameters (max is kMaxParams)");
-    if ((clear_ == nullptr) != (accumulate_ == nullptr)) {
-      detail::config_error__aggregate_must_set_both_clear_and_accumulate();
-    }
+    static_assert(HasClear && HasAccumulate,
+                  "aggregate must set both .clear<>() and .accumulate<>()");
 
     using AllParams = typename detail::FuncParamTypes<decltype(Func)>::type;
     using UniquePTuple = typename detail::unique_params_types<AllParams>::type;
@@ -534,7 +559,7 @@ class AggFuncBuilder {
   vef_vdf_clear_func_t clear_;
   vef_vdf_accumulate_func_t accumulate_;
 
-  template <typename S, auto F, size_t M>
+  template <typename S, auto F, size_t M, bool C, bool A>
   friend class AggFuncBuilder;
 
   template <typename S, auto F>


### PR DESCRIPTION
Same as PR 891.

Disclaimer: we are changing the stable SDK here in a safe way - it doesn't impact the ABI/API in any externally visible way, but allows us to use UBSAN to find problems in extension repos that rely on the stable SDK. Normally, changes to the stable SDK would not be allowed!

#822

