### PR TITLE
Trigger tests after nightly build

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         default: 'full-test'
+  # Runs after every Nightly run, as an independent workflow.
+  # Runs even if Nightly failed, as a source of nightly test results.
+  workflow_run:
+    workflows: ['Nightly Build and Test']
+    types: [completed]
 
 jobs:
   build-and-test:
@@ -48,24 +53,31 @@ jobs:
     env:
       SOURCE_DIR: ${{ github.workspace }}/source
       BUILD_DIR: ${{ github.workspace }}/build
+      # workflow_run supplies no inputs, so fall back to the commit the nightly
+      # run built. Its tags only exist when it succeeded, but head_sha is always
+      # there, so a failed nightly still gets its code tested.
+      REF: ${{ inputs.ref || github.event.workflow_run.head_sha || 'main' }}
+      BUILD_TYPE: ${{ inputs.build-type || 'release' }}
+      ARTIFACT_PREFIX: ${{ inputs.artifact-prefix || 'nightly-full' }}
 
     steps:
     - name: Report Parameters
       run: |
-        echo "Git Rev: ${{ inputs.ref }}"
-        echo "Build type: ${{ inputs.build-type }}"
-        echo "Artifact prefix: ${{ inputs.artifact-prefix }}"
+        echo "Trigger: $GITHUB_EVENT_NAME"
+        echo "Git Rev: $REF"
+        echo "Build type: $BUILD_TYPE"
+        echo "Artifact prefix: $ARTIFACT_PREFIX"
 
     - name: Checkout code
       uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
-        ref: ${{ inputs.ref }}
+        ref: ${{ env.REF }}
         fetch-depth: 50
         path: source
 
     - name: Report Checkout
       run: |
-        echo "Git SHA1: $(git -C source rev-parse ${{ inputs.ref }})"
+        echo "Git SHA1: $(git -C source rev-parse ${{ env.REF }})"
         echo "Git Commit: $(git -C source log -n1 --oneline)"
 
     - name: Setup VillageSQL build environment
@@ -75,22 +87,20 @@ jobs:
 
     - name: Build VillageSQL
       working-directory: ./source
-      env:
-        BUILD_TYPE: ${{ inputs.build-type }}
       run: |
         ./villagesql/bld_tools/build_ci.sh
 
     - name: Run standard tests (unit, integration with only suite village)
       uses: ./source/.github/actions/run-tests
       with:
-        artifact-name: ${{ inputs.artifact-prefix }}-logs-${{ github.run_number }}
+        artifact-name: ${{ env.ARTIFACT_PREFIX }}-logs-${{ github.run_number }}
 
     - name: Run big tests
       uses: ./source/.github/actions/run-tests
       with:
         run-unit-tests: false
         run-big-tests: true
-        artifact-name: ${{ inputs.artifact-prefix }}-big-test-logs-${{ github.run_number }}
+        artifact-name: ${{ env.ARTIFACT_PREFIX }}-big-test-logs-${{ github.run_number }}
 
     - name: Run all test suites (excluding VillageSQL)
       uses: ./source/.github/actions/run-tests
@@ -98,4 +108,4 @@ jobs:
         run-unit-tests: false
         run-all-suites: true
         skip-suite: village
-        artifact-name: ${{ inputs.artifact-prefix }}-all-suites-logs-${{ github.run_number }}
+        artifact-name: ${{ env.ARTIFACT_PREFIX }}-all-suites-logs-${{ github.run_number }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -72,14 +72,3 @@ jobs:
         # Update/create nightly.latest tag (force update if exists)
         git tag -fa "nightly.latest" -m "Latest nightly build $(date +'%Y-%m-%d %H:%M:%S UTC')"
         git push origin "nightly.latest" --force
-
-  post-tag-full-test:
-    name: Post Nightly Tag Build and Test
-    needs: test-and-tag
-    permissions:
-      contents: read
-    uses: ./.github/workflows/full-test-suite.yml
-    with:
-      ref: ${{ needs.test-and-tag.outputs.tag }}
-      build-type: release
-      artifact-prefix: nightly-tag-${{ needs.test-and-tag.outputs.tag }}


### PR DESCRIPTION
## Description

Change the control mechanism for automatic execution to github's  workflow_run trigger.

Since a nightly run of Full Test Suite is interesting whether Nightly succeeded or not, there are no conditions on Nightly's status. 

## Related Issue

Part of the [Server]: Overhaul CI #819 effort.