### PR TITLE
mysql services capability 1

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-mysql-services/r/mysql_services_errlog.result
+++ b/mysql-test/suite/villagesql/extension/vsql-mysql-services/r/mysql_services_errlog.result
@@ -1,0 +1,16 @@
+call mtr.add_suppression("Component reported: 'vsql-errlog-marker");
+INSTALL EXTENSION vsql_mysql_services_errlog_test;
+SELECT vsql_mysql_services_errlog_test.log_warning('vsql-errlog-marker-8f3a') AS emit_status;
+emit_status
+0
+SELECT COUNT(*) > 0 AS marker_logged
+FROM performance_schema.error_log
+WHERE DATA LIKE '%vsql-errlog-marker-8f3a%';
+marker_logged
+1
+UNINSTALL EXTENSION vsql_mysql_services_errlog_test;
+INSTALL EXTENSION vsql_mysql_services_errlog_test;
+SELECT vsql_mysql_services_errlog_test.log_warning('vsql-errlog-marker-reinstall') AS emit_status_again;
+emit_status_again
+0
+UNINSTALL EXTENSION vsql_mysql_services_errlog_test;

--- a/mysql-test/suite/villagesql/extension/vsql-mysql-services/r/mysql_services_keyring.result
+++ b/mysql-test/suite/villagesql/extension/vsql-mysql-services/r/mysql_services_keyring.result
@@ -1,0 +1,43 @@
+# ----------------------------------------------------------------------
+# Setup
+# Creating local configuration file for keyring component: component_keyring_file
+# Creating manifest file for current MySQL server instance
+# Re-starting mysql server with manifest file
+# ----------------------------------------------------------------------
+# Install extension — the server acquires the three consumed services
+# and writes each vtable pointer into the extension.
+INSTALL EXTENSION vsql_mysql_services_test;
+# Round-trip a key through SERVICE_TYPE(keyring_writer) -> SERVICE_TYPE(keyring_reader_with_status)
+SELECT vsql_mysql_services_test.keyring_store('vsql_test_key', NULL, 'round_trip_value') AS store_status;
+store_status
+0
+SELECT vsql_mysql_services_test.keyring_read('vsql_test_key', NULL) AS read_value;
+read_value
+round_trip_value
+# Reading a non-existent key returns NULL (proves the path handles
+# "not found" cleanly via the SERVICE_TYPE(reader)->init flow)
+SELECT vsql_mysql_services_test.keyring_read('vsql_no_such_key', NULL) IS NULL AS missing_is_null;
+missing_is_null
+1
+# NULL data_id short-circuits before touching the service vtable
+SELECT vsql_mysql_services_test.keyring_read(NULL, NULL) IS NULL AS null_id_returns_null;
+null_id_returns_null
+1
+# Uninstall — the capability's on_depopulate releases each acquired
+# service. If teardown is broken, mysqld will leak refs and eventually
+# the keyring component will refuse to unload.
+UNINSTALL EXTENSION vsql_mysql_services_test;
+# Re-install after uninstall: proves teardown left a clean slate so the
+# capability behaves correctly across load cycles within one mysqld run.
+INSTALL EXTENSION vsql_mysql_services_test;
+SELECT vsql_mysql_services_test.keyring_read('vsql_test_key', NULL) AS read_after_reinstall;
+read_after_reinstall
+round_trip_value
+UNINSTALL EXTENSION vsql_mysql_services_test;
+# ----------------------------------------------------------------------
+# Teardown
+# Removing manifest file for current MySQL server instance
+# Removing local keyring file for keyring component: component_keyring_file
+# Removing local configuration file for keyring component: component_keyring_file
+# Restarting server without the manifest file
+# ----------------------------------------------------------------------

--- a/mysql-test/suite/villagesql/extension/vsql-mysql-services/r/mysql_services_missing.result
+++ b/mysql-test/suite/villagesql/extension/vsql-mysql-services/r/mysql_services_missing.result
@@ -1,0 +1,4 @@
+call mtr.add_suppression("failed to acquire MySQL service");
+# INSTALL must fail before the extension becomes usable
+INSTALL EXTENSION vsql_mysql_services_missing_test;
+ERROR HY000: Failed to load VEF extension 'vsql_mysql_services_missing_test': failed to acquire MySQL service 'vsql_intentionally_missing'

--- a/mysql-test/suite/villagesql/extension/vsql-mysql-services/r/mysql_services_session.result
+++ b/mysql-test/suite/villagesql/extension/vsql-mysql-services/r/mysql_services_session.result
@@ -1,0 +1,10 @@
+INSTALL EXTENSION vsql_mysql_services_session_test;
+SELECT vsql_mysql_services_session_test.session_sql_command() AS sql_command;
+sql_command
+select
+UNINSTALL EXTENSION vsql_mysql_services_session_test;
+INSTALL EXTENSION vsql_mysql_services_session_test;
+SELECT vsql_mysql_services_session_test.session_sql_command() AS sql_command_again;
+sql_command_again
+select
+UNINSTALL EXTENSION vsql_mysql_services_session_test;

--- a/mysql-test/suite/villagesql/extension/vsql-mysql-services/t/mysql_services_errlog.test
+++ b/mysql-test/suite/villagesql/extension/vsql-mysql-services/t/mysql_services_errlog.test
@@ -1,0 +1,29 @@
+# Test consuming a server-core service through the MySQL Services capability by
+# writing to the server error log. Consumes mysql_simple_error_log, an
+# always-registered core service, so NO component / server restart / setup is
+# needed. The emitted line is observable via performance_schema.error_log
+# (its log_sink_perfschema sink is active by default), so the test can assert
+# the write landed with plain SQL.
+
+# The VDF writes these markers to the error log on purpose; whitelist them so
+# MTR's error-log check does not fail the test on the expected warnings.
+call mtr.add_suppression("Component reported: 'vsql-errlog-marker");
+
+INSTALL EXTENSION vsql_mysql_services_errlog_test;
+
+# Emit a distinctive marker; VDF returns 0 on success.
+SELECT vsql_mysql_services_errlog_test.log_warning('vsql-errlog-marker-8f3a') AS emit_status;
+
+# The marker must now appear in the error log. Select only the boolean so the
+# result is portable (no timestamps / host-specific columns).
+SELECT COUNT(*) > 0 AS marker_logged
+FROM performance_schema.error_log
+WHERE DATA LIKE '%vsql-errlog-marker-8f3a%';
+
+UNINSTALL EXTENSION vsql_mysql_services_errlog_test;
+
+# Reinstall to prove teardown released the service cleanly and the capability
+# re-populates across load cycles.
+INSTALL EXTENSION vsql_mysql_services_errlog_test;
+SELECT vsql_mysql_services_errlog_test.log_warning('vsql-errlog-marker-reinstall') AS emit_status_again;
+UNINSTALL EXTENSION vsql_mysql_services_errlog_test;

--- a/mysql-test/suite/villagesql/extension/vsql-mysql-services/t/mysql_services_keyring.test
+++ b/mysql-test/suite/villagesql/extension/vsql-mysql-services/t/mysql_services_keyring.test
@@ -1,0 +1,38 @@
+# Test the MySQL Services capability end-to-end.
+#
+# The vsql_mysql_services_test extension declares three consumed services
+# (keyring_component_status, keyring_reader_with_status, keyring_writer) on one
+# MysqlServices capability. The server acquires them at load; the extension's
+# keyring_store/keyring_read VDFs then round-trip a value via the service
+# vtables.
+
+--source include/have_component_keyring_file.inc
+--source suite/component_keyring_file/inc/setup_component.inc
+
+--echo # Install extension — the server acquires the three consumed services
+--echo # and writes each vtable pointer into the extension.
+INSTALL EXTENSION vsql_mysql_services_test;
+
+--echo # Round-trip a key through SERVICE_TYPE(keyring_writer) -> SERVICE_TYPE(keyring_reader_with_status)
+SELECT vsql_mysql_services_test.keyring_store('vsql_test_key', NULL, 'round_trip_value') AS store_status;
+SELECT vsql_mysql_services_test.keyring_read('vsql_test_key', NULL) AS read_value;
+
+--echo # Reading a non-existent key returns NULL (proves the path handles
+--echo # "not found" cleanly via the SERVICE_TYPE(reader)->init flow)
+SELECT vsql_mysql_services_test.keyring_read('vsql_no_such_key', NULL) IS NULL AS missing_is_null;
+
+--echo # NULL data_id short-circuits before touching the service vtable
+SELECT vsql_mysql_services_test.keyring_read(NULL, NULL) IS NULL AS null_id_returns_null;
+
+--echo # Uninstall — the capability's on_depopulate releases each acquired
+--echo # service. If teardown is broken, mysqld will leak refs and eventually
+--echo # the keyring component will refuse to unload.
+UNINSTALL EXTENSION vsql_mysql_services_test;
+
+--echo # Re-install after uninstall: proves teardown left a clean slate so the
+--echo # capability behaves correctly across load cycles within one mysqld run.
+INSTALL EXTENSION vsql_mysql_services_test;
+SELECT vsql_mysql_services_test.keyring_read('vsql_test_key', NULL) AS read_after_reinstall;
+UNINSTALL EXTENSION vsql_mysql_services_test;
+
+--source suite/component_keyring_file/inc/teardown_component.inc

--- a/mysql-test/suite/villagesql/extension/vsql-mysql-services/t/mysql_services_missing.test
+++ b/mysql-test/suite/villagesql/extension/vsql-mysql-services/t/mysql_services_missing.test
@@ -1,0 +1,12 @@
+# Test that requesting a MySQL service that isn't in the registry causes
+# INSTALL EXTENSION to fail with a useful, named error.
+#
+# vsql_mysql_services_missing_test declares a RequiredService<> for a
+# service ("vsql_intentionally_missing") that no component will ever
+# register.
+
+call mtr.add_suppression("failed to acquire MySQL service");
+
+--echo # INSTALL must fail before the extension becomes usable
+--error ER_VILLAGESQL_GENERIC_ERROR
+INSTALL EXTENSION vsql_mysql_services_missing_test;

--- a/mysql-test/suite/villagesql/extension/vsql-mysql-services/t/mysql_services_session.test
+++ b/mysql-test/suite/villagesql/extension/vsql-mysql-services/t/mysql_services_session.test
@@ -1,0 +1,19 @@
+# Test consuming server-core services through the MySQL Services capability —
+# a mini "session attribute" reader (stand-in for vsql::preview::session, but
+# service-backed). Consumes mysql_current_thread_reader + mysql_thd_attributes,
+# both always-registered core services, so NO keyring component / server
+# restart / setup is needed.
+
+INSTALL EXTENSION vsql_mysql_services_session_test;
+
+# The VDF reads the running statement's "sql_command" attribute via the
+# consumed services. Called from a SELECT, so it reports "Select".
+SELECT vsql_mysql_services_session_test.session_sql_command() AS sql_command;
+
+UNINSTALL EXTENSION vsql_mysql_services_session_test;
+
+# Reinstall to prove teardown released the services cleanly and the capability
+# re-populates across load cycles.
+INSTALL EXTENSION vsql_mysql_services_session_test;
+SELECT vsql_mysql_services_session_test.session_sql_command() AS sql_command_again;
+UNINSTALL EXTENSION vsql_mysql_services_session_test;

--- a/mysql-test/suite/villagesql/extension/vsql-mysql-services/t/suite.opt
+++ b/mysql-test/suite/villagesql/extension/vsql-mysql-services/t/suite.opt
@@ -1,0 +1,1 @@
+--vsql_allow_preview_extensions=ON

--- a/villagesql/cmake/VsqlExtension.cmake
+++ b/villagesql/cmake/VsqlExtension.cmake
@@ -87,8 +87,14 @@ endfunction()
 #                   keeps the plain name. CMake target names are suffixed
 #                   with -<VERSION> so multiple versions of the same
 #                   VEB_NAME can coexist.
+#   MYSQL_HEADERS - flag; when present, MySQL's source include (service
+#                   definitions, e.g. <mysql/components/services/*.h>) and its
+#                   build-tree generated include (e.g. mysqld_error.h) are
+#                   added to the fixture's include path, and the build is
+#                   ordered after GenError. The mysql_services capability test
+#                   extensions need this; ordinary VEF-only extensions don't.
 macro(vsql_add_test_extension DIR_NAME VEB_NAME)
-  cmake_parse_arguments(_ext "" "ABI;VERSION" "" ${ARGN})
+  cmake_parse_arguments(_ext "MYSQL_HEADERS" "ABI;VERSION" "" ${ARGN})
 
   if(_ext_ABI STREQUAL "v3")
     set(_vsql_test_ext_include "${CMAKE_SOURCE_DIR}/villagesql/stable_sdk/v3/include")
@@ -126,22 +132,43 @@ macro(vsql_add_test_extension DIR_NAME VEB_NAME)
       "-DCMAKE_EXE_LINKER_FLAGS=--coverage")
   endif()
 
+  set(_ext_cmake_args
+    "-DCMAKE_PREFIX_PATH=${CMAKE_SOURCE_DIR}"
+    "-DVillageSQLExtensionFramework_INCLUDE_DIR=${_vsql_test_ext_include}"
+    "-DVillageSQL_VEB_INSTALL_DIR=${CMAKE_BINARY_DIR}/lib/veb"
+    "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+    "-DEXTENSION_NAME=${VEB_NAME}"
+    "-DEXTENSION_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test-extensions/${DIR_NAME}"
+    ${_ext_cov_args}
+  )
+  # Extensions that consume/provide MySQL component services need MySQL's
+  # headers. Two locations: the source tree ({src}/include) for the service
+  # definitions, and the build tree ({build}/include) for generated headers
+  # such as mysqld_error.h (error-code constants), produced by GenError.
+  if(_ext_MYSQL_HEADERS)
+    list(APPEND _ext_cmake_args
+      "-DMYSQL_INCLUDE_DIR=${CMAKE_SOURCE_DIR}/include"
+      "-DMYSQL_GENERATED_INCLUDE_DIR=${CMAKE_BINARY_DIR}/include")
+  endif()
+
   ExternalProject_Add(${_ext_proj_target}
     SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/test-extensions/shared
     BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/test-extensions/${DIR_NAME}-shared-build
     CMAKE_GENERATOR ${CMAKE_GENERATOR}
-    CMAKE_ARGS
-      "-DCMAKE_PREFIX_PATH=${CMAKE_SOURCE_DIR}"
-      "-DVillageSQLExtensionFramework_INCLUDE_DIR=${_vsql_test_ext_include}"
-      "-DVillageSQL_VEB_INSTALL_DIR=${CMAKE_BINARY_DIR}/lib/veb"
-      "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
-      "-DEXTENSION_NAME=${VEB_NAME}"
-      "-DEXTENSION_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR}/test-extensions/${DIR_NAME}"
-      ${_ext_cov_args}
+    CMAKE_ARGS ${_ext_cmake_args}
     DEPENDS sdk
     BUILD_ALWAYS ON
     INSTALL_COMMAND ""
   )
+
+  # Order the build after GenError so the generated MySQL headers exist before
+  # this extension compiles. Use add_dependencies (not ExternalProject_Add's
+  # DEPENDS) because GenError, defined in utilities/, is created after this
+  # subdirectory is configured — add_dependencies resolves the target lazily,
+  # ExternalProject_Add's DEPENDS requires it to already exist.
+  if(_ext_MYSQL_HEADERS)
+    add_dependencies(${_ext_proj_target} GenError)
+  endif()
 
   add_custom_target(${_ext_copy_target}
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/veb_output_directory

--- a/villagesql/sdk/include/villagesql/abi/preview/mysql_services.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/mysql_services.h
@@ -1,0 +1,69 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// =============================================================================
+// VEF PREVIEW ABI HEADER — UNSTABLE BINARY INTERFACE
+// =============================================================================
+// This header is both:
+//   - an ABI header — extension authors should use the C++ API in
+//     <villagesql/vsql.h>, not these raw types. See villagesql/abi/README.md.
+//   - a preview capability — API and ABI may change or be removed without
+//     notice. See villagesql/preview/README.md.
+// =============================================================================
+
+#ifndef VILLAGESQL_ABI_PREVIEW_MYSQL_SERVICES_H
+#define VILLAGESQL_ABI_PREVIEW_MYSQL_SERVICES_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Preview capability: "vsql::preview::mysql_services"
+//
+// Lets an extension consume MySQL registry services (provided by either a
+// component or the server core). The extension declares every service it uses
+// in one capability_config; the server acquires them at load and releases them
+// at unload.
+//
+// (Providing a service — an extension registering its own implementation into
+// the registry — is a planned follow-up and is not part of this capability
+// yet.)
+//
+// Capability name: VEF_PREVIEW_MYSQL_SERVICES_NAME
+
+#define VEF_PREVIEW_MYSQL_SERVICES_NAME "vsql::preview::mysql_services"
+
+// One service the extension consumes. The server acquires `service_name`'s
+// default implementation from the MySQL component registry and writes the
+// resulting SERVICE_TYPE* into *destination.
+typedef struct {
+  const char *service_name;
+  const void **destination;
+} vef_mysql_service_required_t;
+
+// capability_config passed in vef_required_capability_t. The array points into
+// the extension's MysqlServices wrapper and must outlive registration.
+typedef struct {
+  const vef_mysql_service_required_t *required;
+  size_t required_count;
+} vef_preview_mysql_services_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // VILLAGESQL_ABI_PREVIEW_MYSQL_SERVICES_H

--- a/villagesql/sdk/include/villagesql/preview/detail/mysql_services_register.h
+++ b/villagesql/sdk/include/villagesql/preview/detail/mysql_services_register.h
@@ -1,0 +1,45 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+#ifndef VILLAGESQL_PREVIEW_DETAIL_MYSQL_SERVICES_REGISTER_H
+#define VILLAGESQL_PREVIEW_DETAIL_MYSQL_SERVICES_REGISTER_H
+
+#include <villagesql/abi/preview/mysql_services.h>
+#include <villagesql/detail/capability_traits.h>
+#include <villagesql/preview/mysql_services.h>
+
+namespace vsql::detail {
+
+template <>
+struct CapabilityTraits<::vsql::preview_mysql_services::MysqlServices> {
+  using Cap = ::vsql::preview_mysql_services::MysqlServices;
+  static constexpr const char *kName = VEF_PREVIEW_MYSQL_SERVICES_NAME;
+  static constexpr const char *kCppTypeName =
+      "vsql::preview_mysql_services::MysqlServices";
+  static constexpr const char *kVtableHash = "ver-1";
+
+  using CapabilityConfigType = vef_preview_mysql_services_t;
+  static constexpr const char *kCapabilityConfigHash = "ver-1";
+
+  static constexpr void *vtable_destination(Cap *p) noexcept {
+    return static_cast<void *>(&p->presence_gate_);
+  }
+
+  static const void *capability_config(Cap *p) { return p->config(); }
+};
+
+}  // namespace vsql::detail
+
+#endif  // VILLAGESQL_PREVIEW_DETAIL_MYSQL_SERVICES_REGISTER_H

--- a/villagesql/sdk/include/villagesql/preview/mysql_services.h
+++ b/villagesql/sdk/include/villagesql/preview/mysql_services.h
@@ -1,0 +1,157 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+// =============================================================================
+// PREVIEW CAPABILITY — UNSTABLE API
+// =============================================================================
+// This header is part of the VEF preview surface. Its API and ABI may change
+// or be removed without notice. See villagesql/preview/README.md for details.
+// =============================================================================
+
+#ifndef VILLAGESQL_PREVIEW_MYSQL_SERVICES_H
+#define VILLAGESQL_PREVIEW_MYSQL_SERVICES_H
+
+// Consume MySQL registry services from a VEF extension.
+//
+// Declare one MysqlServices capability at static scope, register the services
+// it uses via require(), and pass it to .with(). VEF acquires them at load and
+// releases them at unload.
+//
+// (Providing a service — registering the extension's own implementation into
+// the registry — is a planned follow-up, not part of this capability yet.)
+//
+// HOW THIS MAPS TO MYSQL COMPONENT SERVICES
+// -----------------------------------------
+// This wrapper only handles ACQUIRING a service and handing you a pointer to
+// it. What each service IS — its methods, their parameters, and return
+// conventions — is defined and documented by MySQL, not here. For a service
+// named NAME you read MySQL's own header:
+//
+//   include/mysql/components/services/NAME.h
+//
+// where a BEGIN_SERVICE_DEFINITION(NAME) block lists each method (as
+// DECLARE_*_METHOD) with doxygen @param/@retval docs. To consume it:
+//
+//   1. Include that MySQL header (for SERVICE_TYPE(NAME) and its method decls).
+//   2. VSQL_REQUIRE_SERVICE(services, NAME, var)  — acquires it into `var`.
+//      (The service-name string is derived from NAME; if a service's registry
+//      name differs from its SERVICE_TYPE name, use the explicit
+//      services.require<SERVICE_TYPE(NAME)>("registry.name", ref) form.)
+//   3. Check var.valid() — see below — then call methods via var->method(...)
+//      EXACTLY as MySQL's header documents them (same parameters, same
+//      convention that a bool return of `false` means success, `true` failure).
+//
+// So MySQL's header is your method reference; this SDK only replaces MySQL's
+// `my_service<SERVICE_TYPE(NAME)>` acquire/release boilerplate with the
+// capability. `var.valid()` is our equivalent of `my_service::is_valid()`.
+//
+// DOT vs ARROW: `var` is a ServiceRef wrapper. Use `.` for the wrapper's own
+// API (var.valid()) and `->` to call through to the MySQL service
+// (var->method()). ALWAYS check var.valid() before any var-> call — `->`
+// dereferences the acquired pointer, which is null if acquisition failed.
+//
+// EXAMPLE
+// -------
+//
+//   #include <villagesql/vsql.h>
+//   #include <villagesql/preview/mysql_services.h>
+//   #include <mysql/components/services/keyring_metadata_query.h>
+//
+//   static vsql::preview_mysql_services::MysqlServices services;
+//   VSQL_REQUIRE_SERVICE(services, keyring_component_status, status);
+//
+//   void f_impl(IntResult out) {
+//     // is_initialized() is MySQL's method, documented in the service's
+//     // header. Guard with valid() first, then call through with ->.
+//     out.set((status.valid() && status->is_initialized()) ? 1 : 0);
+//   }
+//
+//   VEF_GENERATE_ENTRY_POINTS(
+//     make_extension().with(services).func(
+//         make_func<&f_impl>("f").returns(INT).no_params().build()))
+
+#include <cstddef>
+#include <vector>
+
+#include <villagesql/abi/preview/mysql_services.h>
+#include <villagesql/detail/capability_base.h>
+#include <villagesql/detail/capability_traits.h>
+
+namespace vsql::preview_mysql_services {
+
+// Typed accessor to a consumed service. Declare one (at static scope) and pass
+// it to MysqlServices::require(); the server writes the acquired vtable into it
+// at load, after which valid() is true. `ST` is `SERVICE_TYPE(name)`.
+template <typename ST>
+class ServiceRef {
+ public:
+  ST *operator->() const { return ptr_; }
+  ST &operator*() const { return *ptr_; }
+  bool valid() const { return ptr_ != nullptr; }
+
+  // Where the server writes the acquired vtable. Handed to require() as the
+  // config destination slot; not for extension code to set.
+  const void **destination() { return reinterpret_cast<const void **>(&ptr_); }
+
+ private:
+  ST *ptr_ = nullptr;
+};
+
+class MysqlServices : public ::vsql::detail::CapabilityBase<MysqlServices> {
+ public:
+  // Consume `service_name`'s default implementation, resolving into `ref` once
+  // the extension loads. `ref` must outlive the extension (declare it at static
+  // scope, alongside the MysqlServices instance).
+  template <typename ST>
+  void require(const char *service_name, ServiceRef<ST> &ref) {
+    required_.push_back({service_name, ref.destination()});
+  }
+
+ private:
+  friend struct ::vsql::detail::CapabilityTraits<MysqlServices>;
+
+  // Snapshot the vector into the config the server reads at load. Called once
+  // during vef_register, after all require() static initializers have run, so
+  // the vector is final and its data() pointer stable thereafter.
+  const vef_preview_mysql_services_t *config() const {
+    config_ = {required_.data(), required_.size()};
+    return &config_;
+  }
+
+  // The capability loader skips any capability whose vtable_dest is null, so we
+  // expose this field as the destination purely to signal "this capability is
+  // present" and get on_populate called. MysqlServices carries no server
+  // vtable — its real payload is capability_config, and the acquired service
+  // pointers land in the ServiceRefs — so the (null) write here is unused.
+  void *presence_gate_ = nullptr;
+
+  std::vector<vef_mysql_service_required_t> required_;
+  mutable vef_preview_mysql_services_t config_ = {};
+};
+
+}  // namespace vsql::preview_mysql_services
+
+// Convenience: declare a ServiceRef and require a service whose registry name
+// matches its SERVICE_TYPE name (the usual case). The name is written once;
+// #name is the registry string and SERVICE_TYPE(name) the type. For an
+// implementation name that differs from the type (e.g. "svc.impl"), declare a
+// ServiceRef<SERVICE_TYPE(svc)> and call services.require("svc.impl", ref).
+#define VSQL_REQUIRE_SERVICE(services, name, var)                            \
+  static ::vsql::preview_mysql_services::ServiceRef<SERVICE_TYPE(name)> var; \
+  static const int var##_vsql_req = ((services).require(#name, var), 0)
+
+#include <villagesql/preview/detail/mysql_services_register.h>
+
+#endif  // VILLAGESQL_PREVIEW_MYSQL_SERVICES_H

--- a/villagesql/services/CMakeLists.txt
+++ b/villagesql/services/CMakeLists.txt
@@ -21,6 +21,7 @@ SET(VILLAGESQL_SERVICES_SOURCES
   preview/index_profile.cc
   preview/index_type.cc
   preview/keyring.cc
+  preview/mysql_services.cc
   preview/ping.cc
   preview/statement_event.cc
   preview/sql_query.cc

--- a/villagesql/services/capability_registry.cc
+++ b/villagesql/services/capability_registry.cc
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "villagesql/sdk/include/villagesql/abi/preview/keyring.h"
+#include "villagesql/sdk/include/villagesql/abi/preview/mysql_services.h"
 #include "villagesql/sdk/include/villagesql/abi/preview/ping.h"
 #include "villagesql/sdk/include/villagesql/abi/preview/sql_query.h"
 #include "villagesql/sdk/include/villagesql/abi/preview/statement_event.h"
@@ -34,6 +35,7 @@
 #include "villagesql/services/preview/index_profile.h"
 #include "villagesql/services/preview/index_type.h"
 #include "villagesql/services/preview/keyring.h"
+#include "villagesql/services/preview/mysql_services.h"
 #include "villagesql/services/preview/ping.h"
 #include "villagesql/services/preview/sql_query.h"
 #include "villagesql/services/preview/statement_event.h"
@@ -155,6 +157,15 @@ void register_builtin_capabilities() {
                        .on_server_startup = init_thread_worker_psi_keys,
                        .on_populate = on_populate_thread_worker,
                        .on_depopulate = on_depopulate_thread_worker});
+  // mysql_services carries no server vtable — the server acquires services and
+  // writes their pointers back through the config's destination slots. The
+  // extension's vtable_dest receives a null write (an unused sink).
+  register_capability(VEF_PREVIEW_MYSQL_SERVICES_NAME,
+                      {.vtable = nullptr,
+                       .vtable_hash = "ver-1",
+                       .capability_config_hash = "ver-1",
+                       .on_populate = on_populate_mysql_services,
+                       .on_depopulate = on_depopulate_mysql_services});
   register_capability(VEF_PREVIEW_COLUMN_STORE_NAME,
                       {.vtable = preview_column_store_vtable(),
                        .vtable_hash = "ver-1",

--- a/villagesql/services/preview/mysql_services.cc
+++ b/villagesql/services/preview/mysql_services.cc
@@ -1,0 +1,128 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+#include "villagesql/services/preview/mysql_services.h"
+
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+#include "mysql/components/services/registry.h"
+#include "mysql/service_plugin_registry.h"
+#include "villagesql/include/error.h"
+#include "villagesql/sdk/include/villagesql/abi/preview/mysql_services.h"
+
+namespace villagesql::services {
+
+namespace {
+
+// What the capability acquired for one extension, so on_depopulate can release
+// it. Keyed by the config pointer.
+struct ServiceState {
+  std::vector<my_h_service> acquired_handles;
+};
+
+// WorkerState-style keying: config pointer is stable and unique per loaded
+// extension. Protected by g_mu (populate/depopulate run on the INSTALL /
+// UNINSTALL thread, but a mutex keeps this robust to concurrent loads).
+std::mutex g_mu;
+std::unordered_map<const vef_preview_mysql_services_t *, ServiceState> g_states;
+
+// Acquire every consumed service and write its pointer back into the extension.
+// On any failure, roll back what this call already did.
+//
+// TODO(villagesql-beta): consider whether to enforce a manifest allow-list —
+// refusing any service the code consumes that is not listed in the extension's
+// manifest "required_mysql_services". This is an open design decision, not a
+// pending task: it's one way to constrain which services an extension may
+// acquire, but may not be worth its cost (threading the manifest list through
+// PopulateContext). Today any registered service can be acquired without a
+// manifest declaration.
+bool populate(const vef_preview_mysql_services_t *cfg, ServiceState &state,
+              std::string &error_message) {
+  SERVICE_TYPE(registry) *registry = mysql_plugin_registry_acquire();
+  if (registry == nullptr) {
+    error_message = "could not acquire MySQL plugin registry";
+    return true;
+  }
+
+  for (size_t i = 0; i < cfg->required_count; ++i) {
+    const vef_mysql_service_required_t &req = cfg->required[i];
+    if (req.service_name == nullptr || req.destination == nullptr) {
+      error_message = "mysql_services: required entry has null field";
+      mysql_plugin_registry_release(registry);
+      return true;
+    }
+    my_h_service handle = nullptr;
+    if (registry->acquire(req.service_name, &handle) || handle == nullptr) {
+      error_message = std::string("failed to acquire MySQL service '") +
+                      req.service_name + "'";
+      mysql_plugin_registry_release(registry);
+      return true;
+    }
+    *req.destination = reinterpret_cast<const void *>(handle);
+    state.acquired_handles.push_back(handle);
+  }
+
+  mysql_plugin_registry_release(registry);
+  return false;
+}
+
+// Release every acquired service handle. Runs at extension unload.
+void depopulate(ServiceState &state) {
+  SERVICE_TYPE(registry) *registry = mysql_plugin_registry_acquire();
+  if (registry == nullptr) return;
+  for (auto h : state.acquired_handles) {
+    registry->release(h);
+  }
+  mysql_plugin_registry_release(registry);
+}
+
+}  // namespace
+
+bool on_populate_mysql_services(const PopulateContext &ctx,
+                                std::string &error_message) {
+  if (ctx.capability_config == nullptr) return false;
+  const auto *cfg =
+      static_cast<const vef_preview_mysql_services_t *>(ctx.capability_config);
+
+  ServiceState state;
+  if (populate(cfg, state, error_message)) {
+    depopulate(state);  // roll back partial work
+    return true;
+  }
+
+  std::lock_guard<std::mutex> lock(g_mu);
+  g_states[cfg] = std::move(state);
+  return false;
+}
+
+void on_depopulate_mysql_services(const DepopulateContext &ctx) {
+  if (ctx.capability_config == nullptr) return;
+  const auto *cfg =
+      static_cast<const vef_preview_mysql_services_t *>(ctx.capability_config);
+
+  ServiceState state;
+  {
+    std::lock_guard<std::mutex> lock(g_mu);
+    auto it = g_states.find(cfg);
+    if (it == g_states.end()) return;
+    state = std::move(it->second);
+    g_states.erase(it);
+  }
+  depopulate(state);
+}
+
+}  // namespace villagesql::services

--- a/villagesql/services/preview/mysql_services.h
+++ b/villagesql/services/preview/mysql_services.h
@@ -1,0 +1,38 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or
+// modify it under the terms of the GNU General Public License
+// as published by the Free Software Foundation; either version 2
+// of the License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+#ifndef VILLAGESQL_SERVICES_PREVIEW_MYSQL_SERVICES_H
+#define VILLAGESQL_SERVICES_PREVIEW_MYSQL_SERVICES_H
+
+// Server-side of the vsql::preview::mysql_services capability.
+//
+// on_populate reads the extension's capability_config (the list of services it
+// consumes), acquires each from the MySQL component registry, and writes the
+// pointer back into the extension. on_depopulate releases them at unload.
+// Per-extension state is keyed by the config pointer.
+
+#include <string>
+
+#include "villagesql/services/capability_registry.h"
+
+namespace villagesql::services {
+
+bool on_populate_mysql_services(const PopulateContext &ctx,
+                                std::string &error_message);
+void on_depopulate_mysql_services(const DepopulateContext &ctx);
+
+}  // namespace villagesql::services
+
+#endif  // VILLAGESQL_SERVICES_PREVIEW_MYSQL_SERVICES_H

--- a/villagesql/test-extensions/CMakeLists.txt
+++ b/villagesql/test-extensions/CMakeLists.txt
@@ -36,6 +36,13 @@ vsql_add_test_extension(vsql-sys-var-rollback-test     vsql_sys_var_rollback_tes
 vsql_add_test_extension(vsql-noop-test                 vsql_noop_test)
 vsql_add_test_extension(vsql-on-init-test              vsql_on_init_test)
 
+# mysql_services capability test extensions consume raw MySQL component
+# services, so they need MySQL headers (MYSQL_HEADERS flag).
+vsql_add_test_extension(vsql-mysql-services-test         vsql_mysql_services_test         MYSQL_HEADERS)
+vsql_add_test_extension(vsql-mysql-services-missing-test vsql_mysql_services_missing_test MYSQL_HEADERS)
+vsql_add_test_extension(vsql-mysql-services-session-test vsql_mysql_services_session_test MYSQL_HEADERS)
+vsql_add_test_extension(vsql-mysql-services-errlog-test  vsql_mysql_services_errlog_test  MYSQL_HEADERS)
+
 # Built against the frozen stable v3 SDK so the variable-length type registers
 # at VEF_PROTOCOL_3 and is rejected by build_type_descriptor_v3 (missing
 # resolve_params) -- a path the current dev SDK can no longer produce.

--- a/villagesql/test-extensions/shared/CMakeLists.txt
+++ b/villagesql/test-extensions/shared/CMakeLists.txt
@@ -29,6 +29,19 @@ find_package(VillageSQLExtensionFramework REQUIRED)
 
 include_directories(${VillageSQLExtensionFramework_INCLUDE_DIR})
 
+# Extensions that consume/provide raw MySQL component services need MySQL's
+# own headers. The parent passes these only for those extensions (the
+# MYSQL_HEADERS flag on vsql_add_test_extension); VEF-only extensions leave
+# them unset. Two locations: the source tree for service definitions
+# (<mysql/components/services/*.h>), and the build tree for generated headers
+# like mysqld_error.h (error-code constants).
+if(MYSQL_INCLUDE_DIR)
+  include_directories(${MYSQL_INCLUDE_DIR})
+endif()
+if(MYSQL_GENERATED_INCLUDE_DIR)
+  include_directories(${MYSQL_GENERATED_INCLUDE_DIR})
+endif()
+
 add_library(extension SHARED
   ${EXTENSION_SOURCE_DIR}/src/extension.cc
 )

--- a/villagesql/test-extensions/vsql-mysql-services-errlog-test/manifest.json
+++ b/villagesql/test-extensions/vsql-mysql-services-errlog-test/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "vsql_mysql_services_errlog_test",
+  "version": "0.0.1",
+  "description": "VillageSQL test extension writing to the server error log via a consumed MySQL core service",
+  "author": "VillageSQL Community",
+  "license": "GPL-2.0"
+}

--- a/villagesql/test-extensions/vsql-mysql-services-errlog-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-mysql-services-errlog-test/src/extension.cc
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+// vsql_mysql_services_errlog_test extension: writes to the server error log
+// through the MySQL Services capability.
+//
+// Consumes one server-core service (always registered, so no component /
+// restart / setup is needed to run the test):
+//   mysql_simple_error_log — emit a line to the server error log
+//
+// VDF:
+//   log_warning(text) -> INT
+//       Emits `text` to the error log at WARNING severity. Returns 0 on
+//       success, 1 on error. The line is observable via
+//       performance_schema.error_log, which the test asserts against.
+
+#include <cstddef>
+
+#include <mysql/components/services/mysql_simple_error_log.h>
+#include <mysqld_error.h>  // ER_LOG_PRINTF_MSG
+#include <villagesql/preview/mysql_services.h>
+#include <villagesql/vsql.h>
+
+using namespace vsql;
+
+static preview_mysql_services::MysqlServices services;
+VSQL_REQUIRE_SERVICE(services, mysql_simple_error_log, error_log);
+
+// log_warning(text)
+//
+// Writes `text` to the server error log via mysql_simple_error_log::emit.
+// ER_LOG_PRINTF_MSG is the generic "%s" error-log message code, so the text
+// is logged verbatim. WARNING severity is used (not INFORMATION) so the line
+// survives the default log_error_verbosity of 2, which drops info/notes.
+// Returns 0 on success, 1 on error.
+void log_warning(StringArg text, IntResult out) {
+  if (text.is_null() || !error_log.valid()) {
+    out.set(1);
+    return;
+  }
+  const std::string_view msg = text.value();
+  const bool err = error_log->emit("vsql_mysql_services_errlog_test", __FILE__,
+                                   __LINE__, MYSQL_ERROR_LOG_SEVERITY_WARNING,
+                                   ER_LOG_PRINTF_MSG, std::string(msg).c_str());
+  out.set(err ? 1 : 0);
+}
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().with(services).func(
+    make_func<&log_warning>("log_warning").returns(INT).param(STRING).build()))

--- a/villagesql/test-extensions/vsql-mysql-services-missing-test/manifest.json
+++ b/villagesql/test-extensions/vsql-mysql-services-missing-test/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "vsql_mysql_services_missing_test",
+  "version": "0.0.1",
+  "description": "VillageSQL test extension that requests a nonexistent MySQL service to exercise the capability's acquire-failure path",
+  "author": "VillageSQL Community",
+  "license": "GPL-2.0"
+}

--- a/villagesql/test-extensions/vsql-mysql-services-missing-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-mysql-services-missing-test/src/extension.cc
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+// vsql_mysql_services_missing_test extension: requests a MySQL service that
+// is guaranteed not to be registered. INSTALL EXTENSION must fail with an
+// error message naming the missing service.
+
+#include <cstddef>
+
+#include <mysql/components/service.h>
+#include <villagesql/preview/mysql_services.h>
+#include <villagesql/vsql.h>
+
+using namespace vsql;
+
+// Define a service the registry will never have an implementation of.
+BEGIN_SERVICE_DEFINITION(vsql_intentionally_missing)
+DECLARE_BOOL_METHOD(unused, (void));
+END_SERVICE_DEFINITION(vsql_intentionally_missing)
+
+static preview_mysql_services::MysqlServices services;
+VSQL_REQUIRE_SERVICE(services, vsql_intentionally_missing, missing);
+
+// VDF only exists so the extension has a func to register; never callable
+// because INSTALL EXTENSION fails before the extension becomes usable.
+void noop(IntResult out) { out.set(0); }
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().with(services).func(
+    make_func<&noop>("noop").returns(INT).no_params().build()))

--- a/villagesql/test-extensions/vsql-mysql-services-session-test/manifest.json
+++ b/villagesql/test-extensions/vsql-mysql-services-session-test/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "vsql_mysql_services_session_test",
+  "version": "0.0.1",
+  "description": "VillageSQL test extension reading a session attribute via consumed MySQL core services (a mini session capability)",
+  "author": "VillageSQL Community",
+  "license": "GPL-2.0"
+}

--- a/villagesql/test-extensions/vsql-mysql-services-session-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-mysql-services-session-test/src/extension.cc
@@ -1,0 +1,75 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+// vsql_mysql_services_session_test extension: a minimal "session attribute"
+// reader built on the MySQL Services capability — a small stand-in for the
+// vsql::preview::session capability, but implemented purely by consuming MySQL
+// component services rather than server internals.
+//
+// It consumes two server-core services (both always registered, so no keyring
+// component / server restart / setup is needed to run the test):
+//   mysql_current_thread_reader  — hands back the current THD
+//   mysql_thd_attributes         — reads a named attribute off that THD
+//
+// VDF:
+//   session_sql_command() -> STRING
+//       Returns the SQL command name of the running statement (the THD's
+//       "sql_command" attribute), or NULL if the services are unavailable.
+
+#include <cstddef>
+
+#include <mysql/components/services/defs/mysql_string_defs.h>
+#include <mysql/components/services/mysql_current_thread_reader.h>
+#include <mysql/components/services/mysql_thd_attributes.h>
+#include <villagesql/preview/mysql_services.h>
+#include <villagesql/vsql.h>
+
+using namespace vsql;
+
+static preview_mysql_services::MysqlServices services;
+VSQL_REQUIRE_SERVICE(services, mysql_current_thread_reader, thd_reader);
+VSQL_REQUIRE_SERVICE(services, mysql_thd_attributes, attrs);
+
+// session_sql_command()
+//
+// Reads the current statement's SQL command name via the two consumed
+// services. "sql_command" is returned as a mysql_cstring_with_length (a plain
+// {str,length}), so no string-handle conversion is needed.
+void session_sql_command(StringResult out) {
+  if (!thd_reader.valid() || !attrs.valid()) {
+    out.error("MySQL session services not wired up");
+    return;
+  }
+
+  MYSQL_THD thd = nullptr;
+  if (thd_reader->get(&thd) || thd == nullptr) {
+    out.set_null();
+    return;
+  }
+
+  mysql_cstring_with_length value{nullptr, 0};
+  if (attrs->get(thd, "sql_command", &value) || value.str == nullptr) {
+    out.set_null();
+    return;
+  }
+
+  out.set(std::string_view(value.str, value.length));
+}
+
+VEF_GENERATE_ENTRY_POINTS(make_extension().with(services).func(
+    make_func<&session_sql_command>("session_sql_command")
+        .returns(STRING)
+        .no_params()
+        .build()))

--- a/villagesql/test-extensions/vsql-mysql-services-test/manifest.json
+++ b/villagesql/test-extensions/vsql-mysql-services-test/manifest.json
@@ -1,0 +1,7 @@
+{
+  "name": "vsql_mysql_services_test",
+  "version": "0.0.1",
+  "description": "VillageSQL test extension exercising the MySQL Services capability",
+  "author": "VillageSQL Community",
+  "license": "GPL-2.0"
+}

--- a/villagesql/test-extensions/vsql-mysql-services-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-mysql-services-test/src/extension.cc
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 VillageSQL Contributors
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License, version 2.0,
+// as published by the Free Software Foundation.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License, version 2.0, for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA
+
+// vsql_mysql_services_test extension: exercises the MySQL Services capability
+// end-to-end.
+//
+// Declares three consumed services (component_status, reader, writer) on one
+// MysqlServices capability. The server acquires each at load, before any VDF
+// runs. If any fails to acquire, extension load fails.
+//
+// VDFs:
+//   keyring_read(data_id, auth_id)              -> STRING
+//       Reads a secret from the keyring via the SERVICE_TYPE(reader) vtable.
+//   keyring_store(data_id, auth_id, value)      -> INT
+//       Stores a secret via the SERVICE_TYPE(writer) vtable. Returns 0 on
+//       success, 1 on error.
+
+#include <cstddef>
+#include <cstring>
+
+#include <mysql/components/services/keyring_metadata_query.h>  // keyring_component_status
+#include <mysql/components/services/keyring_reader_with_status.h>
+#include <mysql/components/services/keyring_writer.h>
+#include <villagesql/preview/mysql_services.h>
+#include <villagesql/vsql.h>
+
+using namespace vsql;
+
+static preview_mysql_services::MysqlServices services;
+VSQL_REQUIRE_SERVICE(services, keyring_component_status, status);
+VSQL_REQUIRE_SERVICE(services, keyring_reader_with_status, reader);
+VSQL_REQUIRE_SERVICE(services, keyring_writer, writer);
+
+// keyring_read(data_id, auth_id)
+//
+// Returns the secret stored under (data_id, auth_id), or NULL if not found
+// or the keyring component is uninitialised. Pass NULL auth_id for internal
+// keys.
+void keyring_read(StringArg data_id, StringArg auth_id, StringResult out) {
+  if (data_id.is_null()) {
+    out.set_null();
+    return;
+  }
+  if (!status.valid() || !reader.valid()) {
+    out.error("MySQL keyring services not wired up");
+    return;
+  }
+  if (!status->is_initialized()) {
+    out.error("Keyring component is not initialised");
+    return;
+  }
+
+  const char *did = data_id.value().data();
+  const char *aid = auth_id.is_null() ? nullptr : auth_id.value().data();
+
+  my_h_keyring_reader_object obj = nullptr;
+  if (reader->init(did, aid, &obj) || obj == nullptr) {
+    out.set_null();
+    return;
+  }
+
+  size_t key_len = 0, type_len = 0;
+  if (reader->fetch_length(obj, &key_len, &type_len)) {
+    reader->deinit(obj);
+    out.set_null();
+    return;
+  }
+
+  auto buf = out.buffer();
+  if (key_len > buf.size()) {
+    reader->deinit(obj);
+    out.error("Keyring value too large for output buffer");
+    return;
+  }
+
+  char type_buf[64];
+  size_t fetched_len = 0, fetched_type_len = 0;
+  if (reader->fetch(obj, reinterpret_cast<unsigned char *>(buf.data()),
+                    buf.size(), &fetched_len, type_buf, sizeof(type_buf),
+                    &fetched_type_len)) {
+    reader->deinit(obj);
+    out.set_null();
+    return;
+  }
+  reader->deinit(obj);
+  out.set_length(fetched_len);
+}
+
+// keyring_store(data_id, auth_id, value)
+//
+// Stores `value` in the keyring under (data_id, auth_id). Type is hard-coded
+// to "SECRET". Returns 0 on success, 1 on error.
+void keyring_store(StringArg data_id, StringArg auth_id, StringArg value,
+                   IntResult out) {
+  if (data_id.is_null() || value.is_null()) {
+    out.set(1);
+    return;
+  }
+  if (!status.valid() || !writer.valid()) {
+    out.error("MySQL keyring services not wired up");
+    return;
+  }
+  if (!status->is_initialized()) {
+    out.error("Keyring component is not initialised");
+    return;
+  }
+
+  const char *did = data_id.value().data();
+  const char *aid = auth_id.is_null() ? nullptr : auth_id.value().data();
+  auto val = value.value();
+
+  bool err = writer->store(did, aid,
+                           reinterpret_cast<const unsigned char *>(val.data()),
+                           val.size(), "SECRET");
+  out.set(err ? 1 : 0);
+}
+
+VEF_GENERATE_ENTRY_POINTS(make_extension()
+                              .with(services)
+                              .func(make_func<&keyring_read>("keyring_read")
+                                        .returns(STRING)
+                                        .param(STRING)
+                                        .param(STRING)
+                                        .build())
+                              .func(make_func<&keyring_store>("keyring_store")
+                                        .returns(INT)
+                                        .param(STRING)
+                                        .param(STRING)
+                                        .param(STRING)
+                                        .build()))


### PR DESCRIPTION
Exposes only the consumer aspect of mysql services:
1. the most useful part of services, stands by itself
2. keeps the PR smaller
3. provider aspect raises an issue regarding uninstall ordering

two options to add provider, extend this capability, or as a separate capability

part of #422 