### PR TITLE
Improve gcov coverage gathering

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-storage-test/r/storage_recovery_alter.result
+++ b/mysql-test/suite/villagesql/extension/vsql-storage-test/r/storage_recovery_alter.result
@@ -1,3 +1,4 @@
+# restart
 SET PERSIST vsql_allow_preview_extensions = ON;
 # Install the column-store test extension (provides STORED_INT)
 INSTALL EXTENSION vsql_storage_test;

--- a/mysql-test/suite/villagesql/extension/vsql-storage-test/t/storage_recovery_alter.test
+++ b/mysql-test/suite/villagesql/extension/vsql-storage-test/t/storage_recovery_alter.test
@@ -11,6 +11,11 @@
 # recovery. If the durability hole is real, the values are lost/garbage after
 # recovery (RED). A correct implementation preserves them (GREEN).
 
+# Start from a freshly (gracefully) restarted server so this test's crash does
+# not discard information (like gcov test coverage) accumulated by preceding
+# tests sharing this mysqld.
+--source include/restart_mysqld.inc
+
 SET PERSIST vsql_allow_preview_extensions = ON;
 
 --echo # Install the column-store test extension (provides STORED_INT)

--- a/mysql-test/suite/villagesql/startup/r/recovery_complex.result
+++ b/mysql-test/suite/villagesql/startup/r/recovery_complex.result
@@ -1,3 +1,4 @@
+# restart
 #
 # Test crash recovery with uncommitted transactions on COMPLEX columns
 #

--- a/mysql-test/suite/villagesql/startup/r/recovery_complex_index.result
+++ b/mysql-test/suite/villagesql/startup/r/recovery_complex_index.result
@@ -1,3 +1,4 @@
+# restart
 #
 # Test crash recovery with uncommitted transactions on indexed COMPLEX columns
 #

--- a/mysql-test/suite/villagesql/startup/r/recovery_complex_index_partition.result
+++ b/mysql-test/suite/villagesql/startup/r/recovery_complex_index_partition.result
@@ -2,6 +2,7 @@
 # Test crash recovery with uncommitted transactions on indexed COMPLEX columns
 # with PARTITIONED table
 #
+# restart
 #
 # Test crash recovery with uncommitted transactions on indexed COMPLEX columns
 #

--- a/mysql-test/suite/villagesql/startup/r/recovery_complex_index_partition_virtual.result
+++ b/mysql-test/suite/villagesql/startup/r/recovery_complex_index_partition_virtual.result
@@ -2,6 +2,7 @@
 # Test crash recovery with uncommitted transactions on indexed COMPLEX columns
 # with PARTITIONED table and VIRTUAL columns
 #
+# restart
 #
 # Test crash recovery with uncommitted transactions on indexed COMPLEX columns
 #

--- a/mysql-test/suite/villagesql/startup/r/recovery_complex_index_virtual.result
+++ b/mysql-test/suite/villagesql/startup/r/recovery_complex_index_virtual.result
@@ -2,6 +2,7 @@
 # Test crash recovery with uncommitted transactions on indexed COMPLEX columns
 # with VIRTUAL columns (tests column index mapping)
 #
+# restart
 #
 # Test crash recovery with uncommitted transactions on indexed COMPLEX columns
 #

--- a/mysql-test/suite/villagesql/startup/t/recovery_complex.test
+++ b/mysql-test/suite/villagesql/startup/t/recovery_complex.test
@@ -1,3 +1,8 @@
+# Start from a freshly (gracefully) restarted server so this test's crash does
+# not discard information (like gcov test coverage) accumulated by preceding
+# tests sharing this mysqld.
+--source include/restart_mysqld.inc
+
 --echo #
 --echo # Test crash recovery with uncommitted transactions on COMPLEX columns
 --echo #

--- a/mysql-test/suite/villagesql/startup/t/recovery_complex_index.test
+++ b/mysql-test/suite/villagesql/startup/t/recovery_complex_index.test
@@ -1,3 +1,8 @@
+# Start from a freshly (gracefully) restarted server so this test's crash does
+# not discard information (like gcov test coverage) accumulated by preceding
+# tests sharing this mysqld.
+--source include/restart_mysqld.inc
+
 --echo #
 --echo # Test crash recovery with uncommitted transactions on indexed COMPLEX columns
 --echo #

--- a/scripts/villagesql_coverage.sh
+++ b/scripts/villagesql_coverage.sh
@@ -90,8 +90,10 @@ fi
 # --- 3. In-tree villagesql suite + unit tests ---------------------------------
 # The villagesql suite installs the in-tree (instrumented) test extensions, so
 # this is what produces the villagesql/sdk (dev) coverage folded into the delta.
+# --big-test includes the longer tests (e.g. villagesql/startup upgrade
+# scenarios) that are otherwise skipped, so their code paths are covered too.
 soft "In-tree villagesql suite" run_mtr \
-    --do-suite=villagesql --nounit-tests --parallel=auto --force
+    --do-suite=villagesql --nounit-tests --parallel=auto --force --big-test
 soft "villagesql unit tests" ctest --test-dir "$BUILD_DIR" -L villagesql
 
 # --- 4. Delta report ----------------------------------------------------------

--- a/villagesql/cmake/VsqlExtension.cmake
+++ b/villagesql/cmake/VsqlExtension.cmake
@@ -32,6 +32,17 @@ function(vsql_add_extension)
     ${ARGN}
   )
 
+  # Under gcov, instrument the extension .so so running its tests produces
+  # coverage.
+  set(_ext_cov_args "")
+  if(ENABLE_GCOV)
+    set(_ext_cov_args
+      "-DCMAKE_CXX_FLAGS=--coverage"
+      "-DCMAKE_C_FLAGS=--coverage"
+      "-DCMAKE_SHARED_LINKER_FLAGS=--coverage"
+      "-DCMAKE_EXE_LINKER_FLAGS=--coverage")
+  endif()
+
   ExternalProject_Add(${ARG_EXT_TARGET}
     SOURCE_DIR ${ARG_SOURCE_BASE}/${ARG_DIR_NAME}
     BINARY_DIR ${ARG_BINARY_BASE}/${ARG_DIR_NAME}-build
@@ -41,6 +52,7 @@ function(vsql_add_extension)
       "-DVillageSQLExtensionFramework_INCLUDE_DIR=${SDK_STAGING_DIR}/include-dev"
       "-DVillageSQL_VEB_INSTALL_DIR=${CMAKE_BINARY_DIR}/lib/veb"
       "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+      ${_ext_cov_args}
     DEPENDS sdk
     BUILD_ALWAYS ON
     INSTALL_COMMAND ""


### PR DESCRIPTION
Three gaps caused instrumented code to go unmeasured when running the coverage script:

- Crash-recovery tests (storage_recovery_alter, recovery_complex, recovery_complex_index) kill mysqld, which discards the .gcda data accumulated by every earlier test sharing that server. Each now starts with an explicit restart_mysqld.inc so only its own (already flushed) coverage is lost.

- The in-tree villagesql suite ran without --big-test, skipping the longer scenarios (e.g. villagesql/startup upgrade paths) entirely.

- Test extensions were built without instrumentation, so running the extension tests contributed no coverage. vsql_add_extension now forwards --coverage to the ExternalProject build when ENABLE_GCOV is set.

Extends #813 
