### PR TITLE
Extension admin at bootstrap

### DIFF
--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -8560,6 +8560,14 @@ static int init_server_components() {
              "default_tmp_storage_engine", default_tmp_storage_engine);
   }
 
+  // Register the VillageSQL dynamic privileges. Unlike the infrastructure
+  // initialization below, this must also happen under --initialize, before the
+  // bootstrap SQL runs, so that the GRANT ALL PRIVILEGES it issues for root
+  // covers them.
+  if (villagesql::register_extension_privileges()) {
+    unireg_abort(MYSQLD_ABORT_EXIT);
+  }
+
   // Initialize the VillageSQL extension infrastructure. Custom data types
   // provided by extensions must be available before rolling back uncommitted
   // recovered transactions in ha_post_recover().

--- a/villagesql/sql/initialize.cc
+++ b/villagesql/sql/initialize.cc
@@ -262,6 +262,32 @@ static bool do_init_extension_infrastructure(THD *thd) {
 }  // namespace
 
 /**
+  Registers the VillageSQL dynamic privileges.
+
+  Runs unconditionally, including under --initialize: the bootstrap SQL grants
+  root all privileges. If a privilege is missing from the register during
+  bootstrap, root never gets it leaving root without a privilege that every
+  runtime GRANT ALL confers.
+
+  @return Status of performed operation
+  @retval false success
+  @retval true failure
+*/
+bool register_extension_privileges() {
+  // The EXTENSION_ADMIN dynamic privilege guards the extension DDL
+  // (INSTALL/UNINSTALL/ALTER EXTENSION).
+  my_service<SERVICE_TYPE(dynamic_privilege_register)> priv_service(
+      "dynamic_privilege_register.mysql_server", srv_registry);
+  if (!priv_service.is_valid() ||
+      priv_service->register_privilege(STRING_WITH_LEN("EXTENSION_ADMIN"))) {
+    LogVSQL(ERROR_LEVEL, "Failed to register EXTENSION_ADMIN privilege");
+    return true;
+  }
+
+  return false;
+}
+
+/**
   For now, this just initializes villagesql system tables.
 
   @return Status of performed operation
@@ -270,19 +296,6 @@ static bool do_init_extension_infrastructure(THD *thd) {
 */
 bool init_extension_infrastructure() {
   sysd::notify("STATUS=VillageSQL initialization in progress\n");
-
-  // Register the EXTENSION_ADMIN dynamic privilege that guards the extension
-  // DDL (INSTALL/UNINSTALL/ALTER EXTENSION).
-  {
-    my_service<SERVICE_TYPE(dynamic_privilege_register)> priv_service(
-        "dynamic_privilege_register.mysql_server", srv_registry);
-    if (!priv_service.is_valid() ||
-        priv_service->register_privilege(STRING_WITH_LEN("EXTENSION_ADMIN"))) {
-      LogVSQL(ERROR_LEVEL, "Failed to register EXTENSION_ADMIN privilege");
-      sysd::notify("STATUS=VillageSQL initialization unsuccessful\n");
-      return true;
-    }
-  }
 
   villagesql::services::register_builtin_capabilities();
 

--- a/villagesql/sql/initialize.h
+++ b/villagesql/sql/initialize.h
@@ -20,6 +20,11 @@
 
 namespace villagesql {
 
+// Register the VillageSQL dynamic privileges (EXTENSION_ADMIN). Must be called
+// on every startup path, --initialize included, so that the bootstrap
+// GRANT ALL PRIVILEGES for root covers them. See the comment on the definition.
+bool register_extension_privileges();
+
 // Initialize the villagesql extension framework.
 bool init_extension_infrastructure();
 


### PR DESCRIPTION
## Description

Defines the extension admin permission at bootstrap, so the root will have it. 

Content by AI.

## Related Issue

Part of the Notify #eng-health when nightly build and test fails #771 effort.

## How was this tested?

ran by hand locally

funcs_1.innodb_trig_03e
funcs_1.memory_trig_03e
funcs_1.myisam_trig_03e
main.grant
main.roles
