### PR TITLE
Cleanup script utils

### DIFF
--- a/scripts/villagesql_coverage.sh
+++ b/scripts/villagesql_coverage.sh
@@ -31,7 +31,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
+source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
 
 BUILD_DIR="${1:?Usage: $0 <build_dir> [server_mtr_args...]}"
 shift || true

--- a/scripts/villagesql_coverage.sh
+++ b/scripts/villagesql_coverage.sh
@@ -30,7 +30,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
-source "$SCRIPT_DIR/vsql_script_utils.sh"
+
+source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
 
 BUILD_DIR="${1:?Usage: $0 <build_dir> [server_mtr_args...]}"
 shift || true

--- a/villagesql/bld_tools/build_bundled_extensions.sh
+++ b/villagesql/bld_tools/build_bundled_extensions.sh
@@ -31,8 +31,10 @@ INCLUDE_UNBUNDLED="${5:-no}"
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
-source "$SOURCE_DIR/scripts/vsql_script_utils.sh"
+
 EXTENSIONS_LIST="$SOURCE_DIR/villagesql/dev_server/bundled_extensions.txt"
+
+source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
 
 case "$INCLUDE_UNBUNDLED" in
     1|yes) INCLUDE_UNBUNDLED=yes ;;

--- a/villagesql/bld_tools/build_bundled_extensions.sh
+++ b/villagesql/bld_tools/build_bundled_extensions.sh
@@ -34,7 +34,7 @@ SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
 
 EXTENSIONS_LIST="$SOURCE_DIR/villagesql/dev_server/bundled_extensions.txt"
 
-source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
+source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
 
 case "$INCLUDE_UNBUNDLED" in
     1|yes) INCLUDE_UNBUNDLED=yes ;;

--- a/villagesql/bld_tools/build_ci.sh
+++ b/villagesql/bld_tools/build_ci.sh
@@ -16,12 +16,13 @@
 set -euo pipefail
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCRIPTS_DIR="$(cd "$TOOLS_DIR/../scripts" && pwd)"
-source "$SCRIPTS_DIR/vsql_script_utils.sh"
+SOURCE_DIR="${SOURCE_DIR:-$(cd "$TOOLS_DIR/../.." && pwd)}"
 
-SOURCE_DIR="${SOURCE_DIR:-$(cd "$SCRIPTS_DIR/../.." && pwd)}"
 BUILD_DIR="${BUILD_DIR:-$(cd "$SOURCE_DIR/.." && pwd)/build}"
 BUILD_TYPE="${BUILD_TYPE:-release}"
+
+source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
+
 PARALLEL_JOBS="${PARALLEL_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo "4")}"
 
 log_step "VillageSQL CI Build"

--- a/villagesql/bld_tools/build_ci.sh
+++ b/villagesql/bld_tools/build_ci.sh
@@ -21,7 +21,7 @@ SOURCE_DIR="${SOURCE_DIR:-$(cd "$TOOLS_DIR/../.." && pwd)}"
 BUILD_DIR="${BUILD_DIR:-$(cd "$SOURCE_DIR/.." && pwd)/build}"
 BUILD_TYPE="${BUILD_TYPE:-release}"
 
-source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
+source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
 
 PARALLEL_JOBS="${PARALLEL_JOBS:-$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo "4")}"
 

--- a/villagesql/bld_tools/build_info.sh
+++ b/villagesql/bld_tools/build_info.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Copyright (c) 2026 VillageSQL Contributors
+# Shared utilities for VillageSQL build scripts.
+# Source this file; do not execute directly.
+#
+# Usage:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/build_info.sh"
+
+# Parse VSQL_VERSION file from <source_dir>.
+# Sets VSQL_MAJOR, VSQL_MINOR, VSQL_PATCH, VSQL_PRE, VSQL_VERSION.
+vsql_parse_version() {
+    local source_dir="$1"
+    local f="$source_dir/VSQL_VERSION"
+    [[ -f "$f" ]] || die "VSQL_VERSION file not found at $f"
+    VSQL_CODE_BASE=$(grep "^VSQL_CODE_BASE=" "$f" | cut -d'=' -f2)
+    VSQL_MAJOR=$(grep "^VSQL_MAJOR_VERSION=" "$f" | cut -d'=' -f2)
+    VSQL_MINOR=$(grep "^VSQL_MINOR_VERSION=" "$f" | cut -d'=' -f2)
+    VSQL_PATCH=$(grep "^VSQL_PATCH_VERSION=" "$f" | cut -d'=' -f2)
+    # VSQL_PRE_RELEASE_VERSION env var overrides the file (set to "" to strip the suffix)
+    if [[ "${VSQL_PRE_RELEASE_VERSION+set}" == "set" ]]; then
+        VSQL_PRE="$VSQL_PRE_RELEASE_VERSION"
+    else
+        VSQL_PRE=$(grep "^VSQL_PRE_RELEASE_VERSION=" "$f" | cut -d'=' -f2)
+    fi
+    VSQL_VERSION="${VSQL_MAJOR}.${VSQL_MINOR}.${VSQL_PATCH}"
+    if [[ -n "$VSQL_PRE" ]]; then
+        VSQL_VERSION="${VSQL_VERSION}-${VSQL_PRE}"
+    fi
+}
+
+# Set PLATFORM (linux|macos) and ARCH (x86_64|aarch64|arm64) for this machine.
+vsql_platform_info() {
+    PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    [[ "$PLATFORM" == "darwin" ]] && PLATFORM="macos"
+    ARCH="$(uname -m)"
+}

--- a/villagesql/bld_tools/checkout_bundled_extensions.sh
+++ b/villagesql/bld_tools/checkout_bundled_extensions.sh
@@ -22,8 +22,10 @@ INCLUDE_UNBUNDLED="${3:-no}"
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
-source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
+
 EXTENSIONS_LIST="$SOURCE_DIR/villagesql/dev_server/bundled_extensions.txt"
+
+source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
 
 case "$INCLUDE_UNBUNDLED" in
     1|yes) INCLUDE_UNBUNDLED=yes ;;

--- a/villagesql/bld_tools/checkout_bundled_extensions.sh
+++ b/villagesql/bld_tools/checkout_bundled_extensions.sh
@@ -25,7 +25,7 @@ SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
 
 EXTENSIONS_LIST="$SOURCE_DIR/villagesql/dev_server/bundled_extensions.txt"
 
-source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
+source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
 
 case "$INCLUDE_UNBUNDLED" in
     1|yes) INCLUDE_UNBUNDLED=yes ;;

--- a/villagesql/bld_tools/get_sdk.sh
+++ b/villagesql/bld_tools/get_sdk.sh
@@ -9,7 +9,8 @@ BUILD_DIR="${1:?Usage: $0 <build_dir>}"
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
-source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
+
+source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
 vsql_parse_version "$SOURCE_DIR"
 
 echo "$BUILD_DIR/villagesql-extension-sdk-${VSQL_VERSION}"

--- a/villagesql/bld_tools/get_sdk.sh
+++ b/villagesql/bld_tools/get_sdk.sh
@@ -10,7 +10,9 @@ BUILD_DIR="${1:?Usage: $0 <build_dir>}"
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
 
-source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
+# Because build_info expects die() to be available.
+source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
+source "$SOURCE_DIR/villagesql/bld_tools/build_info.sh"
 vsql_parse_version "$SOURCE_DIR"
 
 echo "$BUILD_DIR/villagesql-extension-sdk-${VSQL_VERSION}"

--- a/villagesql/bld_tools/include_bundled_extensions.sh
+++ b/villagesql/bld_tools/include_bundled_extensions.sh
@@ -18,7 +18,7 @@ SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
 
 EXTENSIONS_LIST="$SOURCE_DIR/villagesql/dev_server/bundled_extensions.txt"
 
-source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
+source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
 
 if [[ ! -f "$EXTENSIONS_LIST" ]]; then
     log_error "Extensions list not found: $EXTENSIONS_LIST"

--- a/villagesql/bld_tools/include_bundled_extensions.sh
+++ b/villagesql/bld_tools/include_bundled_extensions.sh
@@ -15,8 +15,10 @@ VEB_SRC_DIR="${2:?Usage: $0 <dst_dir> <veb_src_dir>}"
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
-source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
+
 EXTENSIONS_LIST="$SOURCE_DIR/villagesql/dev_server/bundled_extensions.txt"
+
+source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
 
 if [[ ! -f "$EXTENSIONS_LIST" ]]; then
     log_error "Extensions list not found: $EXTENSIONS_LIST"

--- a/villagesql/bld_tools/package_dev_server.sh
+++ b/villagesql/bld_tools/package_dev_server.sh
@@ -18,13 +18,13 @@
 set -e
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCRIPTS_DIR="$(cd "$TOOLS_DIR/../scripts" && pwd)"
-source "$SCRIPTS_DIR/vsql_script_utils.sh"
-
 SOURCE_DIR="${SOURCE_DIR:-$(cd "$TOOLS_DIR/../.." && pwd)}"
+≈
 BUILD_DIR="${BUILD_DIR:-$(cd "$SOURCE_DIR/.." && pwd)/build}"
 OUTPUT_DIR="${OUTPUT_DIR:-$PWD}"
 STAGING_DIR="${TMPDIR:-/tmp}/villagesql_dev_staging_$$"
+
+source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
 
 cleanup() {
     if [[ -d "$STAGING_DIR" ]]; then
@@ -36,6 +36,7 @@ cleanup() {
 
 trap cleanup EXIT
 
+# From vsql_script_utils
 vsql_parse_version "$SOURCE_DIR"
 vsql_platform_info
 

--- a/villagesql/bld_tools/package_dev_server.sh
+++ b/villagesql/bld_tools/package_dev_server.sh
@@ -19,12 +19,12 @@ set -e
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="${SOURCE_DIR:-$(cd "$TOOLS_DIR/../.." && pwd)}"
-≈
+
 BUILD_DIR="${BUILD_DIR:-$(cd "$SOURCE_DIR/.." && pwd)/build}"
 OUTPUT_DIR="${OUTPUT_DIR:-$PWD}"
 STAGING_DIR="${TMPDIR:-/tmp}/villagesql_dev_staging_$$"
 
-source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
+source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
 
 cleanup() {
     if [[ -d "$STAGING_DIR" ]]; then
@@ -36,7 +36,7 @@ cleanup() {
 
 trap cleanup EXIT
 
-# From vsql_script_utils
+source "$SOURCE_DIR/villagesql/bld_tools/build_info.sh"
 vsql_parse_version "$SOURCE_DIR"
 vsql_platform_info
 

--- a/villagesql/bld_tools/test_extension_vebs.sh
+++ b/villagesql/bld_tools/test_extension_vebs.sh
@@ -25,7 +25,7 @@ set -e
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
-source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
+source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
 
 BUILD_DIR="${1:?Usage: $0 <build_dir> <extension_clones_dir>}"
 EXTENSION_CLONES_DIR="${2:?Usage: $0 <build_dir> <extension_clones_dir>}"

--- a/villagesql/bld_tools/test_extension_vebs.sh
+++ b/villagesql/bld_tools/test_extension_vebs.sh
@@ -25,7 +25,8 @@ set -e
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
-source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
+
+source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
 
 BUILD_DIR="${1:?Usage: $0 <build_dir> <extension_clones_dir>}"
 EXTENSION_CLONES_DIR="${2:?Usage: $0 <build_dir> <extension_clones_dir>}"

--- a/villagesql/bld_tools/workflow_skips_build.sh
+++ b/villagesql/bld_tools/workflow_skips_build.sh
@@ -35,19 +35,19 @@
 
 set -euo pipefail
 
-TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-
-SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
-source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
-
-EXEMPT_FILE="${EXEMPT_FILE:-$TOOLS_DIR/workflow_skip_paths.txt}"
-EVENT_NAME="${1:-}"
-BASE_REF="${2:-}"
-
 # stdout is reserved for the verdict token so the caller can capture it cleanly.
 # The log_* helpers write to stdout, so redirect fd 1 to stderr for the whole
 # script and keep the original stdout on fd 3 for emit() alone.
 exec 3>&1 1>&2
+
+TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
+source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
+
+EXEMPT_FILE="${EXEMPT_FILE:-$TOOLS_DIR/workflow_skip_paths.txt}"
+EVENT_NAME="${1:-}"
+BASE_REF="${2:-}"
 
 # Print the verdict token on the reserved stdout and exit.
 emit() {

--- a/villagesql/bld_tools/workflow_skips_build.sh
+++ b/villagesql/bld_tools/workflow_skips_build.sh
@@ -36,8 +36,9 @@
 set -euo pipefail
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCRIPTS_DIR="$(cd "$TOOLS_DIR/../scripts" && pwd)"
-source "$SCRIPTS_DIR/vsql_script_utils.sh"
+
+SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
+source "$SOURCE_DIR/villagesql/bld_tools/vsql_script_utils.sh"
 
 EXEMPT_FILE="${EXEMPT_FILE:-$TOOLS_DIR/workflow_skip_paths.txt}"
 EVENT_NAME="${1:-}"

--- a/villagesql/scripts/vsql_script_utils.sh
+++ b/villagesql/scripts/vsql_script_utils.sh
@@ -18,32 +18,3 @@ log_warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 log_step()  { echo -e "${BLUE}==>${NC} $*"; }
 die()       { log_error "$*"; exit 1; }
-
-# Parse VSQL_VERSION file from <source_dir>.
-# Sets VSQL_MAJOR, VSQL_MINOR, VSQL_PATCH, VSQL_PRE, VSQL_VERSION.
-vsql_parse_version() {
-    local source_dir="$1"
-    local f="$source_dir/VSQL_VERSION"
-    [[ -f "$f" ]] || die "VSQL_VERSION file not found at $f"
-    VSQL_CODE_BASE=$(grep "^VSQL_CODE_BASE=" "$f" | cut -d'=' -f2)
-    VSQL_MAJOR=$(grep "^VSQL_MAJOR_VERSION=" "$f" | cut -d'=' -f2)
-    VSQL_MINOR=$(grep "^VSQL_MINOR_VERSION=" "$f" | cut -d'=' -f2)
-    VSQL_PATCH=$(grep "^VSQL_PATCH_VERSION=" "$f" | cut -d'=' -f2)
-    # VSQL_PRE_RELEASE_VERSION env var overrides the file (set to "" to strip the suffix)
-    if [[ "${VSQL_PRE_RELEASE_VERSION+set}" == "set" ]]; then
-        VSQL_PRE="$VSQL_PRE_RELEASE_VERSION"
-    else
-        VSQL_PRE=$(grep "^VSQL_PRE_RELEASE_VERSION=" "$f" | cut -d'=' -f2)
-    fi
-    VSQL_VERSION="${VSQL_MAJOR}.${VSQL_MINOR}.${VSQL_PATCH}"
-    if [[ -n "$VSQL_PRE" ]]; then
-        VSQL_VERSION="${VSQL_VERSION}-${VSQL_PRE}"
-    fi
-}
-
-# Set PLATFORM (linux|macos) and ARCH (x86_64|aarch64|arm64) for this machine.
-vsql_platform_info() {
-    PLATFORM="$(uname -s | tr '[:upper:]' '[:lower:]')"
-    [[ "$PLATFORM" == "darwin" ]] && PLATFORM="macos"
-    ARCH="$(uname -m)"
-}


### PR DESCRIPTION
## Description

Moves `scripts/vsql_script_utils.sh` `villagesql/scripts/vsql_script_utils.sh` and splits
build version and platform to a `villagesql/bld_tools/build_info.sh` script.

## Related Issue

Part of the Cleanup release-dev-server #595 effort.

## How was this tested?

Local script execution