### PR TITLE
testing: nightly for rust extensions

### DIFF
--- a/.github/workflows/extension-compat-suite.yml
+++ b/.github/workflows/extension-compat-suite.yml
@@ -175,10 +175,12 @@ jobs:
           else
             echo "EXT_ROOT=extension" >> "$GITHUB_ENV"
           fi
+
       - name: Set up Rust toolchain
         if: matrix.build == 'cargo'
         uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
 
+      # TODO(villagesql-rust): build the HEAD version of the SDK from the repo.
       - name: Install cargo-vsql
         if: matrix.build == 'cargo'
         run: cargo install --path extension/cargo-vsql --locked

--- a/.github/workflows/extension-compat-suite.yml
+++ b/.github/workflows/extension-compat-suite.yml
@@ -137,6 +137,7 @@ jobs:
           path: artifacts/
 
       - name: Download SDK
+        if: matrix.build != 'cargo'
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sdk-${{ matrix.platform }}
@@ -146,9 +147,11 @@ jobs:
         run: |
           mkdir -p package sdk
           tar xzf artifacts/villagesql-dev-server-*.tar.gz -C package
-          tar xzf artifacts/villagesql-extension-sdk-*.tar.gz -C sdk
           echo "PACKAGE_DIR=$(echo "$PWD"/package/villagesql-dev-server-*)" >> "$GITHUB_ENV"
-          echo "SDK_DIR=$(echo "$PWD"/sdk/villagesql-extension-sdk-*)" >> "$GITHUB_ENV"
+          if [ "${{ matrix.build }}" != "cargo" ]; then
+            tar xzf artifacts/villagesql-extension-sdk-*.tar.gz -C sdk
+            echo "SDK_DIR=$(echo "$PWD"/sdk/villagesql-extension-sdk-*)" >> "$GITHUB_ENV"
+          fi
 
       - name: Install build dependencies (Linux)
         if: matrix.os == 'linux'
@@ -165,37 +168,55 @@ jobs:
           CLONE_ARGS=(--depth=1)
           [[ -n "${{ matrix.branch }}" ]] && CLONE_ARGS+=(--branch "${{ matrix.branch }}")
           git clone "${CLONE_ARGS[@]}" ${{ matrix.url }} extension/
+          # Extension root within the clone. Rust examples live in a subdir;
+          # C++ extensions are at the root.
+          if [ -n "${{ matrix.path }}" ]; then
+            echo "EXT_ROOT=extension/${{ matrix.path }}" >> "$GITHUB_ENV"
+          else
+            echo "EXT_ROOT=extension" >> "$GITHUB_ENV"
+          fi
+      - name: Set up Rust toolchain
+        if: matrix.build == 'cargo'
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+
+      - name: Install cargo-vsql
+        if: matrix.build == 'cargo'
+        run: cargo install --path extension/cargo-vsql --locked
 
       - name: Build extension VEB
         id: build_ext
         run: |
           NCORES=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo "4")
-          DEV_ABI_FLAG=""
-          [ "${{ matrix.abi }}" = "dev" ] && DEV_ABI_FLAG="-DVSQL_USE_DEV_ABI=ON"
-          cmake -S extension/ -B ext-build/ \
-            -DVillageSQL_SDK_DIR="$SDK_DIR" \
-            -DCMAKE_BUILD_TYPE=Release \
-            $DEV_ABI_FLAG
-          cmake --build ext-build/ --parallel "$NCORES"
-
-          # Copy the built VEB into the dev server's extension directory
-          find ext-build/ -maxdepth 1 -name "*.veb" \
-            -exec cp {} "$PACKAGE_DIR/lib/veb/" \;
+          if [ "${{ matrix.build }}" = "cargo" ]; then
+            ( cd "$EXT_ROOT" && cargo vsql package )
+            cp "extension/dist/${{ matrix.extension }}.veb" "$PACKAGE_DIR/lib/veb/"
+          else
+            DEV_ABI_FLAG=""
+            [ "${{ matrix.abi }}" = "dev" ] && DEV_ABI_FLAG="-DVSQL_USE_DEV_ABI=ON"
+            cmake -S "$EXT_ROOT"/ -B ext-build/ \
+              -DVillageSQL_SDK_DIR="$SDK_DIR" \
+              -DCMAKE_BUILD_TYPE=Release \
+              $DEV_ABI_FLAG
+            cmake --build ext-build/ --parallel "$NCORES"
+            # Copy the built VEB into the dev server's extension directory
+            find ext-build/ -maxdepth 1 -name "*.veb" \
+              -exec cp {} "$PACKAGE_DIR/lib/veb/" \;
+          fi
 
       - name: Install extension test suite
         run: |
-          if [ ! -d "extension/mysql-test" ]; then
+          if [ ! -d "$EXT_ROOT/mysql-test" ]; then
             echo "No mysql-test/ directory in ${{ matrix.extension }} — skipping suite install"
             exit 0
           fi
           SUITE_DIR="$PACKAGE_DIR/mysql-test/suite/${{ matrix.extension }}"
           mkdir -p "$SUITE_DIR"
-          cp -r extension/mysql-test/. "$SUITE_DIR/"
+          cp -r "$EXT_ROOT/mysql-test"/. "$SUITE_DIR/"
 
       - name: Run MTR suite
         id: run_mtr
         run: |
-          if [ ! -d "extension/mysql-test" ]; then
+          if [ ! -d "$EXT_ROOT/mysql-test" ]; then
             echo "Error: no mysql-test/ directory found in ${{ matrix.extension }}"
             exit 1
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -220,6 +220,7 @@ When adding VillageSQL features:
     - `TODO(villagesql-windows):` - Known problems with supporting Windows
     - `TODO(villagesql-indexing):` - Related to indexing work
     - `TODO(villagesql-back-to-mysql):` - Required for downgrade safety / vanilla MySQL compatibility
+    - `TODO(villagesql-rust):` - Related to the Rust SDK / Rust extension support
 - Avoid `/* */` style comments except for copyright headers
 - Do NOT use section separator comments (e.g., `// ===== Serialization =====`) - they're hard to maintain and add little value
 - Do NOT add explanatory comments on #include lines (e.g., `#include "my_sys.h" // my_ok, my_printf_error`) - they're hard to maintain

--- a/scripts/villagesql_build-compat-matrix.sh
+++ b/scripts/villagesql_build-compat-matrix.sh
@@ -10,6 +10,7 @@
 #   1. build-matrix  — platforms for the build-server job (no abi dimension;
 #                      the server binary is ABI-agnostic)
 #   2. test-matrix   — full (platform, extension, abi) triples for test-extension
+#                      it also carries the extension's build tool and path.
 #
 # Inputs (environment variables, all optional):
 #   PLATFORM_FILTER   — limit to a single platform  (e.g. linux-x86_64)
@@ -34,10 +35,17 @@ EXTS_JSON=$(grep -v '^[[:space:]]*#\|^[[:space:]]*$' "$EXTENSIONS_FILE" \
   | jq -R '
       split(" ") |
       . as $f |
+      ($f[2:] | map(select(startswith("build=")) | ltrimstr("build=")) | .[0] //
+      "cmake") as $build |
+      ($f[2:] | map(select(startswith("path=")) | ltrimstr("path=")) | .[0] // "")
+          as $path |
       {
         url:       ($f[0] | rtrimstr("/")),
         branch:    ($f[1] // ""),
-        extension: ($f[0] | rtrimstr("/") | split("/") | last),
+        build:     $build,
+        path:      $path,
+        extension: (if $path != "" then ($path | split("/") | last)
+                    else ($f[0] | rtrimstr("/") | split("/") | last) end),
         abis:      (($f[2:] | map(select(startswith("abi=")) | ltrimstr("abi=")) | .[0]) as $a |
                    if $a then [$a] else ["stable","dev"] end)
       }' \
@@ -96,7 +104,7 @@ TEST_MATRIX=$(jq -cn \
     $platforms[] as $p |
     $extensions[] as $e |
     ($e.abis | if $abi_filter != "" then map(select(. == $abi_filter)) else . end)[] as $a |
-    ($p + {url: $e.url, branch: $e.branch, extension: $e.extension} + {abi: $a})
+    ($p + {url: $e.url, branch: $e.branch, extension: $e.extension, build: $e.build, path: $e.path} + {abi: $a})
   ]}')
 
 echo "$BUILD_MATRIX"

--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -1,6 +1,9 @@
 # Bundled extensions included in the dev server release tarball.
 # Also tested against the HEAD SDK in extension-compat-suite.yml.
 #
+# TODO(villagesql-ga): In the future, move this per-extension configuration into the
+# extension repos themselves (each declaring its own build/abi/path).
+#
 # Format: <url> [branch-or-tag] [key=value ...]
 #   url:           Full URL or local filesystem path. git clone accepts both.
 #   branch-or-tag: Optional. Omit to clone the default branch.

--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -8,6 +8,10 @@
 #                  Omit to test against both.
 #   bundle=false:  Optional. Omit (or bundle=true) to include in dev server.
 #                  Set bundle=false to run compat tests only — not shipped.
+#   build=<tool>:  Optional. Build system: "cmake" or "cargo". Default "cmake".
+#   path=<subdir>: Optional. Extension lives in this subdir of the repo.
+#                  Default: repo root. Also used to derive the extension name
+#                  (last path segment) so multiple entries can share one URL.
 #
 # Examples:
 #   https://github.com/villagesql/vsql-ai
@@ -26,3 +30,11 @@ https://github.com/villagesql/vsql-network-address main
 https://github.com/villagesql/vsql-rest main abi=dev
 https://github.com/villagesql/vsql-uuid main
 https://github.com/villagesql/vsql-vector main bundle=false
+https://github.com/villagesql/vsql-rust-sdk main build=cargo path=examples/vsql_rot13 abi=stable bundle=false
+https://github.com/villagesql/vsql-rust-sdk main build=cargo path=examples/vsql_keyring abi=stable bundle=false
+https://github.com/villagesql/vsql-rust-sdk main build=cargo path=examples/vsql_ping abi=stable bundle=false
+https://github.com/villagesql/vsql-rust-sdk main build=cargo path=examples/vsql_rational abi=stable bundle=false
+https://github.com/villagesql/vsql-rust-sdk main build=cargo path=examples/vsql_status_var abi=stable bundle=false
+https://github.com/villagesql/vsql-rust-sdk main build=cargo path=examples/vsql_sys_var abi=stable bundle=false
+https://github.com/villagesql/vsql-rust-sdk main build=cargo path=examples/vsql_thread_worker abi=stable bundle=false
+https://github.com/villagesql/vsql-rust-sdk main build=cargo path=tests/sdk_coverage abi=stable bundle=false


### PR DESCRIPTION
## Description

Added in the ability for rust extensions to also be added into the nightly testing. Required adding new fields for the build (cargo vs cmake) and path (root or in a separate folder). Includes testing for 8 Rust extensions ( sdk_coverage, vsql_keyring, vsql_ping, vsql_rational, vsql_rot13, vsql_status_var, vsql_sys_var, vsql_thread_worker). All that needed to be changed within the workflow was forking the build step to allow for either cargo or cmake. The installing and running of tests and recording and uploading of results was unchanged. This should result in the Rust extension testing results being outputted in Slack as part of the previously existing message. 