### PR TITLE
Use JSON for build info

### DIFF
--- a/.github/workflows/extension-compat-suite.yml
+++ b/.github/workflows/extension-compat-suite.yml
@@ -70,18 +70,25 @@ jobs:
           EXTENSION_FILTER: ${{ inputs.extension_filter }}
           ABI_FILTER: ${{ inputs.abi_filter }}
         run: |
-          # Delegate all matrix logic to the script so it can be tested locally:
-          #   PLATFORM_FILTER=macos-arm64 ABI_FILTER=stable \
-          #     ./scripts/villagesql_build-compat-matrix.sh
-          mapfile -t MATRICES < <(./scripts/villagesql_build-compat-matrix.sh)
-          BUILD_MATRIX="${MATRICES[0]}"
-          TEST_MATRIX="${MATRICES[1]}"
+          # Matrix logic lives in villagesql/bld_matrix, so it can be run
+          # locally exactly as it runs here:
+          #   villagesql/bld_matrix/json_test_extensions.sh macos-arm64 "" stable
+          MATRIX=villagesql/bld_matrix
 
-          COUNT=$(echo "$TEST_MATRIX" | jq '.include | length')
+          BUILD_MATRIX=$("$MATRIX/json_build_matrix.sh" "$PLATFORM_FILTER")
+          TESTS=$("$MATRIX/json_test_extensions.sh" \
+            "$PLATFORM_FILTER" "$EXTENSION_FILTER" "$ABI_FILTER")
+
+          COUNT=$(jq 'length' <<<"$TESTS")
           if [ "$COUNT" -eq 0 ]; then
             echo "::error::No test jobs matched filters (platform='$PLATFORM_FILTER' extension='$EXTENSION_FILTER' abi='$ABI_FILTER'). Nothing to test."
             exit 1
           fi
+
+          # json_test_extensions.sh prints a bare array; the strategy matrix
+          # wants it under "include".
+          TEST_MATRIX=$(jq -c '{include: .}' <<<"$TESTS")
+
           echo "build-matrix=$BUILD_MATRIX" >> "$GITHUB_OUTPUT"
           echo "test-matrix=$TEST_MATRIX" >> "$GITHUB_OUTPUT"
 

--- a/villagesql/bld_matrix/README.md
+++ b/villagesql/bld_matrix/README.md
@@ -11,18 +11,27 @@ span lines. Pipe through `jq .` to read it.
 | -------------------- | ------------------------------------------------------------ |
 | `json_extensions.sh` | The bundled-extension manifest, parsed into an array of objects. |
 | `json_platforms.sh`  | The platforms built and tested on, as an array of objects.     |
+| `json_build_matrix.sh` | The build-server matrix, one row per platform.                |
+| `json_test_extensions.sh` | The extension tests, one row per (platform, extension, abi). |
 
 Each script's header comment documents its arguments and environment
 variables, and is the source of truth for them.
 
 ## Scope
 
-These scripts parse and shape; they do not select. Each prints its whole set.
-Filtering by platform, extension, or ABI belongs to the caller assembling a
-particular matrix —
-today [../../scripts/villagesql_build-compat-matrix.sh](../../scripts/villagesql_build-compat-matrix.sh),
-which [extension-compat-suite.yml](../../.github/workflows/extension-compat-suite.yml)
-calls to build its `build-matrix` and `test-matrix`.
+`json_extensions.sh` and `json_platforms.sh` are the data tables. They parse
+and shape but never select, and each prints its whole set.
+
+The rest select and combine. They call the tables they need and take filters
+as positional arguments; pass "" for a filter to keep everything.
+
+A `_matrix` suffix means the output is a GitHub Actions strategy matrix —
+`{"include": [...]}`, ready for `matrix: ${{ fromJson(...) }}`. Everything
+else prints a bare array, which a caller can wrap with `jq '{include: .}'`.
+
+Today [../../scripts/villagesql_build-compat-matrix.sh](../../scripts/villagesql_build-compat-matrix.sh)
+is the caller, and [extension-compat-suite.yml](../../.github/workflows/extension-compat-suite.yml)
+uses it to build its `build-matrix` and `test-matrix`.
 
 ## Examples
 
@@ -37,8 +46,16 @@ MATRIX="$PWD/villagesql/bld_matrix"
 # A manifest from somewhere else.
 EXTENSIONS_FILE=/tmp/exts.txt "$MATRIX/json_extensions.sh"
 
-# One platform, selected by the caller.
-"$MATRIX/json_platforms.sh" | jq -c '[.[] | select(.platform == "macos-arm64")]'
+# The build-server matrix, every platform and then just one.
+"$MATRIX/json_build_matrix.sh"
+"$MATRIX/json_build_matrix.sh" macos-arm64
+
+# Every extension test, then one extension on one platform against one ABI.
+"$MATRIX/json_test_extensions.sh" | jq length
+"$MATRIX/json_test_extensions.sh" macos-arm64 vsql-ai stable
+
+# Wrapped as an Actions matrix, which json_test_extensions.sh leaves to the caller.
+"$MATRIX/json_test_extensions.sh" | jq -c '{include: .}'
 ```
 
 ## Engineering Notes

--- a/villagesql/bld_matrix/README.md
+++ b/villagesql/bld_matrix/README.md
@@ -29,10 +29,6 @@ A `_matrix` suffix means the output is a GitHub Actions strategy matrix —
 `{"include": [...]}`, ready for `matrix: ${{ fromJson(...) }}`. Everything
 else prints a bare array, which a caller can wrap with `jq '{include: .}'`.
 
-Today [../../scripts/villagesql_build-compat-matrix.sh](../../scripts/villagesql_build-compat-matrix.sh)
-is the caller, and [extension-compat-suite.yml](../../.github/workflows/extension-compat-suite.yml)
-uses it to build its `build-matrix` and `test-matrix`.
-
 ## Examples
 
 ```bash

--- a/villagesql/bld_matrix/README.md
+++ b/villagesql/bld_matrix/README.md
@@ -1,30 +1,25 @@
 # VillageSQL Build Matrix
 
-Scripts that turn build configuration into the JSON that GitHub Actions
-consumes. Each script prints one JSON value on stdout and nothing else, so the
-pieces compose in a shell and each can be run and inspected on its own.
+These scripts provide JSON data tables. They may be widely used.
 
 The output is compact — a single line — because Actions step outputs cannot
 span lines. Pipe through `jq .` to read it.
-
-Errors go to stderr and exit non-zero. Nothing else may write to stdout, which
-rules out `log_info` from
-[../scripts/vsql_script_utils.sh](../scripts/vsql_script_utils.sh); `die` is
-safe.
 
 ## The scripts
 
 | File                 | Prints                                                       |
 | -------------------- | ------------------------------------------------------------ |
 | `json_extensions.sh` | The bundled-extension manifest, parsed into an array of objects. |
+| `json_platforms.sh`  | The platforms built and tested on, as an array of objects.     |
 
 Each script's header comment documents its arguments and environment
 variables, and is the source of truth for them.
 
 ## Scope
 
-These scripts parse and shape; they do not select. Filtering by platform,
-extension, or ABI belongs to the caller assembling a particular matrix —
+These scripts parse and shape; they do not select. Each prints its whole set.
+Filtering by platform, extension, or ABI belongs to the caller assembling a
+particular matrix —
 today [../../scripts/villagesql_build-compat-matrix.sh](../../scripts/villagesql_build-compat-matrix.sh),
 which [extension-compat-suite.yml](../../.github/workflows/extension-compat-suite.yml)
 calls to build its `build-matrix` and `test-matrix`.
@@ -41,4 +36,14 @@ MATRIX="$PWD/villagesql/bld_matrix"
 
 # A manifest from somewhere else.
 EXTENSIONS_FILE=/tmp/exts.txt "$MATRIX/json_extensions.sh"
+
+# One platform, selected by the caller.
+"$MATRIX/json_platforms.sh" | jq -c '[.[] | select(.platform == "macos-arm64")]'
 ```
+
+## Engineering Notes
+
+Errors go to stderr and exit non-zero. Nothing else may write to stdout, which
+rules out `log_info` from
+[../scripts/vsql_script_utils.sh](../scripts/vsql_script_utils.sh); `die` is
+safe.

--- a/villagesql/bld_matrix/README.md
+++ b/villagesql/bld_matrix/README.md
@@ -1,0 +1,44 @@
+# VillageSQL Build Matrix
+
+Scripts that turn build configuration into the JSON that GitHub Actions
+consumes. Each script prints one JSON value on stdout and nothing else, so the
+pieces compose in a shell and each can be run and inspected on its own.
+
+The output is compact — a single line — because Actions step outputs cannot
+span lines. Pipe through `jq .` to read it.
+
+Errors go to stderr and exit non-zero. Nothing else may write to stdout, which
+rules out `log_info` from
+[../scripts/vsql_script_utils.sh](../scripts/vsql_script_utils.sh); `die` is
+safe.
+
+## The scripts
+
+| File                 | Prints                                                       |
+| -------------------- | ------------------------------------------------------------ |
+| `json_extensions.sh` | The bundled-extension manifest, parsed into an array of objects. |
+
+Each script's header comment documents its arguments and environment
+variables, and is the source of truth for them.
+
+## Scope
+
+These scripts parse and shape; they do not select. Filtering by platform,
+extension, or ABI belongs to the caller assembling a particular matrix —
+today [../../scripts/villagesql_build-compat-matrix.sh](../../scripts/villagesql_build-compat-matrix.sh),
+which [extension-compat-suite.yml](../../.github/workflows/extension-compat-suite.yml)
+calls to build its `build-matrix` and `test-matrix`.
+
+## Examples
+
+```bash
+MATRIX="$PWD/villagesql/bld_matrix"
+
+"$MATRIX/json_extensions.sh" | jq .
+
+# The extensions shipped in the dev-server tarball.
+"$MATRIX/json_extensions.sh" | jq -r '.[] | select(.bundle) | .extension'
+
+# A manifest from somewhere else.
+EXTENSIONS_FILE=/tmp/exts.txt "$MATRIX/json_extensions.sh"
+```

--- a/villagesql/bld_matrix/json_build_matrix.sh
+++ b/villagesql/bld_matrix/json_build_matrix.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright (c) 2026 VillageSQL Contributors
+#
+# Print the build-server matrix as a compact JSON object.
+#
+# The server binary is ABI-agnostic and carries no extension, so the matrix is
+# one row per platform: {"include": [<platform>, ...]}. The rows are the
+# platform objects themselves, unchanged.
+#
+# The {"include": [...]} shape is a GitHub Actions strategy matrix, so a job
+# consumes this output directly:
+#
+#   strategy:
+#     matrix: ${{ fromJson(needs.prepare.outputs.build-matrix) }}
+#
+# Each row's keys become matrix.<key> in that job — matrix.platform,
+# matrix.runner, matrix.os.
+#
+# Usage: json_build_matrix.sh [platform_filter]
+#   The filter keeps only the platform of that name; omit or pass "" to keep
+#   all. The platform table comes from json_platforms.sh, which this script
+#   calls and then filters.
+#
+# Testable locally:
+#   villagesql/bld_matrix/json_build_matrix.sh | jq .
+#   villagesql/bld_matrix/json_build_matrix.sh macos-arm64
+
+set -euo pipefail
+
+MATRIX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PLATFORM_FILTER="${1:-}"
+
+"$MATRIX_DIR/json_platforms.sh" \
+  | jq -c --arg f "$PLATFORM_FILTER" \
+      '{include: [.[] | select($f == "" or .platform == $f)]}'

--- a/villagesql/bld_matrix/json_extensions.sh
+++ b/villagesql/bld_matrix/json_extensions.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Copyright (c) 2026 VillageSQL Contributors
+#
+# Print bundled_extensions.txt as a compact JSON array, one object per entry.
+#
+# This is the parsed form of the manifest; it applies no filtering. Callers
+# select the entries they want from the array.
+#
+# Each object:
+#   url        — entry URL with any trailing "/" removed
+#   branch     — branch or tag, which every entry must name
+#   build      — build tool, "cmake" when the entry omits it
+#   path       — subdirectory holding the extension, "" for the repo root
+#   extension  — last segment of path, or of url when path is ""
+#   abis       — ["stable","dev"] unless the entry pins one with abi=
+#   bundle     — false only for bundle=false or bundle=no, otherwise true
+#
+# There is no default branch. An entry that names none — whether it stops at
+# the url or goes straight to a key=value option — is an error. Unrecognized
+# keys are ignored.
+#
+# Inputs (environment variables, all optional):
+#   EXTENSIONS_FILE — path to bundled_extensions.txt
+#                     (default: the copy in this script's own source tree)
+#
+# Testable locally:
+#   villagesql/bld_matrix/json_extensions.sh | jq .
+#   EXTENSIONS_FILE=/tmp/exts.txt villagesql/bld_matrix/json_extensions.sh
+
+set -euo pipefail
+
+MATRIX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="$(cd "$MATRIX_DIR/../.." && pwd)"
+source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
+
+EXTENSIONS_FILE="${EXTENSIONS_FILE:-$SOURCE_DIR/villagesql/dev_server/bundled_extensions.txt}"
+
+if [[ ! -f "$EXTENSIONS_FILE" ]]; then
+    die "Extensions list not found: $EXTENSIONS_FILE"
+fi
+
+# -n with inputs, rather than a grep prefilter, so that a manifest holding
+# nothing but comments yields [] instead of failing the pipeline on grep's
+# empty-match exit status.
+jq -Rcn '
+    [
+      inputs
+      | gsub("^\\s+|\\s+$"; "")
+      | select(length > 0 and (startswith("#") | not))
+      | [splits("\\s+")] as $f
+      | if (($f[1] // "") | test("^$|=")) then
+          error("entry names no branch: \(.)")
+        else . end
+      | $f[2:] as $opts
+      | ($opts | map(select(startswith("build=")) | ltrimstr("build=")) | .[0] //
+        "cmake") as $build
+      | ($opts | map(select(startswith("path=")) | ltrimstr("path=")) | .[0] // "")
+          as $path
+      | ($opts | map(select(startswith("abi=")) | ltrimstr("abi=")) | .[0]) as $abi
+      | ($opts | map(select(startswith("bundle=")) | ltrimstr("bundle=")) | .[0] //
+        "true") as $bundle
+      | {
+          url:       ($f[0] | rtrimstr("/")),
+          branch:    $f[1],
+          build:     $build,
+          path:      $path,
+          extension: (if $path != "" then ($path | split("/") | last)
+                      else ($f[0] | rtrimstr("/") | split("/") | last) end),
+          abis:      (if $abi then [$abi] else ["stable","dev"] end),
+          bundle:    ($bundle | ascii_downcase | (. != "false" and . != "no"))
+        }
+    ]' "$EXTENSIONS_FILE"

--- a/villagesql/bld_matrix/json_platforms.sh
+++ b/villagesql/bld_matrix/json_platforms.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Copyright (c) 2026 VillageSQL Contributors
+#
+# Print the platforms VillageSQL builds and tests on, as a compact JSON array.
+#
+# This is the whole set; it applies no filtering. Callers select the platforms
+# they want from the array.
+#
+# Each object:
+#   platform  — platform identifier, used to name artifacts
+#   runner    — GitHub Actions runs-on value: a label array for self-hosted
+#               runners, a plain string for a GitHub-hosted one
+#   os        — operating-system family, "linux" or "macos"
+#
+# The objects are written out by hand below, one per line, and jq assembles
+# them into the array. Add a platform by adding a line.
+#
+# Testable locally:
+#   villagesql/bld_matrix/json_platforms.sh | jq .
+
+set -euo pipefail
+
+jq -sc . <<'PLATFORMS'
+{"platform":"linux-x86_64","runner":["self-hosted","linux","x86_64"],"os":"linux"}
+{"platform":"linux-aarch64","runner":"ubuntu-24.04-arm","os":"linux"}
+{"platform":"macos-arm64","runner":["self-hosted","macOS","ARM64"],"os":"macos"}
+PLATFORMS

--- a/villagesql/bld_matrix/json_test_extensions.sh
+++ b/villagesql/bld_matrix/json_test_extensions.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Copyright (c) 2026 VillageSQL Contributors
+#
+# Print the extension tests to run, as a compact JSON array.
+#
+# One row per (platform, extension, abi) triple: every platform tests every
+# extension against every ABI that extension supports. Each row carries what a
+# test job needs to check the extension out, build it, and run it.
+#
+# The rows are a bare array, not a GitHub Actions matrix. Wrap them in
+# {"include": ...} at the call site if that is what the caller wants.
+#
+# Each object holds the platform's fields — platform, runner, os — plus:
+#   url        — extension repository to clone
+#   branch     — branch or tag to check out
+#   build      — build tool, "cmake" or "cargo"
+#   path       — subdirectory holding the extension, "" for the repo root
+#   extension  — extension name
+#   abi        — the single ABI this row tests
+#
+# Usage: json_test_extensions.sh [platform_filter] [extension_filter] [abi_filter]
+#   Each filter keeps only the value of that name; omit or pass "" to keep all.
+#   The platform and extension tables come from json_platforms.sh and
+#   json_extensions.sh, which this script calls and then filters.
+#
+# Testable locally:
+#   villagesql/bld_matrix/json_test_extensions.sh | jq .
+#   villagesql/bld_matrix/json_test_extensions.sh macos-arm64 vsql-ai stable
+
+set -euo pipefail
+
+MATRIX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+PLATFORM_FILTER="${1:-}"
+EXTENSION_FILTER="${2:-}"
+ABI_FILTER="${3:-}"
+
+PLATFORMS=$("$MATRIX_DIR/json_platforms.sh" \
+  | jq -c --arg f "$PLATFORM_FILTER" '[.[] | select($f == "" or .platform == $f)]')
+
+# An empty side leaves nothing to cross-multiply, so stop before doing the
+# work the other side would cost.
+if [ "$(jq 'length' <<<"$PLATFORMS")" -eq 0 ]; then
+    echo '[]'
+    exit 0
+fi
+
+EXTENSIONS=$("$MATRIX_DIR/json_extensions.sh" \
+  | jq -c --arg f "$EXTENSION_FILTER" '[.[] | select($f == "" or .extension == $f)]')
+
+if [ "$(jq 'length' <<<"$EXTENSIONS")" -eq 0 ]; then
+    echo '[]'
+    exit 0
+fi
+
+jq -cn \
+  --argjson platforms "$PLATFORMS" \
+  --argjson extensions "$EXTENSIONS" \
+  --arg abi_filter "$ABI_FILTER" \
+  '[
+    $platforms[] as $p |
+    $extensions[] as $e |
+    ($e.abis | if $abi_filter != "" then map(select(. == $abi_filter)) else . end)[] as $a |
+    ($p + {url: $e.url, branch: $e.branch, extension: $e.extension,
+           build: $e.build, path: $e.path} + {abi: $a})
+  ]'

--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -4,9 +4,9 @@
 # TODO(villagesql-ga): In the future, move this per-extension configuration into the
 # extension repos themselves (each declaring its own build/abi/path).
 #
-# Format: <url> [branch-or-tag] [key=value ...]
+# Format: <url> <branch-or-tag> [key=value ...]
 #   url:           Full URL or local filesystem path. git clone accepts both.
-#   branch-or-tag: Optional. Omit to clone the default branch.
+#   branch-or-tag: Branch to clone.
 #   abi=<abi>:     Optional. ABI to test against: "stable" or "dev".
 #                  Omit to test against both.
 #   bundle=false:  Optional. Omit (or bundle=true) to include in dev server.
@@ -17,7 +17,6 @@
 #                  (last path segment) so multiple entries can share one URL.
 #
 # Examples:
-#   https://github.com/villagesql/vsql-ai
 #   https://github.com/villagesql/vsql-ai v1.2.0
 #   /Users/me/src/vsql-ai my-feature-branch
 #


### PR DESCRIPTION
## Description

Provides individual access paths for different build information.

Replaces current use of `scripts/villagesql_build-compat-matrix.sh` with selected scripts from `villagesql/bld_matrix/`.

Allows wider access to JSON encoded build info in other build tooling.

## Related Issue

Part of the [Server]: Overhaul CI #819 effort.

