### PR TITLE
dev_server: add vsql-currency to bundle

### DIFF
--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -25,6 +25,7 @@
 https://github.com/villagesql/vsql-ai main
 https://github.com/villagesql/vsql-boolean main
 https://github.com/villagesql/vsql-crypto main
+https://github.com/villagesql/vsql-currency main build=cargo abi=stable bundle=false
 https://github.com/villagesql/vsql-fuzzystrmatch main
 https://github.com/villagesql/vsql-trgm main
 https://github.com/villagesql/vsql-cube main


### PR DESCRIPTION
## Description
vsql-currency is a standalone Rust extension. bundle=false keeps it out of the dev server tarball, which build_bundled_extensions.sh would fail to produce since that script only knows how to run cmake.

This may break the nightly extension check.

AI=CLAUDE

## Related Issue
n/a

## How was this tested?
n/a

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
