### PR TITLE
auth: accept any unscrambled secret

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-auth/r/auth_client_plugin.result
+++ b/mysql-test/suite/villagesql/extension/vsql-auth/r/auth_client_plugin.result
@@ -1,0 +1,69 @@
+INSTALL EXTENSION vsql_auth_test;
+CREATE USER auth_user IDENTIFIED WITH vsql_auth_test;
+CREATE USER vsql_auth_test_user;
+GRANT SELECT ON *.* TO vsql_auth_test_user;
+GRANT PROXY ON vsql_auth_test_user TO auth_user;
+#
+# Default policy (accept_client_plugin empty): the method accepts only its
+# pin. A stock client offers caching_sha2_password, which the callback
+# rejects, so the server switches to mysql_clear_password.
+#
+# With --enable_cleartext_plugin the client complies with the switch and
+# resends the token verbatim -> accepted.
+#
+CURRENT_USER()	@@external_user
+vsql_auth_test_user@%	auth_user
+#
+# Without --enable_cleartext_plugin the client refuses the switch to
+# cleartext -> ER 2059 (the switch WAS attempted).
+#
+mysql: [Warning] Using a password on the command line interface can be insecure.
+ERROR 2059 (HY000): Authentication plugin 'mysql_clear_password' cannot be loaded: plugin not enabled
+#
+# Now have the method ALSO accept the offered plugin as-is (no switch).
+# The offer is the scrambler the stock client sends, so its first reply is
+# a hash rather than the token: the handler rejects it (ER 1045) -- and
+# there is NO 2059, proving the server accepted the offer and did not
+# force a switch.
+#
+SET GLOBAL vsql_auth_test.accept_client_plugin = 'caching_sha2_password';
+mysql: [Warning] Using a password on the command line interface can be insecure.
+ERROR 1045 (28000): Access denied for user 'auth_user'@'localhost' (using password: NO)
+#
+# A method that accepts the offer is authoritative: even with the client
+# willing to use cleartext, no switch happens, so the scrambled first
+# reply still fails (ER 1045, not 2059).
+#
+mysql: [Warning] Using a password on the command line interface can be insecure.
+ERROR 1045 (28000): Access denied for user 'auth_user'@'localhost' (using password: NO)
+#
+# Back to strict pin: clearing the sysvar restores switch-to-pin, so the
+# cleartext client authenticates again.
+#
+SET GLOBAL vsql_auth_test.accept_client_plugin = '';
+CURRENT_USER()
+vsql_auth_test_user@%
+#
+# Decoy path: the accept decision is consulted for the single auto-create
+# method too. Opt the method into unknown accounts, then a strict pin
+# still switches a stock cleartext client to the pin and provisions.
+#
+call mtr.add_suppression("routing unknown accounts");
+SET GLOBAL vsql_auth_test.auto_create = ON;
+CREATE ROLE vsql_role_granted;
+GRANT SELECT ON *.* TO vsql_role_granted;
+SELECT CURRENT_USER() AS who;
+who
+decoy_user@%
+SELECT user, host, plugin FROM mysql.user WHERE user = 'decoy_user';
+user	host	plugin
+decoy_user	%	vsql_auth_test
+#
+# Cleanup.
+#
+SET GLOBAL vsql_auth_test.auto_create = OFF;
+DROP USER 'decoy_user'@'%';
+DROP ROLE vsql_role_granted;
+DROP USER auth_user;
+DROP USER vsql_auth_test_user;
+UNINSTALL EXTENSION vsql_auth_test;

--- a/mysql-test/suite/villagesql/extension/vsql-auth/r/auth_client_plugin.result
+++ b/mysql-test/suite/villagesql/extension/vsql-auth/r/auth_client_plugin.result
@@ -41,8 +41,8 @@ ERROR 1045 (28000): Access denied for user 'auth_user'@'localhost' (using passwo
 # cleartext client authenticates again.
 #
 SET GLOBAL vsql_auth_test.accept_client_plugin = '';
-CURRENT_USER()
-vsql_auth_test_user@%
+CURRENT_USER()	@@external_user
+vsql_auth_test_user@%	auth_user
 #
 # Decoy path: the accept decision is consulted for the single auto-create
 # method too. Opt the method into unknown accounts, then a strict pin

--- a/mysql-test/suite/villagesql/extension/vsql-auth/t/auth_client_plugin.test
+++ b/mysql-test/suite/villagesql/extension/vsql-auth/t/auth_client_plugin.test
@@ -1,0 +1,93 @@
+# A VEF auth method decides which client-side auth plugins it accepts as-is. The
+# vsql_auth_test method pins mysql_clear_password; SET GLOBAL
+# vsql_auth_test.accept_client_plugin names one extra plugin it also accepts
+# (empty by default = accept only the pin). This test drives real logins and
+# checks whether the server accepts the client's offered plugin or forces a
+# switch to the pin.
+#
+# The stock client offers the scrambler caching_sha2_password, so:
+#   - offer NOT accepted -> switch to mysql_clear_password; without
+#     --enable_cleartext_plugin the client refuses -> ER 2059
+#     "'mysql_clear_password' cannot be loaded: plugin not enabled".
+#   - offer accepted -> no switch; the scrambler's first reply is a hash, not the
+#     token, so login fails with ER 1045 -- and NO 2059.
+# ER 2059 vs ER 1045 is the "switch forced" vs "offer accepted" signal.
+#
+# Each case uses --exec $MYSQL ... 2>&1 (not --connect) so the exact error line is
+# captured in the .result: the 2059-vs-1045 text IS the assertion; --connect
+# matches only an error code, not the message.
+
+INSTALL EXTENSION vsql_auth_test;
+
+CREATE USER auth_user IDENTIFIED WITH vsql_auth_test;
+CREATE USER vsql_auth_test_user;
+GRANT SELECT ON *.* TO vsql_auth_test_user;
+GRANT PROXY ON vsql_auth_test_user TO auth_user;
+
+--echo #
+--echo # Default policy (accept_client_plugin empty): the method accepts only its
+--echo # pin. A stock client offers caching_sha2_password, which the callback
+--echo # rejects, so the server switches to mysql_clear_password.
+--echo #
+--echo # With --enable_cleartext_plugin the client complies with the switch and
+--echo # resends the token verbatim -> accepted.
+--echo #
+--exec $MYSQL --enable_cleartext_plugin --user=auth_user --password=vsql-auth-test-token -e "SELECT CURRENT_USER(), @@external_user"
+
+--echo #
+--echo # Without --enable_cleartext_plugin the client refuses the switch to
+--echo # cleartext -> ER 2059 (the switch WAS attempted).
+--echo #
+--error 1
+--exec $MYSQL --user=auth_user --password=vsql-auth-test-token -e "SELECT 1" 2>&1
+
+--echo #
+--echo # Now have the method ALSO accept the offered plugin as-is (no switch).
+--echo # The offer is the scrambler the stock client sends, so its first reply is
+--echo # a hash rather than the token: the handler rejects it (ER 1045) -- and
+--echo # there is NO 2059, proving the server accepted the offer and did not
+--echo # force a switch.
+--echo #
+SET GLOBAL vsql_auth_test.accept_client_plugin = 'caching_sha2_password';
+--error 1
+--exec $MYSQL --user=auth_user --password=vsql-auth-test-token -e "SELECT 1" 2>&1
+
+--echo #
+--echo # A method that accepts the offer is authoritative: even with the client
+--echo # willing to use cleartext, no switch happens, so the scrambled first
+--echo # reply still fails (ER 1045, not 2059).
+--echo #
+--error 1
+--exec $MYSQL --enable_cleartext_plugin --user=auth_user --password=vsql-auth-test-token -e "SELECT 1" 2>&1
+
+--echo #
+--echo # Back to strict pin: clearing the sysvar restores switch-to-pin, so the
+--echo # cleartext client authenticates again.
+--echo #
+SET GLOBAL vsql_auth_test.accept_client_plugin = '';
+--exec $MYSQL --enable_cleartext_plugin --user=auth_user --password=vsql-auth-test-token -e "SELECT CURRENT_USER()"
+
+--echo #
+--echo # Decoy path: the accept decision is consulted for the single auto-create
+--echo # method too. Opt the method into unknown accounts, then a strict pin
+--echo # still switches a stock cleartext client to the pin and provisions.
+--echo #
+call mtr.add_suppression("routing unknown accounts");
+SET GLOBAL vsql_auth_test.auto_create = ON;
+CREATE ROLE vsql_role_granted;
+GRANT SELECT ON *.* TO vsql_role_granted;
+--connect(decoy_con, localhost, decoy_user, vsql-auth-test-token, , , , CLEARTEXT)
+SELECT CURRENT_USER() AS who;
+--connection default
+--disconnect decoy_con
+SELECT user, host, plugin FROM mysql.user WHERE user = 'decoy_user';
+
+--echo #
+--echo # Cleanup.
+--echo #
+SET GLOBAL vsql_auth_test.auto_create = OFF;
+DROP USER 'decoy_user'@'%';
+DROP ROLE vsql_role_granted;
+DROP USER auth_user;
+DROP USER vsql_auth_test_user;
+UNINSTALL EXTENSION vsql_auth_test;

--- a/mysql-test/suite/villagesql/extension/vsql-auth/t/auth_client_plugin.test
+++ b/mysql-test/suite/villagesql/extension/vsql-auth/t/auth_client_plugin.test
@@ -1,5 +1,6 @@
 # A VEF auth method decides which client-side auth plugins it accepts as-is. The
-# vsql_auth_test method pins mysql_clear_password; SET GLOBAL
+# vsql_auth_test method pins mysql_clear_password (its "pin" = the client plugin
+# the server switches an unaccepted client to); SET GLOBAL
 # vsql_auth_test.accept_client_plugin names one extra plugin it also accepts
 # (empty by default = accept only the pin). This test drives real logins and
 # checks whether the server accepts the client's offered plugin or forces a
@@ -65,7 +66,7 @@ SET GLOBAL vsql_auth_test.accept_client_plugin = 'caching_sha2_password';
 --echo # cleartext client authenticates again.
 --echo #
 SET GLOBAL vsql_auth_test.accept_client_plugin = '';
---exec $MYSQL --enable_cleartext_plugin --user=auth_user --password=vsql-auth-test-token -e "SELECT CURRENT_USER()"
+--exec $MYSQL --enable_cleartext_plugin --user=auth_user --password=vsql-auth-test-token -e "SELECT CURRENT_USER(), @@external_user"
 
 --echo #
 --echo # Decoy path: the accept decision is consulted for the single auto-create

--- a/sql/auth/sql_authentication.cc
+++ b/sql/auth/sql_authentication.cc
@@ -1226,6 +1226,23 @@ static bool maybe_provision(THD *thd, MPVIO_EXT *mpvio) {
   return false;
 }
 
+// VillageSQL: whether this VEF connection accepts the client's OFFERED plugin
+// as-is (no switch to the pin). Only reached for an offer that is not already
+// the pin (the caller accepts an exact-pin match separately). The extension --
+// not the server -- knows which client plugins frame a credential it can parse,
+// so the accept decision is entirely the method's: the server stays agnostic
+// about client plugins and simply asks the method's accepts_client_plugin
+// callback (stashed on the connection before the handler runs). A method that
+// declares no callback accepts no non-pin offer, so it forces the usual switch
+// to the pinned plugin (the client resends the credential verbatim), and a
+// naive client still connects.
+inline bool vef_offered_plugin_acceptable(MPVIO_EXT *mpvio) {
+  const char *offered = mpvio->cached_client_reply.plugin;
+  if (offered == nullptr) return false;
+  if (mpvio->vef_auth_info.vef_accepts_client_plugin == nullptr) return false;
+  return mpvio->vef_auth_info.vef_accepts_client_plugin(offered);
+}
+
 LEX_CSTRING validate_password_plugin_name = {
     STRING_WITH_LEN("validate_password")};
 
@@ -3536,7 +3553,10 @@ static int server_mpvio_read_packet(MYSQL_PLUGIN_VIO *param, uchar **buf) {
     // VillageSQL: via mpvio_client_plugin_name() so a VEF method (which has no
     // MySQL plugin) resolves its pinned client plugin instead.
     auto client_auth_plugin_name = mpvio_client_plugin_name(mpvio);
-    if (client_auth_plugin_name == nullptr ||
+    // VillageSQL: a VEF login (no MySQL plugin) relaxes the exact-match below.
+    const bool vef_accepts_offer =
+        mpvio->plugin == nullptr && vef_offered_plugin_acceptable(mpvio);
+    if (client_auth_plugin_name == nullptr || vef_accepts_offer ||
         my_strcasecmp(system_charset_info, mpvio->cached_client_reply.plugin,
                       client_auth_plugin_name) == 0) {
       mpvio->status = MPVIO_EXT::FAILURE;

--- a/villagesql/sdk/include/villagesql/abi/preview/auth.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/auth.h
@@ -156,6 +156,14 @@ typedef struct {
   // copied.
   void (*request_provision)(vef_auth_ctx_t *ctx, const char *account,
                             const char *const *roles, uint32_t n_roles);
+
+  // The name of the client-side auth plugin the connection actually used (as
+  // advertised by the client), e.g. "mysql_clear_password" or
+  // "authentication_openid_connect_client". Lets a handler pick how to parse
+  // the credential packet by which client plugin produced it, instead of
+  // sniffing packet bytes (different client plugins frame the credential
+  // differently). Empty if unknown. Valid for the duration of the handler call.
+  const char *(*client_auth_plugin)(vef_auth_ctx_t *ctx);
 } vef_auth_ops_t;
 
 // The handler the extension implements. Invoked synchronously on the connecting
@@ -198,6 +206,15 @@ typedef struct {
   // activate-only default (the DBA owns grants; a token can only activate roles
   // already granted).
   bool (*auto_grant_roles)(void);
+  // Optional callback: return true if this method can parse a credential
+  // delivered by the client plugin named `offered` as-is, so the server accepts
+  // it without switching to client_auth_plugin. Returning false (or a nullptr
+  // callback) forces a change-plugin switch to client_auth_plugin -- the client
+  // resends the credential verbatim -- so a naive client still connects.
+  // Queried during handshake negotiation, before the handler's first read, so
+  // it must be a pure predicate (no packet I/O, no blocking, no side effects).
+  // `offered` is the raw client-supplied plugin name.
+  bool (*accepts_client_plugin)(const char *offered);
 } vef_auth_cc_t;
 
 // Server-side vtable. Version first, matching the other preview capabilities.

--- a/villagesql/sdk/include/villagesql/preview/auth.h
+++ b/villagesql/sdk/include/villagesql/preview/auth.h
@@ -185,13 +185,13 @@ class AuthDescriptor {
     return *this;
   }
 
-  // `accepts_client_plugin`: which client plugins this method can parse a
-  // credential from as-is; the server accepts an offer this returns true for
-  // without switching to client_plugin(). Optional -- unset switches every
-  // offer to client_plugin(). Return true for a token-framing plugin whose
-  // payload this method decodes (and typically client_plugin() itself). Must be
-  // a pure predicate; see vef_auth_cc_t::accepts_client_plugin for the
-  // contract.
+  // `accepts_client_plugin`: a callback letting the method accept or reject the
+  // client plugin the client initially offered. Returning true keeps that
+  // plugin; returning false switches the client to client_plugin(). If not set,
+  // the normal client plugin negotiation continues (every offer switches to
+  // client_plugin()). The callback must only inspect the offered name and
+  // return a decision -- no packet I/O, blocking, or side effects (it runs
+  // mid-handshake). See vef_auth_cc_t::accepts_client_plugin for the contract.
   constexpr AuthDescriptor &accepts_client_plugin(
       bool (*callback)(const char *offered)) {
     cc_.accepts_client_plugin = callback;

--- a/villagesql/sdk/include/villagesql/preview/auth.h
+++ b/villagesql/sdk/include/villagesql/preview/auth.h
@@ -70,6 +70,14 @@ class AuthContext {
   // The client host or IP.
   const char *host_or_ip() const { return ops_->host_or_ip(ctx_); }
 
+  // The client-side auth plugin the connection actually used (as advertised by
+  // the client), e.g. "mysql_clear_password" or
+  // "authentication_openid_connect_client". Lets a handler pick how to parse
+  // the credential packet by which client plugin produced it. Empty if unknown.
+  const char *client_auth_plugin() const {
+    return ops_->client_auth_plugin(ctx_);
+  }
+
   // Set the effective account the session runs AS (CURRENT_USER()). Required
   // before returning kOk. Mapping to a different account than user_name() is
   // proxying and needs a GRANT PROXY, exactly as on the plugin path.
@@ -174,6 +182,19 @@ class AuthDescriptor {
   // the activate-only default (the DBA owns grants).
   constexpr AuthDescriptor &auto_grant(bool (*callback)()) {
     cc_.auto_grant_roles = callback;
+    return *this;
+  }
+
+  // `accepts_client_plugin`: which client plugins this method can parse a
+  // credential from as-is; the server accepts an offer this returns true for
+  // without switching to client_plugin(). Optional -- unset switches every
+  // offer to client_plugin(). Return true for a token-framing plugin whose
+  // payload this method decodes (and typically client_plugin() itself). Must be
+  // a pure predicate; see vef_auth_cc_t::accepts_client_plugin for the
+  // contract.
+  constexpr AuthDescriptor &accepts_client_plugin(
+      bool (*callback)(const char *offered)) {
+    cc_.accepts_client_plugin = callback;
     return *this;
   }
 

--- a/villagesql/services/preview/auth.cc
+++ b/villagesql/services/preview/auth.cc
@@ -245,13 +245,21 @@ void vef_auth_request_provision(vef_auth_ctx_t *ctx, const char *account,
   mpvio->vef_auth_info.vef_provision_request = req;
 }
 
+const char *vef_auth_client_plugin(vef_auth_ctx_t *ctx) {
+  // The client-plugin name the client advertised for this connection, cached on
+  // the handshake context. Set before the handler's first read, so it is
+  // available throughout the handler call.
+  const char *p = ctx->mpvio->cached_client_reply.plugin;
+  return p != nullptr ? p : "";
+}
+
 const vef_auth_ops_t g_vef_auth_ops = {
     VEF_PREVIEW_AUTH_ABI_VERSION,  vef_auth_read_packet,
     vef_auth_write_packet,         vef_auth_user_name,
     vef_auth_auth_string,          vef_auth_host_or_ip,
     vef_auth_set_authenticated_as, vef_auth_set_external_user,
     vef_auth_set_active_roles,     vef_auth_account_unknown,
-    vef_auth_request_provision};
+    vef_auth_request_provision,    vef_auth_client_plugin};
 
 }  // namespace
 
@@ -531,6 +539,10 @@ static bool try_vef_authenticate(const vef_auth_cc_t *cc, MPVIO_EXT *mpvio) {
   // driving the handler: the handler's first read_packet triggers the handshake
   // change-plugin request that reads it back via mpvio_client_plugin_name().
   mpvio->vef_auth_info.vef_client_auth_plugin = cc->client_auth_plugin;
+  // Stash the method's accept-offer predicate (may be null) so the negotiation
+  // that first read triggers can ask this method whether the client's offered
+  // plugin is acceptable as-is.
+  mpvio->vef_auth_info.vef_accepts_client_plugin = cc->accepts_client_plugin;
 
   // Run the extension's authenticator over an ops table on this MPVIO_EXT.
   vef_auth_ctx_t ctx{mpvio};

--- a/villagesql/services/preview/auth_info.h
+++ b/villagesql/services/preview/auth_info.h
@@ -40,6 +40,11 @@ struct VefAuthInfo {
   // advertise/expect comes from the method's config instead of from
   // client_plugin_name(plugin). Set by the seam before invoking the handler.
   const char *vef_client_auth_plugin;
+  // The method's accepts_client_plugin callback (or null if it declared none),
+  // stashed alongside vef_client_auth_plugin so the handshake negotiation can
+  // ask the method whether the client's offered plugin is acceptable as-is
+  // without a registry lookup. Set by the seam before invoking the handler.
+  bool (*vef_accepts_client_plugin)(const char *offered);
   villagesql::services::VefAuthState *vef_auth_state;
   villagesql::services::VefProvisionRequest *vef_provision_request;
 };

--- a/villagesql/test-extensions/vsql-auth-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-auth-test/src/extension.cc
@@ -19,7 +19,8 @@
 // tokens below. The connecting account "auth_user" proxies to
 // "vsql_auth_test_user"; any other account authenticates as itself. The
 // auto_create / auto_grant opt-ins are exposed as sysvars (default OFF) so
-// tests toggle each independently.
+// tests toggle each independently, and accept_client_plugin (a sysvar) selects
+// one extra client plugin the method accepts as-is during negotiation.
 //
 // Tokens: kToken (no roles); kTokenRoles (stages vsql_role_granted +
 // vsql_role_denied); kTokenQuotedRole (stages a role whose name has a quoted
@@ -44,6 +45,11 @@ constexpr char kToken[] = "vsql-auth-test-token";
 constexpr char kTokenRoles[] = "vsql-auth-test-token-roles";
 constexpr char kTokenQuotedRole[] = "vsql-auth-test-token-quoted-role";
 constexpr char kMappedAccount[] = "vsql_auth_test_user";
+
+// The client plugin this method advertises (via .client_plugin) and reads a
+// verbatim token from. The accept-offer callback below always accepts this
+// name; a test can additionally accept one other client plugin via a sysvar.
+constexpr char kClientPlugin[] = "mysql_clear_password";
 
 using vsql::preview_auth::AuthContext;
 using vsql::preview_auth::AuthResult;
@@ -74,6 +80,25 @@ bool g_auto_create = false;
 bool g_auto_grant = false;
 bool auto_create_enabled() { return g_auto_create; }
 bool auto_grant_enabled() { return g_auto_grant; }
+
+// One extra client plugin (besides kClientPlugin) this method accepts as-is,
+// selected by a test via SET GLOBAL vsql_auth_test.accept_client_plugin. Empty
+// (the default) means the method accepts only kClientPlugin. Set it to another
+// plugin name to prove the server accepts that offer without forcing a switch.
+char *g_accept_client_plugin = nullptr;
+
+// accepts_client_plugin: the server asks this during handshake negotiation
+// which client plugins this method accepts a credential from as-is. Accept
+// kClientPlugin always, plus whatever plugin the test selected via the sysvar;
+// any other offer returns false, so the server switches the client to
+// kClientPlugin and it resends the token verbatim.
+bool accepts_client_plugin(const char *offered) {
+  if (offered == nullptr) return false;
+  if (std::strcmp(offered, kClientPlugin) == 0) return true;
+  const char *extra = g_accept_client_plugin;
+  return extra != nullptr && extra[0] != '\0' &&
+         std::strcmp(offered, extra) == 0;
+}
 
 // The authenticator. Reads one packet (the token), compares it to the fixed
 // test tokens, and on success resolves the session account. Fail closed
@@ -135,19 +160,25 @@ AuthResult authenticate(AuthContext &c) {
 
 constexpr auto AUTH_METHOD =
     vsql::preview_auth::make_auth<&authenticate>("vsql_auth_test")
-        .client_plugin("mysql_clear_password")
+        .client_plugin(kClientPlugin)
         .auto_create(&auto_create_enabled)
         .auto_grant(&auto_grant_enabled)
+        .accepts_client_plugin(&accepts_client_plugin)
         .build();
 vsql::preview_auth::AuthCapability g_auth{AUTH_METHOD};
 
-// Sysvars backing the two opt-ins (default OFF): SET GLOBAL
-// vsql_auth_test.auto_create / .auto_grant lets a test enable each feature.
+// Sysvars backing the opt-ins. auto_create / auto_grant default OFF; SET GLOBAL
+// vsql_auth_test.auto_create / .auto_grant toggles each feature.
+// accept_client_plugin defaults empty (accept only kClientPlugin); set it to
+// another plugin name to have the method accept that offer as-is.
 auto SYS_VARS = sv::make_capability({
     sv::make_bool("auto_create", "Route unknown accounts here for provisioning",
                   &g_auto_create, false),
     sv::make_bool("auto_grant", "Grant token-staged roles to existing accounts",
                   &g_auto_grant, false),
+    sv::make_str("accept_client_plugin",
+                 "One extra client plugin to also accept as-is",
+                 &g_accept_client_plugin, ""),
 });
 
 }  // namespace


### PR DESCRIPTION
instead of requiring an exact match with the pinned client plugin, causing extra roundtrips and client using a specific client plugin, accept any that offer unscrambled information

part of #639