### PR TITLE
Standardize encodings - Normalization lib

### DIFF
--- a/unittest/gunit/villagesql/CMakeLists.txt
+++ b/unittest/gunit/villagesql/CMakeLists.txt
@@ -21,6 +21,7 @@ SET(VILLAGESQL_UNIT_TESTS
   abi_v1_check-t
   abi_v2_check-t
   custom_indexes-t
+  identifier_names-t
   semver-t
   type_builder-t
   type_context-t

--- a/unittest/gunit/villagesql/identifier_names-t.cc
+++ b/unittest/gunit/villagesql/identifier_names-t.cc
@@ -1,0 +1,158 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+#include "mysql/strings/m_ctype.h"
+#include "sql/mysqld.h"
+#include "sql/mysqld_cs.h"
+#include "villagesql/schema/identifier_names.h"
+
+namespace villagesql_unittest {
+
+using namespace villagesql;
+
+class IdentifierNamesTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    original_lctn_ = test_get_lower_case_table_names();
+
+    system_charset_info = &my_charset_utf8mb3_general_ci;
+  }
+
+  void TearDown() override { test_set_lower_case_table_names(original_lctn_); }
+
+  int original_lctn_;
+};
+
+TEST_F(IdentifierNamesTest, FsNameCollationFollowsLowerCaseTableNames) {
+  test_set_lower_case_table_names(0);
+  EXPECT_EQ(fs_name_collation(), &my_charset_utf8mb3_bin);
+
+  for (int setting : {1, 2}) {
+    test_set_lower_case_table_names(setting);
+    EXPECT_EQ(fs_name_collation(), &my_charset_utf8mb3_tolower_ci);
+  }
+}
+
+TEST_F(IdentifierNamesTest, DatabaseAndTableNamesFollowLowerCaseTableNames) {
+  test_set_lower_case_table_names(0);
+  EXPECT_EQ(canonical_database_name("MyDB"), "MyDB");
+  EXPECT_EQ(canonical_table_name("MyTable"), "MyTable");
+
+  for (int setting : {1, 2}) {
+    test_set_lower_case_table_names(setting);
+    EXPECT_EQ(canonical_database_name("MyDB"), "mydb");
+    EXPECT_EQ(canonical_table_name("MyTable"), "mytable");
+  }
+}
+
+TEST_F(IdentifierNamesTest, ColumnNamesAlwaysLowercased) {
+  for (int setting : {0, 1, 2}) {
+    test_set_lower_case_table_names(setting);
+    EXPECT_EQ(canonical_column_name("MyColumn"), "mycolumn");
+    EXPECT_EQ(canonical_column_name("mycolumn"), "mycolumn");
+  }
+}
+
+TEST_F(IdentifierNamesTest, TypeIndexExtensionNamesAlwaysLowercased) {
+  for (int setting : {0, 1, 2}) {
+    test_set_lower_case_table_names(setting);
+    EXPECT_EQ(canonical_type_name("COMPLEX"), "complex");
+    EXPECT_EQ(canonical_index_name("MyIndex"), "myindex");
+    EXPECT_EQ(canonical_extension_name("MyExt"), "myext");
+  }
+}
+
+// Canonical forms must byte-match the data dictionary's lowercasing, or
+// lookups against DD-stored names miss. 
+TEST_F(IdentifierNamesTest, LoweringMatchesDataDictionary) {
+
+  // U+1E9E (capital sharp S) is a case where utf8mb3 lowering (unchanged)
+  // differs from utf8mb4_0900 case folding (maps to U+00DF).
+  const std::string capital_sharp_s = "STRA\xE1\xBA\x9E\x45";  // STRAẞE
+  const std::string dd_lowered = "stra\xE1\xBA\x9E\x65";       // straẞe
+
+  for (int setting : {1, 2}) {
+    test_set_lower_case_table_names(setting);
+    EXPECT_EQ(canonical_database_name(capital_sharp_s), dd_lowered);
+    EXPECT_EQ(canonical_table_name(capital_sharp_s), dd_lowered);
+  }
+
+  // Column, type, and index names are lowercased regardless of setting.
+  EXPECT_EQ(canonical_column_name(capital_sharp_s), dd_lowered);
+  EXPECT_EQ(canonical_type_name(capital_sharp_s), dd_lowered);
+  EXPECT_EQ(canonical_index_name(capital_sharp_s), dd_lowered);
+}
+
+// Lowercasing preserves accents: café and cafe are distinct identifiers.
+TEST_F(IdentifierNamesTest, AccentsPreserved) {
+  const std::string cafe_upper = "CAF\xC3\x89";  // CAFÉ
+  const std::string cafe_lower = "caf\xC3\xA9";  // café
+
+  EXPECT_EQ(canonical_column_name(cafe_upper), cafe_lower);
+  EXPECT_FALSE(column_names_equal(cafe_lower, "cafe"));
+  EXPECT_TRUE(column_names_equal(cafe_upper, cafe_lower));
+
+  test_set_lower_case_table_names(2);
+  EXPECT_EQ(canonical_table_name(cafe_upper), cafe_lower);
+  EXPECT_FALSE(table_names_equal(cafe_lower, "cafe"));
+}
+
+// ß and ss compare equal under utf8mb4_0900_ai_ci; identifier comparisons
+// must keep them distinct.
+TEST_F(IdentifierNamesTest, SharpSDistinctFromSs) {
+  const std::string strasse_sharp = "stra\xC3\x9F\x65";  // straße
+
+  EXPECT_FALSE(column_names_equal(strasse_sharp, "strasse"));
+  EXPECT_FALSE(type_names_equal(strasse_sharp, "strasse"));
+
+  for (int setting : {0, 2}) {
+    test_set_lower_case_table_names(setting);
+    EXPECT_FALSE(database_names_equal(strasse_sharp, "strasse"));
+    EXPECT_FALSE(table_names_equal(strasse_sharp, "strasse"));
+  }
+
+  // ß is already lowercase; canonicalization leaves it unchanged.
+  EXPECT_EQ(canonical_column_name(strasse_sharp), strasse_sharp);
+}
+
+TEST_F(IdentifierNamesTest, EqualityHelpers) {
+  test_set_lower_case_table_names(0);
+  EXPECT_FALSE(database_names_equal("MyDB", "mydb"));
+  EXPECT_FALSE(table_names_equal("MyTable", "mytable"));
+  EXPECT_TRUE(database_names_equal("MyDB", "MyDB"));
+
+  test_set_lower_case_table_names(2);
+  EXPECT_TRUE(database_names_equal("MyDB", "mydb"));
+  EXPECT_TRUE(table_names_equal("MyTable", "mytable"));
+
+  // Case-insensitive regardless of lower_case_table_names.
+  for (int setting : {0, 2}) {
+    test_set_lower_case_table_names(setting);
+    EXPECT_TRUE(column_names_equal("Price", "PRICE"));
+    EXPECT_TRUE(index_names_equal("Idx1", "IDX1"));
+    EXPECT_TRUE(type_names_equal("Complex", "COMPLEX"));
+    EXPECT_TRUE(extension_names_equal("MyExt", "MYEXT"));
+    EXPECT_FALSE(column_names_equal("price", "prices"));
+  }
+}
+
+TEST_F(IdentifierNamesTest, TypeParameterCollation) {
+  EXPECT_EQ(type_parameter_collation(), &my_charset_utf8mb4_0900_ai_ci);
+}
+
+}  // namespace villagesql_unittest

--- a/unittest/gunit/villagesql/identifier_names-t.cc
+++ b/unittest/gunit/villagesql/identifier_names-t.cc
@@ -78,9 +78,8 @@ TEST_F(IdentifierNamesTest, TypeIndexExtensionNamesAlwaysLowercased) {
 }
 
 // Canonical forms must byte-match the data dictionary's lowercasing, or
-// lookups against DD-stored names miss. 
+// lookups against DD-stored names miss.
 TEST_F(IdentifierNamesTest, LoweringMatchesDataDictionary) {
-
   // U+1E9E (capital sharp S) is a case where utf8mb3 lowering (unchanged)
   // differs from utf8mb4_0900 case folding (maps to U+00DF).
   const std::string capital_sharp_s = "STRA\xE1\xBA\x9E\x45";  // STRAẞE

--- a/unittest/gunit/villagesql/identifier_names-t.cc
+++ b/unittest/gunit/villagesql/identifier_names-t.cc
@@ -20,6 +20,7 @@
 #include "sql/mysqld.h"
 #include "sql/mysqld_cs.h"
 #include "villagesql/schema/identifier_names.h"
+#include "villagesql/schema/systable/helpers.h"
 
 namespace villagesql_unittest {
 

--- a/villagesql/schema/CMakeLists.txt
+++ b/villagesql/schema/CMakeLists.txt
@@ -14,6 +14,7 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 SET(VILLAGESQL_SCHEMA_SOURCES
+  identifier_names.cc
   schema_manager.cc
   util.cc
   upgrade.cc

--- a/villagesql/schema/identifier_names.cc
+++ b/villagesql/schema/identifier_names.cc
@@ -1,0 +1,98 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "villagesql/schema/identifier_names.h"
+
+#include "mysql/strings/m_ctype.h"
+#include "sql/dd/impl/types/object_table_definition_impl.h"
+#include "sql/mysqld.h"
+#include "sql/mysqld_cs.h"
+#include "sql/strfunc.h"
+
+namespace villagesql {
+
+const CHARSET_INFO *fs_name_collation() {
+  return dd::Object_table_definition_impl::fs_name_collation();
+}
+
+std::string canonical_database_name(const std::string &name) {
+  if (::lower_case_table_names == 0) {
+    return name;
+  }
+  return casedn(fs_name_collation(), name);
+}
+
+std::string canonical_table_name(const std::string &name) {
+  if (::lower_case_table_names == 0) {
+    return name;
+  }
+  return casedn(fs_name_collation(), name);
+}
+
+std::string canonical_column_name(const std::string &name) {
+  // utf8mb3 lowering, not utf8mb4_0900 folding: they differ for characters
+  // like U+1E9E, and the DD uses utf8mb3 (dd::tables::Columns).
+  return casedn(&my_charset_utf8mb3_tolower_ci, name);
+}
+
+std::string canonical_extension_name(const std::string &name) {
+  return casedn(system_charset_info, name);
+}
+
+std::string canonical_type_name(const std::string &name) {
+  return casedn(&my_charset_utf8mb3_tolower_ci, name);
+}
+
+std::string canonical_index_name(const std::string &name) {
+  // Index names ignore lower_case_table_names (see dd::tables::Indexes).
+  return casedn(&my_charset_utf8mb3_tolower_ci, name);
+}
+
+bool database_names_equal(const std::string &a, const std::string &b) {
+  return canonical_database_name(a) == canonical_database_name(b);
+}
+
+bool table_names_equal(const std::string &a, const std::string &b) {
+  return canonical_table_name(a) == canonical_table_name(b);
+}
+
+bool column_names_equal(const std::string &a, const std::string &b) {
+  return canonical_column_name(a) == canonical_column_name(b);
+}
+
+bool index_names_equal(const std::string &a, const std::string &b) {
+  return canonical_index_name(a) == canonical_index_name(b);
+}
+
+bool type_names_equal(const std::string &a, const std::string &b) {
+  return canonical_type_name(a) == canonical_type_name(b);
+}
+
+bool extension_names_equal(const std::string &a, const std::string &b) {
+  return canonical_extension_name(a) == canonical_extension_name(b);
+}
+
+const CHARSET_INFO *type_parameter_collation() {
+  return &my_charset_utf8mb4_0900_ai_ci;
+}
+
+void test_set_lower_case_table_names(int value) {
+  ::lower_case_table_names = value;
+}
+
+int test_get_lower_case_table_names() { return ::lower_case_table_names; }
+
+}  // namespace villagesql

--- a/villagesql/schema/identifier_names.cc
+++ b/villagesql/schema/identifier_names.cc
@@ -89,10 +89,4 @@ const CHARSET_INFO *type_parameter_collation() {
   return &my_charset_utf8mb4_0900_ai_ci;
 }
 
-void test_set_lower_case_table_names(int value) {
-  ::lower_case_table_names = value;
-}
-
-int test_get_lower_case_table_names() { return ::lower_case_table_names; }
-
 }  // namespace villagesql

--- a/villagesql/schema/identifier_names.h
+++ b/villagesql/schema/identifier_names.h
@@ -1,0 +1,73 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef VILLAGESQL_SCHEMA_IDENTIFIER_NAMES_H_
+#define VILLAGESQL_SCHEMA_IDENTIFIER_NAMES_H_
+
+#include <string>
+
+struct CHARSET_INFO;
+
+namespace villagesql {
+
+// Single home for identifier collation rules. System tables store names
+// as entered; canonical forms are for in-memory keys and comparisons only.
+// Identifiers never contain characters outside utf8mb3 (the parser converts
+// them to the system charset), so utf8mb3 case folding always applies.
+
+// Collation for database/table names; delegates to the DD's
+// Object_table_definition_impl::fs_name_collation().
+const CHARSET_INFO *fs_name_collation();
+
+// Database names: follow lower_case_table_names (like MySQL DD)
+std::string canonical_database_name(const std::string &name);
+
+// Table names: follow lower_case_table_names (like MySQL DD)
+std::string canonical_table_name(const std::string &name);
+
+// Column names: always case-insensitive (like MySQL DD)
+std::string canonical_column_name(const std::string &name);
+
+// Extension names: always case-insensitive (like plugin names)
+std::string canonical_extension_name(const std::string &name);
+
+// Type names: always case-insensitive (like SQL type names)
+std::string canonical_type_name(const std::string &name);
+
+// Index names: always case-insensitive (like MySQL DD)
+std::string canonical_index_name(const std::string &name);
+
+// Equality per MySQL identifier rules. Use these instead of ad-hoc
+// my_strcasecmp calls.
+bool database_names_equal(const std::string &a, const std::string &b);
+bool table_names_equal(const std::string &a, const std::string &b);
+bool column_names_equal(const std::string &a, const std::string &b);
+bool index_names_equal(const std::string &a, const std::string &b);
+bool type_names_equal(const std::string &a, const std::string &b);
+bool extension_names_equal(const std::string &a, const std::string &b);
+
+// Collation canonicalizing custom-type parameter strings. Parameters are not
+// MySQL identifiers; the canonical form is embedded in stored
+// type_parameters JSON, so this must stay stable.
+const CHARSET_INFO *type_parameter_collation();
+
+// Test-only access to the lower_case_table_names global.
+void test_set_lower_case_table_names(int value);
+int test_get_lower_case_table_names();
+
+}  // namespace villagesql
+
+#endif  // VILLAGESQL_SCHEMA_IDENTIFIER_NAMES_H_

--- a/villagesql/schema/identifier_names.h
+++ b/villagesql/schema/identifier_names.h
@@ -28,8 +28,9 @@ namespace villagesql {
 // Identifiers never contain characters outside utf8mb3 (the parser converts
 // them to the system charset), so utf8mb3 case folding always applies.
 
-// Collation for database/table names, from the DD's fs_name_collation().
-const CHARSET_INFO *get_identifier_charset();
+// Collation for database/table names; delegates to the DD's
+// Object_table_definition_impl::fs_name_collation().
+const CHARSET_INFO *fs_name_collation();
 
 // Database names: follow lower_case_table_names like MySQL DD
 std::string canonical_database_name(const std::string &name);

--- a/villagesql/schema/identifier_names.h
+++ b/villagesql/schema/identifier_names.h
@@ -28,26 +28,25 @@ namespace villagesql {
 // Identifiers never contain characters outside utf8mb3 (the parser converts
 // them to the system charset), so utf8mb3 case folding always applies.
 
-// Collation for database/table names; delegates to the DD's
-// Object_table_definition_impl::fs_name_collation().
-const CHARSET_INFO *fs_name_collation();
+// Collation for database/table names, from the DD's fs_name_collation().
+const CHARSET_INFO *get_identifier_charset();
 
-// Database names: follow lower_case_table_names (like MySQL DD)
+// Database names: follow lower_case_table_names like MySQL DD
 std::string canonical_database_name(const std::string &name);
 
-// Table names: follow lower_case_table_names (like MySQL DD)
+// Table names: follow lower_case_table_names like MySQL DD
 std::string canonical_table_name(const std::string &name);
 
-// Column names: always case-insensitive (like MySQL DD)
+// Column names: always case-insensitive like MySQL DD
 std::string canonical_column_name(const std::string &name);
 
-// Extension names: always case-insensitive (like plugin names)
+// Extension names: always case-insensitive like plugin names
 std::string canonical_extension_name(const std::string &name);
 
-// Type names: always case-insensitive (like SQL type names)
+// Type names: always case-insensitive like SQL type names
 std::string canonical_type_name(const std::string &name);
 
-// Index names: always case-insensitive (like MySQL DD)
+// Index names: always case-insensitive like MySQL DD
 std::string canonical_index_name(const std::string &name);
 
 // Equality per MySQL identifier rules. Use these instead of ad-hoc

--- a/villagesql/schema/identifier_names.h
+++ b/villagesql/schema/identifier_names.h
@@ -64,10 +64,6 @@ bool extension_names_equal(const std::string &a, const std::string &b);
 // type_parameters JSON, so this must stay stable.
 const CHARSET_INFO *type_parameter_collation();
 
-// Test-only access to the lower_case_table_names global.
-void test_set_lower_case_table_names(int value);
-int test_get_lower_case_table_names();
-
 }  // namespace villagesql
 
 #endif  // VILLAGESQL_SCHEMA_IDENTIFIER_NAMES_H_


### PR DESCRIPTION
## Description

This is the second ([first](https://github.com/villagesql/villagesql-server/pull/937)) of the standardizing encodings PRs. Introducing the canonicalization library - the single place where identifier collation rules are present for VillageSQL system tables. It includes canonicalization (normalization) functions and comparison helpers for database, table, column, index, type and extension names. It also includes type_parameter_collation(), which returns the collation used to canonicalize custom type parameter strings. And unit tests.

No existing code changes or behavior changes. 

Note: Canonicalization and normalization are synonymous here. The new functions are named canonical_* so they don't collide with the existing normalize_* functions, which are in the same namespace, and I like canonical better.

## Related Issue

Part of the fixes for #811

## How was this tested?

Added new unit tests that verify the canonicalization rules at all lower_case_table_names settings.