### PR TITLE
deadlock on concurrent queries

### DIFF
--- a/villagesql/sql/func_lookup.cc
+++ b/villagesql/sql/func_lookup.cc
@@ -49,7 +49,12 @@ const FuncDescriptor *find_func(std::string_view ext_name,
   return victionary.funcs().acquire(key, cleanup_scope);
 }
 
-bool func_exists(std::string_view ext_name, std::string_view func_name) {
+// When acquire_read_lock is true, acquires the victionary read lock for the
+// lookup; otherwise the caller must already hold the read (or write) lock and
+// we only assert that.
+static bool func_exists_impl(std::string_view ext_name,
+                             std::string_view func_name,
+                             bool acquire_read_lock) {
   if (ext_name.empty() || func_name.empty()) {
     return false;
   }
@@ -65,9 +70,22 @@ bool func_exists(std::string_view ext_name, std::string_view func_name) {
 
   FuncKey key{std::string{func_name}, std::string{ext_name}};
 
-  auto lock = victionary.get_read_lock();
+  if (acquire_read_lock) {
+    auto lock = victionary.get_read_lock();
+    return victionary.funcs().get_committed(key) != nullptr;
+  }
 
+  // Caller must already hold the read (or write) lock; do not acquire it here.
+  victionary.assert_read_or_write_lock_held();
   return victionary.funcs().get_committed(key) != nullptr;
+}
+
+bool func_exists_locked(std::string_view ext_name, std::string_view func_name) {
+  return func_exists_impl(ext_name, func_name, /*acquire_read_lock=*/false);
+}
+
+bool func_exists(std::string_view ext_name, std::string_view func_name) {
+  return func_exists_impl(ext_name, func_name, /*acquire_read_lock=*/true);
 }
 
 const FuncDescriptor *find_func_unqualified(std::string_view func_name,

--- a/villagesql/sql/func_lookup.h
+++ b/villagesql/sql/func_lookup.h
@@ -51,6 +51,12 @@ const FuncDescriptor *find_func(std::string_view ext_name,
 // Returns: true if the function exists, false otherwise.
 bool func_exists(std::string_view ext_name, std::string_view func_name);
 
+// Same as func_exists(), but assumes the caller already holds the
+// VictionaryClient read (or write) lock and does NOT acquire it.
+//
+// Returns: true if the function exists, false otherwise.
+bool func_exists_locked(std::string_view ext_name, std::string_view func_name);
+
 // Find VDF by function name only (unqualified lookup).
 // Returns the FuncDescriptor if exactly one extension provides the function.
 // Sets *ambiguous_extensions to a comma-separated list if multiple found.

--- a/villagesql/sql/metadata_modifier.cc
+++ b/villagesql/sql/metadata_modifier.cc
@@ -904,8 +904,9 @@ bool Metadata_modifier::validate_entries() {
       return true;
     }
 
-    // Verify that the function exists in VictionaryClient
-    if (!func_exists(routine.extension_name, routine.function_name)) {
+    // Verify that the function exists in VictionaryClient. Use the _locked
+    // variant: validate_entries already holds the read lock.
+    if (!func_exists_locked(routine.extension_name, routine.function_name)) {
       villagesql_error("Custom function '%s' not found in extension '%s'",
                        MYF(0), routine.function_name.c_str(),
                        routine.extension_name.c_str());


### PR DESCRIPTION
Concurrent queries that call an extension function over a custom-type table could deadlock the whole server.

Root cause is a nested read-lock on the single, non-recursive, writer-preference `VictionaryClient::m_lock`:

  - `Metadata_modifier::validate_entries()` acquires the victionary read lock, then in its `to_call_` loop calls `func_exists()`, which acquires the read lock *again*.
  - On a writer-preference rwlock (macOS), once a writer is queued a new read request blocks even for a thread that already holds a read lock. The inner acquisition then blocks behind a waiting writer while the outer read lock is still held; the writer waits on that outer lock forever -> cyclic deadlock.