### PR TITLE
todos: rust and check tags

### DIFF
--- a/scripts/villint.sh
+++ b/scripts/villint.sh
@@ -195,6 +195,7 @@ ALLOWED_TODO_TAGS=(
   "villagesql-blob"
   "villagesql-indexing"
   "villagesql-back-to-mysql"
+  "villagesql-rust"
 )
 
 INVALID_TODO_TAGS_FOUND=0
@@ -715,6 +716,8 @@ for file in $OTHER_FILES; do
   fi
 
   apply_if_changed "$file" "$temp" "Fixed whitespace/newline in $file" || true
+
+  check_todo_tags "$file"
 done
 
 # --- Check for Accidental Laptop Strings ---


### PR DESCRIPTION
Discovered that villint.sh was not catching when invalid tags were being used in a .yaml file. Added check_todo_tags() underneath "Other files" section in villint.sh. Also, added villagesql-rust into the list of allowed tags. 