### PR TITLE
Update tests auth tests

### DIFF
--- a/mysql-test/r/mysql_native_password.result
+++ b/mysql-test/r/mysql_native_password.result
@@ -15,5 +15,5 @@ CREATE USER regular_user;
 ALTER USER regular_user IDENTIFIED WITH mysql_native_password BY 'abcd';
 ERROR HY000: Plugin 'mysql_native_password' is not loaded
 connect(localhost,native_password_user,abcd,test,MYSQL_PORT,MYSQL_SOCK);
-ERROR HY000: Plugin 'mysql_native_password' is not loaded
+ERROR HY000: authentication method 'mysql_native_password' is not available (no such plugin or extension auth method)
 DROP USER native_password_user, regular_user;

--- a/mysql-test/r/plugin_auth_qa_1.result
+++ b/mysql-test/r/plugin_auth_qa_1.result
@@ -88,7 +88,7 @@ user	plugin
 new_user	new_plugin_server
 plug_dest	caching_sha2_password
 connect(plug_user,localhost,new_user,new_dest);
-ERROR HY000: Plugin 'new_plugin_server' is not loaded
+ERROR HY000: authentication method 'new_plugin_server' is not available (no such plugin or extension auth method)
 UPDATE mysql.user SET plugin='test_plugin_server' WHERE user='new_user';
 UPDATE mysql.user SET USER='new_dest' WHERE user='plug_dest';
 FLUSH PRIVILEGES;

--- a/mysql-test/t/mysql_native_password.test
+++ b/mysql-test/t/mysql_native_password.test
@@ -26,7 +26,7 @@ CREATE USER regular_user;
 ALTER USER regular_user IDENTIFIED WITH mysql_native_password BY 'abcd';
 
 --replace_result $MASTER_MYPORT MYSQL_PORT $MASTER_MYSOCK MYSQL_SOCK
---error ER_PLUGIN_IS_NOT_LOADED
+--error ER_VILLAGESQL_GENERIC_ERROR
 --connect(con_1, localhost, native_password_user, abcd,,,,)
 
 --error 1

--- a/mysql-test/t/plugin_auth_qa_1.test
+++ b/mysql-test/t/plugin_auth_qa_1.test
@@ -82,7 +82,7 @@ FLUSH PRIVILEGES;
 --source include/plugin_auth_check_non_default_users.inc
 --echo connect(plug_user,localhost,new_user,new_dest);
 --disable_query_log
---error ER_PLUGIN_IS_NOT_LOADED
+--error ER_VILLAGESQL_GENERIC_ERROR
 connect(plug_user,localhost,new_user,new_dest);
 --enable_query_log
 UPDATE mysql.user SET plugin='test_plugin_server' WHERE user='new_user';


### PR DESCRIPTION
## Description

Fixes the failing mysql_native_password to use the latest error code and response text.

## Related Issues

- Part of the [Server]: Overhaul CI #819 effort.
- Part of the Notify #eng-health when nightly build and test fails #771 effort.
- May involve [VEF Hook]: Expose authentication plugin interface through VEF ABI #639

## How was this tested?

Local test runs