### PR TITLE
Extend unit tests

### DIFF
--- a/unittest/gunit/villagesql/CMakeLists.txt
+++ b/unittest/gunit/villagesql/CMakeLists.txt
@@ -23,6 +23,8 @@ SET(VILLAGESQL_UNIT_TESTS
   custom_indexes-t
   identifier_names-t
   semver-t
+  pending_action-t
+  storage_page_latch-t
   type_builder-t
   type_context-t
   type_descriptor-t

--- a/unittest/gunit/villagesql/CMakeLists.txt
+++ b/unittest/gunit/villagesql/CMakeLists.txt
@@ -22,8 +22,8 @@ SET(VILLAGESQL_UNIT_TESTS
   abi_v2_check-t
   custom_indexes-t
   identifier_names-t
-  semver-t
   pending_action-t
+  semver-t
   storage_page_latch-t
   type_builder-t
   type_context-t

--- a/unittest/gunit/villagesql/pending_action-t.cc
+++ b/unittest/gunit/villagesql/pending_action-t.cc
@@ -62,7 +62,7 @@ TEST_F(PendingActionTest, CreateVersionUpdatePopulatesFields) {
 
   EXPECT_EQ("2.0.0", a.target_version());
   EXPECT_EQ("abc123", a.target_veb_sha256());
-  // Stamped from the server clock; only its shape is predictable.
+  // Stamped from the server clock; only its format is predictable.
   EXPECT_THAT(a.requested_at(), ::testing::MatchesRegex(kTimestampPattern));
 
   // A freshly created action has not been attempted, so it carries no failure.
@@ -120,7 +120,7 @@ TEST_F(PendingActionTest, RoundTripWithFailure) {
   EXPECT_EQ(original.last_error_at(), parsed.last_error_at());
 }
 
-// An operator can edit this column by hand, so every malformed shape must be
+// An operator can edit this column by hand, so every malformed json must be
 // rejected with a message naming what is wrong.
 TEST_F(PendingActionTest, DeserializeRejectsMalformedInput) {
   struct {

--- a/unittest/gunit/villagesql/pending_action-t.cc
+++ b/unittest/gunit/villagesql/pending_action-t.cc
@@ -1,0 +1,175 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Tests for PendingAction, the deferred extension version update recorded in
+// villagesql.extensions.pending_action.
+//
+// The JSON wire format is private to the class: ReadFromTable/StoreToTable are
+// the only public way in and both need a TABLE. Serialize/Deserialize are
+// reachable here through the friend declaration in extensions.h, following the
+// same pattern VictionaryClient and TypeContext already use for their tests.
+//
+// Deserialize's rejection paths matter because the column holds free-form JSON
+// that an operator can edit by hand: a malformed cell must produce a precise
+// diagnostic rather than a half-populated action. The storage layer turns that
+// diagnostic into a failed-apply record (see read_from_table in extensions.cc),
+// so these messages reach the operator through PENDING_LAST_ERROR.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <optional>
+#include <string>
+
+#include "villagesql/schema/systable/extensions.h"
+
+namespace villagesql_unittest {
+
+using villagesql::PendingAction;
+
+class PendingActionTest : public ::testing::Test {
+ protected:
+  // "YYYY-MM-DDTHH:MM:SS.uuuuuuZ". Written with [0-9] rather than \d: gtest
+  // matches with POSIX extended regular expressions here, which have no \d.
+  static constexpr const char *kTimestampPattern =
+      R"([0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{6}Z)";
+
+  // Thin wrappers: the tests are the friend's members, so they reach the
+  // private wire format through these.
+  static std::string serialize(const PendingAction &a) { return a.Serialize(); }
+
+  static bool deserialize(const std::string &raw, PendingAction &out,
+                          std::string &error) {
+    return PendingAction::Deserialize(raw, out, error);
+  }
+};
+
+TEST_F(PendingActionTest, CreateVersionUpdatePopulatesFields) {
+  const PendingAction a = PendingAction::CreateVersionUpdate("2.0.0", "abc123");
+
+  EXPECT_EQ("2.0.0", a.target_version());
+  EXPECT_EQ("abc123", a.target_veb_sha256());
+  // Stamped from the server clock; only its shape is predictable.
+  EXPECT_THAT(a.requested_at(), ::testing::MatchesRegex(kTimestampPattern));
+
+  // A freshly created action has not been attempted, so it carries no failure.
+  EXPECT_FALSE(a.has_failure());
+  EXPECT_EQ("", a.last_error());
+  EXPECT_EQ("", a.last_error_at());
+}
+
+TEST_F(PendingActionTest, MarkFailedRecordsErrorAndTime) {
+  PendingAction a = PendingAction::CreateVersionUpdate("2.0.0", "abc123");
+
+  a.MarkFailed("target .so failed to load");
+
+  EXPECT_TRUE(a.has_failure());
+  EXPECT_EQ("target .so failed to load", a.last_error());
+  EXPECT_THAT(a.last_error_at(), ::testing::MatchesRegex(kTimestampPattern));
+
+  // The action still targets the same version: a failure annotates, it does
+  // not clear the request.
+  EXPECT_EQ("2.0.0", a.target_version());
+  EXPECT_EQ("abc123", a.target_veb_sha256());
+
+  // A later failure replaces the previous record rather than accumulating.
+  a.MarkFailed("second attempt failed");
+  EXPECT_EQ("second attempt failed", a.last_error());
+}
+
+TEST_F(PendingActionTest, RoundTripWithoutFailure) {
+  const PendingAction original =
+      PendingAction::CreateVersionUpdate("2.0.0", "deadbeef");
+
+  PendingAction parsed;
+  std::string error;
+  ASSERT_FALSE(deserialize(serialize(original), parsed, error)) << error;
+  EXPECT_EQ("", error);
+
+  EXPECT_EQ(original.target_version(), parsed.target_version());
+  EXPECT_EQ(original.target_veb_sha256(), parsed.target_veb_sha256());
+  EXPECT_EQ(original.requested_at(), parsed.requested_at());
+  EXPECT_FALSE(parsed.has_failure());
+}
+
+TEST_F(PendingActionTest, RoundTripWithFailure) {
+  PendingAction original = PendingAction::CreateVersionUpdate("3.1.4", "cafe");
+  original.MarkFailed("Pending action could not be read: boom");
+
+  PendingAction parsed;
+  std::string error;
+  ASSERT_FALSE(deserialize(serialize(original), parsed, error)) << error;
+
+  EXPECT_EQ("3.1.4", parsed.target_version());
+  EXPECT_EQ("cafe", parsed.target_veb_sha256());
+  EXPECT_TRUE(parsed.has_failure());
+  EXPECT_EQ(original.last_error(), parsed.last_error());
+  EXPECT_EQ(original.last_error_at(), parsed.last_error_at());
+}
+
+// An operator can edit this column by hand, so every malformed shape must be
+// rejected with a message naming what is wrong.
+TEST_F(PendingActionTest, DeserializeRejectsMalformedInput) {
+  struct {
+    const char *raw;
+    const char *expected_error;
+  } cases[] = {
+      {"not json at all", "JSON parse error"},
+      {"", "JSON parse error"},
+      {"[1, 2, 3]", "not an object"},
+      {"\"a string\"", "not an object"},
+      {R"({"target_veb_sha256": "abc"})",
+       "missing string field 'target_version'"},
+      {R"({"target_version": "2.0.0"})",
+       "missing string field 'target_veb_sha256'"},
+      // Present but of the wrong type is as bad as absent.
+      {R"({"target_version": 7, "target_veb_sha256": "abc"})",
+       "missing string field 'target_version'"},
+      {R"({"target_version": "2.0.0", "target_veb_sha256": null})",
+       "missing string field 'target_veb_sha256'"},
+      // requested_at is required too: an action always records when it was
+      // queued.
+      {R"({"target_version": "2.0.0", "target_veb_sha256": "abc"})",
+       "missing string field 'requested_at'"},
+  };
+
+  for (const auto &c : cases) {
+    PendingAction out;
+    std::string error;
+    EXPECT_TRUE(deserialize(c.raw, out, error)) << "raw: " << c.raw;
+    EXPECT_THAT(error, ::testing::HasSubstr(c.expected_error))
+        << "raw: " << c.raw;
+  }
+}
+
+// A hand-written object carrying exactly the three required fields parses;
+// the optional failure record is simply absent.
+TEST_F(PendingActionTest, DeserializeAcceptsHandWrittenObject) {
+  PendingAction out;
+  std::string error;
+  ASSERT_FALSE(deserialize(R"({"target_version": "2.0.0",
+                               "target_veb_sha256": "abc",
+                               "requested_at": "2026-01-02T03:04:05.000000Z"})",
+                           out, error))
+      << error;
+
+  EXPECT_EQ("2.0.0", out.target_version());
+  EXPECT_EQ("abc", out.target_veb_sha256());
+  EXPECT_EQ("2026-01-02T03:04:05.000000Z", out.requested_at());
+  EXPECT_FALSE(out.has_failure());
+}
+
+}  // namespace villagesql_unittest

--- a/unittest/gunit/villagesql/semver-t.cc
+++ b/unittest/gunit/villagesql/semver-t.cc
@@ -693,6 +693,104 @@ TEST_F(SemverTest, ParseStoredVersion) {
   std::string error;
   EXPECT_FALSE(v5.parse_schema_version("invalid", &error));
   EXPECT_FALSE(error.empty());
+
+  // A legacy-layout version (starts with a digit, so no code base prefix) that
+  // fails body validation is rejected through the legacy branch.
+  Semver v6;
+  error.clear();
+  EXPECT_FALSE(v6.parse_schema_version("1.2.x", &error));
+  EXPECT_THAT(error, ::testing::HasSubstr("must be numeric"));
+}
+
+// Error messages quote the offending input, and anything unprintable in it is
+// rendered as a readable escape rather than emitted raw. These strings end up
+// in the error log and in client-visible errors, so a stray control character
+// must not travel with them.
+TEST_F(SemverTest, ErrorMessagesEscapeUnprintableInput) {
+  struct {
+    const char *version;
+    char raw;
+    const char *expected_escape;
+  } cases[] = {
+      {"mysql-8.4_1.2.\t3", '\t', "\\t"},
+      {"mysql-8.4_1.2.a\nb", '\n', "\\n"},
+      {"mysql-8.4_1.2.a\rb", '\r', "\\r"},
+      {"mysql-8.4_1.2.a\\b", '\\', "\\\\"},
+      // Not printable and not one of the named escapes: rendered as hex.
+      {"mysql-8.4_1.2.a\x01"
+       "b",
+       '\x01', "\\x01"},
+  };
+
+  for (const auto &c : cases) {
+    Semver v;
+    std::string error;
+    EXPECT_FALSE(v.parse(c.version, &error)) << "version: " << c.version;
+    EXPECT_THAT(error, ::testing::HasSubstr("must be numeric"));
+    EXPECT_THAT(error, ::testing::HasSubstr(c.expected_escape));
+    // The raw character must not survive into the message. Skipped for the
+    // backslash case, where the escape is itself made of backslashes.
+    if (c.raw != '\\') {
+      EXPECT_EQ(std::string::npos, error.find(c.raw))
+          << "raw character leaked for version: " << c.version;
+    }
+  }
+}
+
+// A core component that is numeric but too large for the target type is
+// reported as out of range, distinct from the "must be numeric" case.
+TEST_F(SemverTest, ParseRejectsOutOfRangeComponent) {
+  Semver v;
+  std::string error;
+  EXPECT_FALSE(v.parse("mysql-8.4_99999999999999999999999.0.0", &error));
+  EXPECT_THAT(error, ::testing::HasSubstr("is out of range"));
+  EXPECT_FALSE(v.is_valid());
+}
+
+// A code base prefix with nothing after the separator.
+TEST_F(SemverTest, ParseRejectsEmptyVersionBody) {
+  Semver v;
+  std::string error;
+  EXPECT_FALSE(v.parse("mysql-8.4_", &error));
+  EXPECT_EQ("Empty version string", error);
+  EXPECT_FALSE(v.is_valid());
+}
+
+// Every known code base maps to its canonical static spelling. Percona code
+// bases were previously only reached via parse_schema_version.
+TEST_F(SemverTest, ParseAcceptsAllKnownCodeBases) {
+  const std::string_view code_bases[] = {
+      Semver::kMysql84CodeBase, Semver::kMysql97CodeBase,
+      Semver::kPercona84CodeBase, Semver::kPercona97CodeBase};
+
+  for (const std::string_view cb : code_bases) {
+    Semver v;
+    const std::string version = std::string(cb) + "_1.2.3";
+    std::string error;
+    ASSERT_TRUE(v.parse(version, &error)) << version << ": " << error;
+    EXPECT_EQ(cb, v.code_base());
+    EXPECT_EQ(version, v.to_string());
+  }
+}
+
+TEST_F(SemverTest, PrereleasePrecedenceIsSymmetric) {
+  const Semver num_low = from_components(1, 0, 0, Semver::kMysql84CodeBase,
+                                         std::vector<std::string>{"1"});
+  const Semver num_high = from_components(1, 0, 0, Semver::kMysql84CodeBase,
+                                          std::vector<std::string>{"2"});
+  const Semver alpha = from_components(1, 0, 0, Semver::kMysql84CodeBase,
+                                       std::vector<std::string>{"alpha"});
+  const Semver beta = from_components(1, 0, 0, Semver::kMysql84CodeBase,
+                                      std::vector<std::string>{"beta"});
+
+  // Numeric identifiers compare numerically
+  EXPECT_TRUE(num_low < num_high);
+
+  // A numeric identifier has lower precedence than an alphanumeric one
+  EXPECT_TRUE(num_high < alpha);
+
+  // Alphanumeric identifiers compare lexically
+  EXPECT_TRUE(alpha < beta);
 }
 
 }  // namespace villagesql_unittest

--- a/unittest/gunit/villagesql/storage_page_latch-t.cc
+++ b/unittest/gunit/villagesql/storage_page_latch-t.cc
@@ -1,0 +1,86 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Argument validation in vef_storage_page_latch(), the preview storage ABI
+// entry point.
+//
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+#include <villagesql/abi/preview/storage.h>
+
+namespace villagesql_unittest {
+
+class StoragePageLatchTest : public ::testing::Test {
+ protected:
+  // Non-null addresses that must never be dereferenced on the paths below.
+  vef_storage_block_ref_t opaque_block() {
+    return static_cast<vef_storage_block_ref_t>(&m_block_placeholder);
+  }
+  vef_storage_mtr_ref_t opaque_mtr() {
+    return static_cast<vef_storage_mtr_ref_t>(&m_mtr_placeholder);
+  }
+
+  unsigned char m_block_placeholder = 0;
+  unsigned char m_mtr_placeholder = 0;
+};
+
+// A null block is rejected before anything is cast or dereferenced
+TEST_F(StoragePageLatchTest, RejectsNullBlock) {
+  char err[512] = {};
+  EXPECT_EQ(VEF_STORAGE_ERROR_INVALID_ARGUMENT,
+            vef_storage_page_latch(nullptr, 0, VEF_STORAGE_PAGE_LATCH_EXCLUSIVE,
+                                   opaque_mtr(), err, sizeof(err)));
+  EXPECT_STREQ("Invalid argument: block is null", err);
+}
+
+// A null mtr is rejected for the same reason: there is nothing to latch in.
+TEST_F(StoragePageLatchTest, RejectsNullMtr) {
+  char err[512] = {};
+  EXPECT_EQ(VEF_STORAGE_ERROR_INVALID_ARGUMENT,
+            vef_storage_page_latch(opaque_block(), 0,
+                                   VEF_STORAGE_PAGE_LATCH_EXCLUSIVE, nullptr,
+                                   err, sizeof(err)));
+  EXPECT_STREQ("Invalid argument: mtr_ref is null", err);
+}
+
+// When both are null the message names the block
+TEST_F(StoragePageLatchTest, BothNullReportsBlock) {
+  char err[512] = {};
+  EXPECT_EQ(VEF_STORAGE_ERROR_INVALID_ARGUMENT,
+            vef_storage_page_latch(nullptr, 0, VEF_STORAGE_PAGE_LATCH_EXCLUSIVE,
+                                   nullptr, err, sizeof(err)));
+  EXPECT_STREQ("Invalid argument: block is null", err);
+}
+
+// The error buffer is optional: a caller that does not want the message can
+// pass nullptr, or a zero length, and still gets the status code.
+TEST_F(StoragePageLatchTest, ToleratesNullErrorBuffer) {
+  EXPECT_EQ(VEF_STORAGE_ERROR_INVALID_ARGUMENT,
+            vef_storage_page_latch(nullptr, 0, VEF_STORAGE_PAGE_LATCH_EXCLUSIVE,
+                                   nullptr, nullptr, 0));
+
+  // A non-null buffer with zero length must not be written to either.
+  char err[8] = "untouch";
+  EXPECT_EQ(VEF_STORAGE_ERROR_INVALID_ARGUMENT,
+            vef_storage_page_latch(nullptr, 0, VEF_STORAGE_PAGE_LATCH_EXCLUSIVE,
+                                   nullptr, err, 0));
+  EXPECT_STREQ("untouch", err);
+}
+
+}  // namespace villagesql_unittest

--- a/unittest/gunit/villagesql/storage_page_latch-t.cc
+++ b/unittest/gunit/villagesql/storage_page_latch-t.cc
@@ -16,7 +16,6 @@
 
 // Argument validation in vef_storage_page_latch(), the preview storage ABI
 // entry point.
-//
 
 #include <gtest/gtest.h>
 

--- a/villagesql/schema/systable/extensions.h
+++ b/villagesql/schema/systable/extensions.h
@@ -26,6 +26,11 @@
 // Forward declarations
 struct TABLE;
 
+// Forward declarations for friend classes
+namespace villagesql_unittest {
+class PendingActionTest;
+}
+
 namespace villagesql {
 
 // Forward declaration for TableTraits
@@ -106,6 +111,9 @@ class PendingAction {
   std::string Serialize() const;
   static bool Deserialize(const std::string &raw, PendingAction &out,
                           std::string &error_message);
+
+  // Friend classes
+  friend class villagesql_unittest::PendingActionTest;
 
   // Internal layout is private. Field names and JSON shape may change
   // without breaking callers as long as the public getters keep returning


### PR DESCRIPTION
Add unittest/gunit/villagesql/pending_action-t.cc covering the deferred extension version update stored in villagesql.extensions.pending_action.

Serialize/Deserialize are private, so extensions.h gains a friend declaration for villagesql_unittest::PendingActionTest, the same pattern VictionaryClient and TypeContext already use.

Extend semver-t.cc with cases for unprintable characters escaped in error messages, out-of-range core components, an empty version body.

Closes #961