### PR TITLE
reject duplicate index profile

### DIFF
--- a/mysql-test/include/villagesql/create_extension_sdk.inc
+++ b/mysql-test/include/villagesql/create_extension_sdk.inc
@@ -16,6 +16,10 @@
 #     When set, copies to {name}-{version}.veb instead of {name}.veb.
 #     Use this when the test needs versioned VEB files on disk (e.g. for
 #     INSTALL EXTENSION foo VERSION 'x.y.z').
+#   --let $extension_common_header = /path/to/common.h
+#     Companion header(s) copied next to extension.cc so the source can
+#     #include them. May name several headers separated by spaces, e.g.
+#     --let $extension_common_header = /path/a.h /path/b.h
 #
 # The VEB file will be created and moved to the VEB directory.
 #
@@ -61,9 +65,9 @@ if (!$extension_version)
 # Copy source file
 --exec cp $extension_source $ext_build_dir/src/extension.cc
 
-# Optionally place a shared companion header next to extension.cc so the source
-# can #include it. Gated on $extension_common_header, so other consumers of this
-# include (which never set it) are unaffected.
+# Optionally place shared companion header(s) next to extension.cc so the source
+# can #include them. Gated on $extension_common_header, so other consumers of
+# this include (which never set it) are unaffected.
 if ($extension_common_header)
 {
   --exec cp $extension_common_header $ext_build_dir/src/

--- a/mysql-test/include/villagesql/create_extension_sdk_expect_build_failure.inc
+++ b/mysql-test/include/villagesql/create_extension_sdk_expect_build_failure.inc
@@ -9,6 +9,11 @@
 #   --let $build_failure_grep = optional string to grep for in build output
 #   --source include/villagesql/create_extension_sdk_expect_build_failure.inc
 #
+# Optional:
+#   --let $extension_common_header = /path/to/common.h
+#     Companion header(s) copied next to extension.cc so the source can
+#     #include them. May name several headers separated by spaces.
+#
 # If $build_failure_grep is set, the test also verifies that the build output
 # contains the expected string (e.g. a static_assert message).
 
@@ -43,8 +48,8 @@ if (!$extension_version)
 
 --exec cp $extension_source $ext_build_dir/src/extension.cc
 
-# Optionally place a shared companion header next to extension.cc so the source
-# can #include it.
+# Optionally place shared companion header(s) next to extension.cc so the source
+# can #include them.
 if ($extension_common_header)
 {
   --exec cp $extension_common_header $ext_build_dir/src/

--- a/mysql-test/suite/villagesql/extension/r/extension_duplicate_index_profile.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_duplicate_index_profile.result
@@ -1,0 +1,14 @@
+call mtr.add_suppression("Failed to load VEF extension");
+call mtr.add_suppression("already exists");
+SET PERSIST vsql_allow_preview_extensions = ON;
+Creating extension dup_index_profile using SDK...
+Created dup_index_profile.veb
+# INSTALL fails: duplicate index-profile name within one extension.
+INSTALL EXTENSION dup_index_profile;
+ERROR HY000: Failed to install extension 'dup_index_profile': index profile 'DUP_PROFILE' already exists
+# Verify extension was NOT installed.
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS
+WHERE extension_name = 'dup_index_profile';
+EXTENSION_NAME	EXTENSION_VERSION
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/mysql-test/suite/villagesql/extension/r/extension_duplicate_index_type.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_duplicate_index_type.result
@@ -1,0 +1,14 @@
+call mtr.add_suppression("Failed to load VEF extension");
+call mtr.add_suppression("already exists");
+SET PERSIST vsql_allow_preview_extensions = ON;
+Creating extension dup_index_type using SDK...
+Created dup_index_type.veb
+# INSTALL fails: duplicate index-type name within one extension.
+INSTALL EXTENSION dup_index_type;
+ERROR HY000: Failed to install extension 'dup_index_type': index type 'DUP_INDEX' already exists
+# Verify extension was NOT installed.
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS
+WHERE extension_name = 'dup_index_type';
+EXTENSION_NAME	EXTENSION_VERSION
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/mysql-test/suite/villagesql/extension/t/extension_duplicate_index_profile.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_duplicate_index_profile.test
@@ -1,0 +1,26 @@
+# Scenario: an extension that registers two index profiles with the same name
+# must be rejected at INSTALL EXTENSION time. The extension
+# (std_data/dup_index_profile.cc) registers one type and one index type, then
+# DUP_PROFILE twice; it is built on the fly and installed here. Index profiles
+# are a preview capability, so preview extensions must be allowed first.
+
+call mtr.add_suppression("Failed to load VEF extension");
+call mtr.add_suppression("already exists");
+
+SET PERSIST vsql_allow_preview_extensions = ON;
+
+--let $extension_name = dup_index_profile
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/dup_index_profile.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/index_build_common.h $MYSQL_TEST_DIR/suite/villagesql/std_data/type_build_common.h
+--source include/villagesql/create_extension_sdk.inc
+
+--echo # INSTALL fails: duplicate index-profile name within one extension.
+--error ER_VILLAGESQL_GENERIC_ERROR
+INSTALL EXTENSION dup_index_profile;
+
+--echo # Verify extension was NOT installed.
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS
+WHERE extension_name = 'dup_index_profile';
+
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/mysql-test/suite/villagesql/extension/t/extension_duplicate_index_type.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_duplicate_index_type.test
@@ -1,0 +1,26 @@
+# Scenario: an extension that registers two index types with the same name must
+# be rejected at INSTALL EXTENSION time. The extension
+# (std_data/dup_index_type.cc) registers DUP_INDEX twice; it is built on the fly
+# and installed here. Index types are a preview capability, so preview
+# extensions must be allowed first.
+
+call mtr.add_suppression("Failed to load VEF extension");
+call mtr.add_suppression("already exists");
+
+SET PERSIST vsql_allow_preview_extensions = ON;
+
+--let $extension_name = dup_index_type
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/dup_index_type.cc
+--let $extension_common_header = $MYSQL_TEST_DIR/suite/villagesql/std_data/index_build_common.h
+--source include/villagesql/create_extension_sdk.inc
+
+--echo # INSTALL fails: duplicate index-type name within one extension.
+--error ER_VILLAGESQL_GENERIC_ERROR
+INSTALL EXTENSION dup_index_type;
+
+--echo # Verify extension was NOT installed.
+SELECT extension_name, extension_version FROM INFORMATION_SCHEMA.EXTENSIONS
+WHERE extension_name = 'dup_index_type';
+
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/mysql-test/suite/villagesql/std_data/dup_index_profile.cc
+++ b/mysql-test/suite/villagesql/std_data/dup_index_profile.cc
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Bad-registration test: an extension that registers two index profiles with
+// the SAME name ("DUP_PROFILE"). Both profiles reference one real type and one
+// real index type so profile-reference validation passes and registration
+// reaches the duplicate-profile check, which must reject the extension at
+// INSTALL EXTENSION time. The index hooks and the type ops are shared no-op
+// stubs -- registration fails before any of them is ever called.
+
+#include "index_build_common.h"
+#include "type_build_common.h"
+
+using namespace vsql::preview_index_builder;
+
+static constexpr const char kDupType[] = "DUP_PROFILE_TYPE";
+static constexpr const char kDupIndex[] = "DUP_PROFILE_INDEX";
+
+// Custom type referenced by the profiles (uses shared stub type-ops).
+constexpr auto DUP_TYPE = vsql::make_type<kDupType>()
+                              .persisted_length(8)
+                              .max_decode_buffer_length(8)
+                              .from_string<&tbc::stub_encode>()
+                              .to_string<&tbc::stub_decode>()
+                              .compare<&tbc::stub_compare>()
+                              .build();
+
+// One index type referenced by the profiles.
+// clang-format off
+static constexpr auto DUP_INDEX =
+    make_index_type<kDupIndex, ibc::DupCtx>()
+        .lifecycle()
+            .create<&ibc::dup_create>()
+            .load<&ibc::dup_load>()
+            .drop<&ibc::dup_drop>()
+        .dml()
+            .insert<&ibc::dup_insert>()
+            .mark_delete<&ibc::dup_mark_delete>()
+            .purge<&ibc::dup_purge>()
+        .scan()
+            .begin<&ibc::dup_begin>()
+            .position<&ibc::dup_position>()
+            .fetch<&ibc::dup_fetch>()
+            .save<&ibc::dup_save>()
+            .restore<&ibc::dup_restore>()
+            .end<&ibc::dup_end>()
+        .global()
+            .capabilities(Index::Support::KNN)
+            .storage_props(Index::Storage::HAS_COLUMN_REF | Index::Storage::REF_LOOKUP)
+        .build();
+// clang-format on
+
+// Two index profiles with the SAME name, both referencing the type + index
+// type above.
+static constexpr const char kDupProfile[] = "DUP_PROFILE";
+
+static const auto DUP_PROFILE_1 = make_index_profile(kDupProfile)
+                                      .for_type(kDupType)
+                                      .using_index(kDupIndex)
+                                      .build();
+static const auto DUP_PROFILE_2 = make_index_profile(kDupProfile)
+                                      .for_type(kDupType)
+                                      .using_index(kDupIndex)
+                                      .build();
+
+static auto INDEX_TYPE = IndexTypeCapability().index_type(DUP_INDEX);
+static auto INDEX_PROFILE = IndexProfileCapability()
+                                .index_profile(DUP_PROFILE_1)
+                                .index_profile(DUP_PROFILE_2);
+
+VEF_GENERATE_ENTRY_POINTS(
+    vsql::make_extension().with(INDEX_TYPE).with(INDEX_PROFILE).type(DUP_TYPE))

--- a/mysql-test/suite/villagesql/std_data/dup_index_type.cc
+++ b/mysql-test/suite/villagesql/std_data/dup_index_type.cc
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Bad-registration test: an extension that registers two index types with the
+// SAME name ("DUP_INDEX"). Registration must reject the extension at INSTALL
+// EXTENSION time. The hooks are shared no-op stubs -- registration fails on the
+// duplicate before any of them is ever called.
+
+#include "index_build_common.h"
+
+using namespace vsql::preview_index_builder;
+
+// Two index types with the SAME name. Written as two explicit chains (not a
+// template helper) so the builder's dependent template methods resolve without
+// a `.template` qualifier.
+static constexpr const char kDupIndex1[] = "DUP_INDEX";
+static constexpr const char kDupIndex2[] = "DUP_INDEX";
+
+// clang-format off
+static constexpr auto DUP_INDEX_1 =
+    make_index_type<kDupIndex1, ibc::DupCtx>()
+        .lifecycle()
+            .create<&ibc::dup_create>()
+            .load<&ibc::dup_load>()
+            .drop<&ibc::dup_drop>()
+        .dml()
+            .insert<&ibc::dup_insert>()
+            .mark_delete<&ibc::dup_mark_delete>()
+            .purge<&ibc::dup_purge>()
+        .scan()
+            .begin<&ibc::dup_begin>()
+            .position<&ibc::dup_position>()
+            .fetch<&ibc::dup_fetch>()
+            .save<&ibc::dup_save>()
+            .restore<&ibc::dup_restore>()
+            .end<&ibc::dup_end>()
+        .global()
+            .capabilities(Index::Support::KNN)
+            .storage_props(Index::Storage::HAS_COLUMN_REF | Index::Storage::REF_LOOKUP)
+        .build();
+
+static constexpr auto DUP_INDEX_2 =
+    make_index_type<kDupIndex2, ibc::DupCtx>()
+        .lifecycle()
+            .create<&ibc::dup_create>()
+            .load<&ibc::dup_load>()
+            .drop<&ibc::dup_drop>()
+        .dml()
+            .insert<&ibc::dup_insert>()
+            .mark_delete<&ibc::dup_mark_delete>()
+            .purge<&ibc::dup_purge>()
+        .scan()
+            .begin<&ibc::dup_begin>()
+            .position<&ibc::dup_position>()
+            .fetch<&ibc::dup_fetch>()
+            .save<&ibc::dup_save>()
+            .restore<&ibc::dup_restore>()
+            .end<&ibc::dup_end>()
+        .global()
+            .capabilities(Index::Support::KNN)
+            .storage_props(Index::Storage::HAS_COLUMN_REF | Index::Storage::REF_LOOKUP)
+        .build();
+// clang-format on
+
+static auto INDEX_TYPE =
+    IndexTypeCapability().index_type(DUP_INDEX_1).index_type(DUP_INDEX_2);
+
+VEF_GENERATE_ENTRY_POINTS(vsql::make_extension().with(INDEX_TYPE))

--- a/mysql-test/suite/villagesql/std_data/index_build_common.h
+++ b/mysql-test/suite/villagesql/std_data/index_build_common.h
@@ -1,0 +1,136 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// Shared no-op index hooks for the bad-registration test extensions. Those
+// tests are rejected during registration, before any hook is ever called, so
+// the bodies are irrelevant to what is under test and are defined once here.
+//
+// The `make_index_type<>` chains stay in the individual extension sources: the
+// builder's chained methods return dependent types, so wrapping a chain in a
+// function template would require a `.template` qualifier on every step.
+
+#ifndef VILLAGESQL_TEST_STD_DATA_INDEX_BUILD_COMMON_H
+#define VILLAGESQL_TEST_STD_DATA_INDEX_BUILD_COMMON_H
+
+#include <villagesql/preview/index_builder.h>
+#include <villagesql/vsql.h>
+
+#include <cstdint>
+
+namespace ibc {
+
+using vsql::preview_index_builder::Index;
+using vsql::preview_index_builder::IndexScanDesc;
+using vsql::preview_index_builder::IndexScanKey;
+
+using vsql::preview_storage::MtrCtx;
+using vsql::preview_storage::Segment;
+using vsql::preview_storage::Space;
+
+struct DupCtx {};
+using Ctx = Index::StorageCtx<DupCtx>;
+struct DupCursor {};
+
+// ---- Lifecycle stubs ----
+inline bool dup_create(Ctx * /*ctx*/, const Index & /*index*/,
+                       Space::Ref /*space_ref*/, Segment::TrxRef /*trx_ref*/,
+                       char * /*err*/, uint32_t /*err_len*/) {
+  return false;
+}
+
+inline bool dup_drop(Ctx * /*ctx*/, const Index & /*index*/,
+                     Segment::TrxRef /*trx_ref*/, char * /*err*/,
+                     uint32_t /*err_len*/) {
+  return false;
+}
+
+inline bool dup_load(Ctx * /*ctx*/, const Index & /*index*/,
+                     Index::StorageRef /*storage_ref*/, char * /*err*/,
+                     uint32_t /*err_len*/) {
+  return false;
+}
+
+// ---- DML stubs ----
+inline bool dup_insert(Ctx * /*ctx*/, const Index & /*index*/,
+                       Segment::TrxRef /*trx_ref*/,
+                       IndexScanKey::KeyPartData * /*key_columns*/,
+                       IndexScanKey::KeyPartData * /*pkey_columns*/,
+                       IndexScanKey::KeyPartRef * /*key_ref*/, char * /*err*/,
+                       uint32_t /*err_len*/) {
+  return false;
+}
+
+inline bool dup_mark_delete(Ctx * /*ctx*/, const Index & /*index*/,
+                            Segment::TrxRef /*trx_ref*/,
+                            IndexScanKey::KeyPartRef * /*key_ref*/,
+                            IndexScanKey::KeyPartData * /*key_columns*/,
+                            IndexScanKey::KeyPartData * /*pkey_columns*/,
+                            bool /*delete_mark*/, char * /*err*/,
+                            uint32_t /*err_len*/) {
+  return false;
+}
+
+inline bool dup_purge(Ctx * /*ctx*/, const Index & /*index*/,
+                      Segment::TrxRef /*trx_ref*/,
+                      IndexScanKey::KeyPartRef * /*key_ref*/,
+                      IndexScanKey::KeyPartData * /*key_columns*/,
+                      IndexScanKey::KeyPartData * /*pkey_columns*/,
+                      char * /*err*/, uint32_t /*err_len*/) {
+  return false;
+}
+
+// ---- Scan stubs ----
+inline bool dup_begin(Ctx * /*ctx*/, const Index & /*index*/,
+                      MtrCtx::Ref /*mctx*/, const IndexScanDesc & /*scan_desc*/,
+                      Index::Cursor *cursor, bool *eof, char * /*err*/,
+                      uint32_t /*err_len*/) {
+  *cursor = new DupCursor{};
+  *eof = true;
+  return false;
+}
+
+inline bool dup_position(Index::Cursor /*cursor*/, Index::CursorOp /*op*/,
+                         bool *eof, char * /*err*/, uint32_t /*err_len*/) {
+  *eof = true;
+  return false;
+}
+
+inline bool dup_fetch(Index::Cursor /*cursor*/,
+                      IndexScanKey::KeyPartRef * /*key_ref*/,
+                      IndexScanKey::KeyPartData * /*key_columns*/,
+                      IndexScanKey::KeyPartData * /*pkey_columns*/,
+                      char * /*err*/, uint32_t /*err_len*/) {
+  return false;
+}
+
+inline bool dup_save(Index::Cursor /*cursor*/, char * /*err*/,
+                     uint32_t /*err_len*/) {
+  return false;
+}
+
+inline bool dup_restore(Index::Cursor /*cursor*/, MtrCtx::Ref /*mctx*/,
+                        bool *eof, char * /*err*/, uint32_t /*err_len*/) {
+  *eof = true;
+  return false;
+}
+
+inline void dup_end(Index::Cursor *cursor) {
+  delete static_cast<DupCursor *>(*cursor);
+  *cursor = nullptr;
+}
+
+}  // namespace ibc
+
+#endif  // VILLAGESQL_TEST_STD_DATA_INDEX_BUILD_COMMON_H

--- a/villagesql/veb/register.cc
+++ b/villagesql/veb/register.cc
@@ -231,6 +231,12 @@ bool register_preview_capabilities(THD &thd,
             index_type_name.c_str());
   }
 
+  // Detects an index profile registered more than once within this same
+  // extension batch. get_committed() below only sees already-committed
+  // descriptors, not the ones marked for insertion earlier in this loop, so a
+  // same-named duplicate inside one extension would otherwise slip through.
+  std::set<IndexProfileDescriptorKey> seen_index_profile_keys;
+
   for (auto &descriptor : preview.index_profiles) {
     std::string profile_name = descriptor.profile_name();
     std::string ext_name = descriptor.extension_name();
@@ -238,6 +244,13 @@ bool register_preview_capabilities(THD &thd,
     LogVSQL(INFORMATION_LEVEL,
             "Registering index profile '%s' from extension '%s'",
             profile_name.c_str(), ext_name.c_str());
+
+    if (!seen_index_profile_keys.insert(descriptor.key()).second) {
+      error_out = "index profile '" + profile_name + "' already exists";
+      LogVSQL(ERROR_LEVEL, "Extension '%s': %s", ext_name.c_str(),
+              error_out.c_str());
+      return true;
+    }
 
     const IndexProfileDescriptor *existing =
         victionary.index_profile_descriptors().get_committed(descriptor.key());

--- a/villagesql/veb/register.cc
+++ b/villagesql/veb/register.cc
@@ -189,6 +189,12 @@ bool register_preview_capabilities(THD &thd,
     }
   }
 
+  // Detects an index type registered more than once within this same extension
+  // batch. get_committed() below only sees already-committed descriptors, not
+  // the ones marked for insertion earlier in this loop, so a same-named
+  // duplicate inside one extension would otherwise slip through.
+  std::set<IndexTypeDescriptorKey> seen_index_type_keys;
+
   for (auto &descriptor : preview.index_types) {
     std::string index_type_name = descriptor.index_type_name();
     std::string ext_name = descriptor.extension_name();
@@ -196,6 +202,13 @@ bool register_preview_capabilities(THD &thd,
     LogVSQL(INFORMATION_LEVEL,
             "Registering index type '%s' from extension '%s'",
             index_type_name.c_str(), ext_name.c_str());
+
+    if (!seen_index_type_keys.insert(descriptor.key()).second) {
+      error_out = "index type '" + index_type_name + "' already exists";
+      LogVSQL(ERROR_LEVEL, "Extension '%s': %s", ext_name.c_str(),
+              error_out.c_str());
+      return true;
+    }
 
     const IndexTypeDescriptor *existing =
         victionary.index_type_descriptors().get_committed(descriptor.key());


### PR DESCRIPTION
Guard the index-profile loop with an in-batch
std::set<IndexProfileDescriptorKey> of seen keys.

Closes #845 