### PR TITLE
valgrind: fix shutdown order

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -2446,18 +2446,11 @@ static void close_connections(void) {
   */
   Events::deinit();
 
-  // Unload VEF extensions. Must run before plugin_shutdown() (in clean_up(),
-  // much later) so component services like component_sys_variable_unregister
-  // are still available for on_depopulate to unregister sys/status variables.
-  // depopulate_capabilities() also joins background threads and removes their
-  // THDs from Global_THD_manager so wait_till_no_thd() can complete.
-  //
-  // destroy_extension_state() below is intentionally split out to run after
-  // wait_till_no_thd(): connection threads in THD::cleanup() ->
-  // trans_rollback()
-  // -> rollback_all_tables() can hold VictionaryClient locks, so destroying
-  // VictionaryClient here (before threads exit) causes crashes.
-  villagesql::deinit_extension_infrastructure();
+  // VillageSQL extension shutdown, phase 1 of 2: depopulate capabilities. Must
+  // run here, before wait_till_no_thd() and plugin_shutdown(). The two-phase
+  // ordering contract is documented at the declarations in
+  // villagesql/sql/initialize.h.
+  villagesql::depopulate_extension_capabilities();
 
   DBUG_PRINT("quit", ("Waiting for threads to die (count=%u)",
                       thd_manager->get_thd_count()));
@@ -2468,12 +2461,6 @@ static void close_connections(void) {
   */
   log_alive_threads_info(thd_manager, 100);
   thd_manager->wait_till_no_thd();
-  // Destroy VictionaryClient and SchemaManager only after wait_till_no_thd():
-  // connection threads in THD::cleanup() -> trans_rollback() ->
-  // rollback_all_tables() hold VictionaryClient locks, so we must wait for all
-  // THDs to exit. wait_till_no_connection() below is socket cleanup and is not
-  // sufficient.
-  villagesql::destroy_extension_state();
   /*
     Connection threads might take a little while to go down after removing from
     global thread list. Give it some time.
@@ -2786,6 +2773,10 @@ static void clean_up(bool print_message) {
   table_def_start_shutdown();
   delegates_shutdown();
   plugin_shutdown();
+  // VillageSQL extension shutdown, phase 2 of 2: unload the .so files and
+  // destroy extension state. Must run after plugin_shutdown() (InnoDB is now
+  // down). See villagesql/sql/initialize.h for the two-phase ordering contract.
+  villagesql::destroy_extension_state();
   // needs to be done after plugin shutdown, since plugins can still
   // hold references to the service
   binlog::services::iterator::FileStorage::unregister_service();

--- a/villagesql/sql/initialize.cc
+++ b/villagesql/sql/initialize.cc
@@ -333,7 +333,14 @@ void depopulate_extension_capabilities() {
     for (const ExtensionDescriptor *desc :
          vclient.extension_descriptors().get_all_committed()) {
       const veb::ExtensionRegistration &reg = desc->registration();
-      if (reg.registration == nullptr) continue;
+      // A committed descriptor is only inserted after a successful
+      // load_vef_extension(), so both registration and dlhandle are always
+      // populated. Assert the full invariant here (phase 2 relies on dlhandle)
+      // so the "registration set but dlhandle null" state cannot slip through;
+      // skip defensively in release if it is ever broken.
+      if (should_assert_if_null(reg.registration) ||
+          should_assert_if_null(reg.dlhandle))
+        continue;
       targets.push_back({reg.registration, desc->extension_name(),
                          desc->extension_version()});
     }
@@ -361,7 +368,9 @@ void destroy_extension_state() {
     for (const ExtensionDescriptor *desc :
          vclient.extension_descriptors().get_all_committed()) {
       const veb::ExtensionRegistration &reg = desc->registration();
-      if (reg.dlhandle == nullptr) continue;
+      // As in phase 1, a committed descriptor always has an open dlhandle;
+      // skip defensively in release if that invariant is ever broken.
+      if (should_assert_if_null(reg.dlhandle)) continue;
       LogVSQL(INFORMATION_LEVEL, "Unloading extension '%s' version '%s'",
               desc->extension_name().c_str(),
               desc->extension_version().c_str());

--- a/villagesql/sql/initialize.cc
+++ b/villagesql/sql/initialize.cc
@@ -20,6 +20,9 @@
 #include <rapidjson/stringbuffer.h>
 #include <rapidjson/writer.h>
 
+#include <string>
+#include <vector>
+
 #include "sql/bootstrap.h"
 #include "sql/dd/cache/dictionary_client.h"
 #include "sql/sd_notify.h"
@@ -282,7 +285,7 @@ bool init_extension_infrastructure() {
   return false;
 }
 
-void deinit_extension_infrastructure() {
+void depopulate_extension_capabilities() {
   VictionaryClient &vclient = VictionaryClient::instance();
   if (!vclient.is_initialized()) {
     LogVSQL(INFORMATION_LEVEL,
@@ -291,24 +294,82 @@ void deinit_extension_infrastructure() {
   }
 
   LogVSQL(INFORMATION_LEVEL,
-          "Deinitializing VillageSQL extension infrastructure");
+          "Depopulating capabilities for VillageSQL extensions");
 
+  // See initialize.h for why this is phase 1 and must run before
+  // wait_till_no_thd()/plugin_shutdown() while leaving the .so files loaded.
+  //
+  // depopulate_capabilities() BLOCKS: on_depopulate_thread_worker joins the
+  // extension's background thread, and statement_event/auth spin until their
+  // in-flight extension calls drain. Those extension callbacks may themselves
+  // take the VictionaryClient lock (e.g. a worker or statement-event handler
+  // touching a custom type). We therefore snapshot the registrations under a
+  // read lock and RELEASE it before depopulating: holding the VictionaryClient
+  // lock across depopulate would invert lock order against a connection thread
+  // that is mid-callback and about to take the lock (or in rollback_all_tables,
+  // which takes the write lock) -> deadlock, since wait_till_no_thd() has not
+  // yet run and those threads are still draining. The committed descriptor set
+  // is stable without the lock here: listeners are closed and connections have
+  // been killed, so no INSTALL/UNINSTALL EXTENSION can mutate it.
+  //
+  // TODO(villagesql): the only reason this must run before wait_till_no_thd()
+  // is that thread_worker registers THDs that nothing but depopulation reaps
+  // (poll-based workers don't wake on set_kill_conn, only on their stop pipe).
+  // If we make those workers respond to the global shutdown signal so they
+  // self-exit and remove their THDs during the normal kill window, this call
+  // could move to after wait_till_no_thd() (still before plugin_shutdown()).
+  // At that point no connection or worker threads are alive, so the lock-order
+  // inversion above cannot occur and the snapshot-and-release dance becomes
+  // unnecessary - a plain locked iteration would do. It stays two phases
+  // regardless: phase 2 must remain after innodb_shutdown().
+  struct DepopulateTarget {
+    const vef_registration_t *registration;
+    std::string name;
+    std::string version;
+  };
+  std::vector<DepopulateTarget> targets;
   {
-    auto guard = vclient.get_write_lock();
-    auto descriptors = vclient.extension_descriptors().get_all_committed();
-
-    for (const ExtensionDescriptor *desc : descriptors) {
-      LogVSQL(INFORMATION_LEVEL, "Unloading extension '%s' version '%s'",
-              desc->extension_name().c_str(),
-              desc->extension_version().c_str());
-      veb::unload_vef_extension({.reason = services::UnloadReason::kShutdown},
-                                desc->registration());
+    auto guard = vclient.get_read_lock();
+    for (const ExtensionDescriptor *desc :
+         vclient.extension_descriptors().get_all_committed()) {
+      const veb::ExtensionRegistration &reg = desc->registration();
+      if (reg.registration == nullptr) continue;
+      targets.push_back({reg.registration, desc->extension_name(),
+                         desc->extension_version()});
     }
+  }
+
+  for (const DepopulateTarget &target : targets) {
+    LogVSQL(INFORMATION_LEVEL,
+            "Depopulating capabilities for extension '%s' version '%s'",
+            target.name.c_str(), target.version.c_str());
+    services::depopulate_capabilities(
+        {.reason = services::UnloadReason::kShutdown}, target.registration);
   }
 }
 
 void destroy_extension_state() {
-  VictionaryClient::instance().destroy();
+  VictionaryClient &vclient = VictionaryClient::instance();
+
+  // Phase 2: now that InnoDB has finished shutting down and no longer
+  // references extension-provided storage interfaces, unload the .so files and
+  // destroy the extension state. Capabilities were already depopulated in
+  // depopulate_extension_capabilities().
+  if (vclient.is_initialized()) {
+    // Release the write lock before destroy() below tears the lock down.
+    auto guard = vclient.get_write_lock();
+    for (const ExtensionDescriptor *desc :
+         vclient.extension_descriptors().get_all_committed()) {
+      const veb::ExtensionRegistration &reg = desc->registration();
+      if (reg.dlhandle == nullptr) continue;
+      LogVSQL(INFORMATION_LEVEL, "Unloading extension '%s' version '%s'",
+              desc->extension_name().c_str(),
+              desc->extension_version().c_str());
+      veb::close_vef_extension(reg);
+    }
+  }
+
+  vclient.destroy();
   SchemaManager::deinit();
   LogVSQL(INFORMATION_LEVEL,
           "VillageSQL extension infrastructure deinitialized");

--- a/villagesql/sql/initialize.h
+++ b/villagesql/sql/initialize.h
@@ -23,12 +23,53 @@ namespace villagesql {
 // Initialize the villagesql extension framework.
 bool init_extension_infrastructure();
 
-// Unloads all loaded extensions. Must run before plugin_shutdown() so
-// component services are still available for deregistration.
-void deinit_extension_infrastructure();
+// VillageSQL extension shutdown runs in two phases, invoked from two different
+// points in the server shutdown sequence (sql/mysqld.cc). The split exists
+// because the teardown steps have opposing ordering constraints relative to
+// InnoDB shutdown:
+//
+//   Phase 1 - depopulate_extension_capabilities() - runs in
+//     close_connections(), before wait_till_no_thd() and plugin_shutdown().
+//   Phase 2 - destroy_extension_state() - runs in clean_up(), after
+//     plugin_shutdown() (i.e. after innodb_shutdown()).
+//
+// Why phase 1 must be early:
+//   - Capability background threads (thread_worker) register THDs in
+//     Global_THD_manager; only depopulation joins them, so it must precede
+//     wait_till_no_thd() or that call blocks forever.
+//   - sys/status var depopulation calls component services that
+//     plugin_shutdown() tears down, so it must precede plugin_shutdown().
+//
+// Why phase 2 must be late:
+//   - InnoDB's dict cache holds Custom_column objects whose destructors call
+//     extension-provided storage functions during innodb_shutdown(). The .so
+//     files and the VictionaryClient type metadata must outlive InnoDB, so
+//     they can only be unloaded/destroyed after plugin_shutdown().
+//
+// Extending this: two phases suffice only because every current capability
+// tears down either "before threads are gone" or "before InnoDB is down", and
+// the single phase-1 point happens to satisfy both. If a future capability
+// needs a teardown step with a third ordering constraint - for example a
+// deinitialization that can only run AFTER wait_till_no_thd(), once every
+// connection thread has exited - two fixed phases will not be enough. At that
+// point, replace these functions with an explicit per-capability teardown-phase
+// mechanism: tag each capability with the phase it must be torn down in (e.g.
+// kBeforeThreadsGone, kBeforeInnoDBDown, kAfterInnoDBDown) and drive each phase
+// from the corresponding point in the shutdown sequence, rather than
+// re-deriving these constraints by hand.
 
-// Destroys the VictionaryClient and SchemaManager state. Must run after
-// wait_till_no_thd() so no connection threads are mid-rollback.
+// Phase 1: depopulate the capabilities of all loaded extensions (deregister
+// sys/status variables, join capability background threads, drain in-flight
+// capability calls). Does NOT unload the .so files or destroy extension state;
+// InnoDB still references extension storage interfaces until its dict cache is
+// cleared during innodb_shutdown(). See the two-phase note above.
+void depopulate_extension_capabilities();
+
+// Phase 2: unload the extension .so files and destroy the VictionaryClient and
+// SchemaManager state. Safe only after wait_till_no_thd() (no connection thread
+// is mid-rollback holding VictionaryClient locks) AND after
+// plugin_shutdown()/innodb_shutdown() (InnoDB no longer calls into
+// extension-provided storage interfaces). See the two-phase note above.
 void destroy_extension_state();
 
 /**

--- a/villagesql/sql/initialize.h
+++ b/villagesql/sql/initialize.h
@@ -41,22 +41,32 @@ bool init_extension_infrastructure();
 //     plugin_shutdown() tears down, so it must precede plugin_shutdown().
 //
 // Why phase 2 must be late:
-//   - InnoDB's dict cache holds Custom_column objects whose destructors call
-//     extension-provided storage functions during innodb_shutdown(). The .so
-//     files and the VictionaryClient type metadata must outlive InnoDB, so
-//     they can only be unloaded/destroyed after plugin_shutdown().
+//   - InnoDB may keep invoking extension-provided storage/type callbacks right
+//     up until it has fully shut down, so the .so files and the
+//     VictionaryClient type metadata must remain available until
+//     innodb_shutdown() completes.
+//     This is broader than object teardown: e.g. Custom_column destructors call
+//     storage functions during dict_close(), and the background purge thread
+//     may call an extension's compare function while purging a secondary index
+//     over a custom type. Hence unload/destroy can only run after
+//     plugin_shutdown().
 //
-// Extending this: two phases suffice only because every current capability
-// tears down either "before threads are gone" or "before InnoDB is down", and
-// the single phase-1 point happens to satisfy both. If a future capability
-// needs a teardown step with a third ordering constraint - for example a
-// deinitialization that can only run AFTER wait_till_no_thd(), once every
-// connection thread has exited - two fixed phases will not be enough. At that
-// point, replace these functions with an explicit per-capability teardown-phase
-// mechanism: tag each capability with the phase it must be torn down in (e.g.
-// kBeforeThreadsGone, kBeforeInnoDBDown, kAfterInnoDBDown) and drive each phase
-// from the corresponding point in the shutdown sequence, rather than
-// re-deriving these constraints by hand.
+// TODO(villagesql): make capability teardown ordering explicit. Two phases
+// suffice today only because every current capability tears down either
+// "before threads are gone" or "before InnoDB is down", and the single phase-1
+// point happens to satisfy both. This is fragile: all of phase 1 runs before
+// innodb_shutdown(), so a storage- or type-related capability that grows an
+// on_depopulate() hook would be torn down while InnoDB can still call into it
+// (e.g. the purge thread comparing a custom type) - a latent ordering bug. It
+// is safe now only because such capabilities have no on_depopulate() and there
+// is not yet a capability tied to custom data types. The model also cannot
+// express a third ordering constraint - e.g. a teardown that must run AFTER
+// wait_till_no_thd(), once every connection thread has exited. The fix is an
+// explicit per-capability teardown-phase mechanism: tag each capability with
+// the phase it must be torn down in (e.g. kBeforeThreadsGone,
+// kBeforeInnoDBDown, kAfterInnoDBDown) and drive each phase from the
+// corresponding point in the shutdown sequence, rather than re-deriving these
+// constraints by hand.
 
 // Phase 1: depopulate the capabilities of all loaded extensions (deregister
 // sys/status variables, join capability background threads, drain in-flight


### PR DESCRIPTION
When fixing an LSAN issue, we found, via valgrind, an uninitialized memory read during shutdown. The root cause is that we were destroying the extension state too early, before innodb shutdown. As a result, some references to the .so files were still present in the custom index code.

The fix here is to split the shutdown into two phases:

1. deinit the capabilities - this is done before plugin_shutdown (which is when innodb shuts down)
2. destroy the extension state - this is now done after plugin_shutdown, when it is safe to unload the .so files

Note: if we improve the background thread capability, we could move the first phase to be after wait_till_no_thds(), which would be nice. For now, it has to come before.

#822
Closes #908
