### PR TITLE
Correct sanitizer result paths

### DIFF
--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -178,11 +178,14 @@ jobs:
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: sanitizer-ext-mtr-logs-${{ github.run_number }}
-        # Under --parallel each worker writes its mysqld.N.err to var/<N>/log/.
+        # test_extension_vebs.sh with MTR_BINDIR=$BUILD_DIR puts output into
+        # $BUILD_DIR/mysql-test/var (not the source # tree). Under --parallel
+        # each worker writes its mysqld.N.err to var/<N>/log/.
         path: |
-          ${{ env.SOURCE_DIR }}/mysql-test/var/log/
-          ${{ env.SOURCE_DIR }}/mysql-test/var/*/log/
-        if-no-files-found: ignore
+          ${{ env.BUILD_DIR }}/mysql-test/var/log/
+          ${{ env.BUILD_DIR }}/mysql-test/var/*/log/
+        if-no-files-found: warn
+        retention-days: 7
 
     - name: Fail if any sanitizer phase failed
       if: always()

--- a/villagesql/bld_tools/test_extension_vebs.sh
+++ b/villagesql/bld_tools/test_extension_vebs.sh
@@ -87,7 +87,9 @@ fi
 log_info "MTR flags: ${MTR_FLAGS[*]}"
 
 # MTR must be invoked from its own directory; MTR_BINDIR tells it where to
-# find the built mysqld and client binaries.
+# find the built mysqld and client binaries. Setting MTR_BINDIR also relocates
+# MTR's default vardir to $BUILD_DIR/mysql-test/var instead of the source tree,
+# so the CI steps that upload logs on failure glob that path.
 #
 # --force: continue past individual test failures so all suites are exercised
 # and all failures are visible in one run.


### PR DESCRIPTION
## Description

Upload sanitizer test results from the correct location.

## Related Issue

Part of the [Server]: Sanitizer cleanliness #822 effort 

<!-- Link the GitHub issue this PR addresses, e.g. Fixes #123 -->

Workflow executed from development branch.