### PR TITLE
testing: rust filtered out of checkout

### DIFF
--- a/villagesql/bld_tools/build_bundled_extensions.sh
+++ b/villagesql/bld_tools/build_bundled_extensions.sh
@@ -91,8 +91,8 @@ while IFS= read -r line; do
     fi
 
     # This script builds with cmake. Skip entries that use another build tool
-    # such as cargo. Rust extensions build stable-toolchain and are memory-safe
-    # by nature, so we don't instrument the .so.
+    # such as cargo. The real issue is that we try to clone the rust-sdk
+    # multiple times, leading to an error.
     # TODO(villagesql-rust): Let's consider doing a bigger rework of the 
     # extension build system to support multiple build tools, but for now we just
     # skip non-cmake extensions.

--- a/villagesql/bld_tools/build_bundled_extensions.sh
+++ b/villagesql/bld_tools/build_bundled_extensions.sh
@@ -90,6 +90,20 @@ while IFS= read -r line; do
         continue
     fi
 
+    # This script builds with cmake. Skip entries that use another build tool
+    # such as cargo. Rust extensions build stable-toolchain and are memory-safe
+    # by nature, so we don't instrument the .so.
+    # TODO(villagesql-rust): consider running MTR suites against the sanitized
+    # server to exercise the FFI/ABI boundary.
+    BUILD_TOOL=cmake
+    for FIELD in "${FIELDS[@]:2}"; do
+        [[ "$FIELD" == build=* ]] && BUILD_TOOL="${FIELD#build=}"
+    done
+    if [[ "$BUILD_TOOL" != "cmake" ]]; then
+        log_info "Skipping $REPO_NAME (build=$BUILD_TOOL not supported here)"
+        continue
+    fi
+
     if [[ "$INCLUDE_UNBUNDLED" == "no" ]]; then
         BUNDLE=true
         for FIELD in "${FIELDS[@]:2}"; do

--- a/villagesql/bld_tools/build_bundled_extensions.sh
+++ b/villagesql/bld_tools/build_bundled_extensions.sh
@@ -93,8 +93,9 @@ while IFS= read -r line; do
     # This script builds with cmake. Skip entries that use another build tool
     # such as cargo. Rust extensions build stable-toolchain and are memory-safe
     # by nature, so we don't instrument the .so.
-    # TODO(villagesql-rust): consider running MTR suites against the sanitized
-    # server to exercise the FFI/ABI boundary.
+    # TODO(villagesql-rust): Let's consider doing a bigger rework of the 
+    # extension build system to support multiple build tools, but for now we just
+    # skip non-cmake extensions.
     BUILD_TOOL=cmake
     for FIELD in "${FIELDS[@]:2}"; do
         [[ "$FIELD" == build=* ]] && BUILD_TOOL="${FIELD#build=}"

--- a/villagesql/bld_tools/build_bundled_extensions.sh
+++ b/villagesql/bld_tools/build_bundled_extensions.sh
@@ -93,7 +93,7 @@ while IFS= read -r line; do
     # This script builds with cmake. Skip entries that use another build tool
     # such as cargo. The real issue is that we try to clone the rust-sdk
     # multiple times, leading to an error.
-    # TODO(villagesql-rust): Let's consider doing a bigger rework of the 
+    # TODO(villagesql-rust): Let's consider doing a bigger rework of the
     # extension build system to support multiple build tools, but for now we just
     # skip non-cmake extensions.
     BUILD_TOOL=cmake

--- a/villagesql/bld_tools/checkout_bundled_extensions.sh
+++ b/villagesql/bld_tools/checkout_bundled_extensions.sh
@@ -55,7 +55,10 @@ while IFS= read -r line; do
         continue
     fi
 
-    # TODO(villagesql-rust): Let's consider doing a bigger rework of the 
+    # This script builds with cmake. Skip entries that use another build tool
+    # such as cargo. The real issue is that we try to clone the rust-sdk
+    # multiple times, leading to an error.
+    # TODO(villagesql-rust): Let's consider doing a bigger rework of the
     # extension build system to support multiple build tools, but for now we just
     # skip non-cmake extensions.
     BUILD_TOOL=cmake

--- a/villagesql/bld_tools/checkout_bundled_extensions.sh
+++ b/villagesql/bld_tools/checkout_bundled_extensions.sh
@@ -58,8 +58,9 @@ while IFS= read -r line; do
     # This script builds with cmake. Skip entries that use another build tool
     # such as cargo. Rust extensions build stable-toolchain and are memory-safe
     # by nature, so we don't instrument the .so.
-    # TODO(villagesql-rust): consider running MTR suites against the sanitized
-    # server to exercise the FFI/ABI boundary.
+    # TODO(villagesql-rust): Let's consider doing a bigger rework of the 
+    # extension build system to support multiple build tools, but for now we just
+    # skip non-cmake extensions.
     BUILD_TOOL=cmake
     for FIELD in "${FIELDS[@]:2}"; do
         [[ "$FIELD" == build=* ]] && BUILD_TOOL="${FIELD#build=}"

--- a/villagesql/bld_tools/checkout_bundled_extensions.sh
+++ b/villagesql/bld_tools/checkout_bundled_extensions.sh
@@ -39,6 +39,8 @@ if [[ ! -d "$EXTENSION_CLONES_DIR" ]]; then
     die "Extension directory not found: $EXTENSION_CLONES_DIR (mkdir first)"
 fi
 
+FAILED=0
+
 while IFS= read -r line; do
     [[ "$line" =~ ^[[:space:]]*# ]] && continue
     [[ -z "${line// }" ]] && continue
@@ -50,6 +52,20 @@ while IFS= read -r line; do
     REPO_NAME="${SOURCE##*/}"
 
     if [[ -n "$EXTENSION_FILTER" && "$REPO_NAME" != "$EXTENSION_FILTER" ]]; then
+        continue
+    fi
+
+    # This script builds with cmake. Skip entries that use another build tool
+    # such as cargo. Rust extensions build stable-toolchain and are memory-safe
+    # by nature, so we don't instrument the .so.
+    # TODO(villagesql-rust): consider running MTR suites against the sanitized
+    # server to exercise the FFI/ABI boundary.
+    BUILD_TOOL=cmake
+    for FIELD in "${FIELDS[@]:2}"; do
+        [[ "$FIELD" == build=* ]] && BUILD_TOOL="${FIELD#build=}"
+    done
+    if [[ "$BUILD_TOOL" != "cmake" ]]; then
+        log_info "Skipping $REPO_NAME (build=$BUILD_TOOL not supported here)"
         continue
     fi
 

--- a/villagesql/bld_tools/checkout_bundled_extensions.sh
+++ b/villagesql/bld_tools/checkout_bundled_extensions.sh
@@ -55,9 +55,6 @@ while IFS= read -r line; do
         continue
     fi
 
-    # This script builds with cmake. Skip entries that use another build tool
-    # such as cargo. Rust extensions build stable-toolchain and are memory-safe
-    # by nature, so we don't instrument the .so.
     # TODO(villagesql-rust): Let's consider doing a bigger rework of the 
     # extension build system to support multiple build tools, but for now we just
     # skip non-cmake extensions.


### PR DESCRIPTION
## Description

The checkout bundled extensions and sanitizer steps were crashing after the Rust extensions were added to the nightly testing because of the fact that they all link back to a singular directory. This caused them to try to clone into the same spot. We don't really want the Rust extensions to be sanitized though, as Rust should confirm the extensions are all safe through the nature of the language. 

To resolve this issue, only extensions that use the build tool cmake are allowed to pass through being bundled, causing the rust extensions that use build tool=cargo to be skipped.

## Related Issue

N/a

## How was this tested?

Full testing can't be completed locally, but based on a local run of checkout_bundled_extensions, all 8 of the rust extensions are successfully being skipped. 

## Checklist

- [X] I have signed the CLA
- [X] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [X] I have added or updated tests as appropriate
- [X] My changes maintain compatibility with upstream MySQL 8.4
