### PR TITLE
Build one flavor of docker image

### DIFF
--- a/.github/workflows/build-docker-branch.yml
+++ b/.github/workflows/build-docker-branch.yml
@@ -1,0 +1,130 @@
+name: Build Docker Branch
+
+# Builds ONE platform-specific VillageSQL Server Docker image and pushes it to
+# the registry under its arch-specific tag (e.g. villagesql/server:0.0.5-arm64).
+# This is the CI face of docker/server/publish_image.sh.
+#
+# One call per target. The caller fans out and is responsible for supplying a
+# 'platform' and a 'runner' that agree with each other: the image is always
+# built natively, never under QEMU emulation, because compiling the server
+# under emulation takes hours. A mismatch is a caller error and will simply
+# produce a slow or failed build.
+#
+# Stitching the per-arch tags into the shared multi-arch tags is a separate
+# step (docker/server/publish_manifest.sh) and is not done here.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git tag, branch, or SHA to build from.'
+        required: true
+        type: string
+      tag:
+        description: 'Image tag to build and push, e.g. 0.0.5. The arch suffix is appended. Use a distinguishable value (e.g. 0.0.5-test) for test pushes.'
+        required: true
+        type: string
+      platform:
+        description: 'Single docker platform to build, e.g. linux/arm64. Must be native to "runner".'
+        required: true
+        type: string
+      runner:
+        description: 'JSON-encoded runs-on value (array or quoted string), e.g. ["self-hosted","linux","x86_64"] or "ubuntu-24.04-arm".'
+        required: true
+        type: string
+      repo:
+        description: 'Image repository to push to.'
+        required: false
+        type: string
+        default: 'villagesql/server'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git tag, branch, or SHA to build from (e.g. 0.0.5 or main).'
+        required: true
+        type: string
+        default: 'main'
+      tag:
+        description: 'Image tag to build and push. The arch suffix is appended. Use a distinguishable value (e.g. 0.0.5-test) for test pushes.'
+        required: true
+        type: string
+      platform:
+        description: 'Single docker platform to build. Must be native to the chosen runner.'
+        required: true
+        type: choice
+        options:
+          - linux/amd64
+          - linux/arm64
+        default: linux/amd64
+      runner:
+        description: 'JSON-encoded runs-on value, e.g. ["self-hosted","linux","x86_64"] or "ubuntu-24.04-arm".'
+        required: true
+        type: string
+        default: '["self-hosted","linux","x86_64"]'
+      repo:
+        description: 'Image repository to push to.'
+        required: false
+        type: string
+        default: 'villagesql/server'
+
+permissions:
+  contents: read
+
+jobs:
+
+  build-image:
+    name: Build Image (${{ inputs.platform }})
+    runs-on: ${{ fromJSON(inputs.runner) }}
+    timeout-minutes: 60
+
+    steps:
+      - name: Report Parameters
+        run: |
+          echo "Git Rev: ${{ inputs.ref }}"
+          echo "Image Tag: ${{ inputs.tag }}"
+          echo "Platform: ${{ inputs.platform }}"
+          echo "Runner: ${{ inputs.runner }}"
+          echo "Repository: ${{ inputs.repo }}"
+
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+          path: source
+          ref: ${{ inputs.ref }}
+
+      - name: Report Checkout
+        run: |
+          echo "Git SHA1: $(git -C source rev-parse ${{ inputs.ref }})"
+          echo "Git Commit: $(git -C source log -n1 --oneline)"
+
+      # Drop any local copy of the exact tag we are about to build.
+      - name: Clean prior image for this tag
+        run: |
+          # shellcheck source=/dev/null
+          source source/docker/server/docker_release_lib.sh
+          IMAGE="$(arch_tag '${{ inputs.repo }}' '${{ inputs.tag }}' '${{ inputs.platform }}')"
+          echo "Removing $IMAGE if present"
+          docker image rm -f "$IMAGE" || true
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # The default buildx 'docker' driver is what we want: a native
+      # single-platform build whose layer cache lives in the daemon and so
+      # outlives the job. Creating a docker-container builder would only buy
+      # multi-platform and cache export, neither of which applies, at the cost
+      # of a cold source compile every run.
+      #
+      # Build args (VSQL_PRE_RELEASE_VERSION, VSQL_DEV_ABI) are left at the
+      # publish_image.sh defaults: a release build against the dev ABI.
+      - name: Build and push image
+        run: |
+          source/docker/server/publish_image.sh \
+            --tag "${{ inputs.tag }}" \
+            --platform "${{ inputs.platform }}" \
+            --repo "${{ inputs.repo }}" \
+            --push

--- a/villagesql/bld_matrix/json_platforms.sh
+++ b/villagesql/bld_matrix/json_platforms.sh
@@ -21,7 +21,7 @@
 set -euo pipefail
 
 jq -sc . <<'PLATFORMS'
-{"platform":"linux-x86_64","runner":["self-hosted","linux","x86_64"],"os":"linux"}
-{"platform":"linux-aarch64","runner":"ubuntu-24.04-arm","os":"linux"}
-{"platform":"macos-arm64","runner":["self-hosted","macOS","ARM64"],"os":"macos"}
+{"platform":"linux-x86_64","docker-arch":"amd64","runner":["self-hosted","linux","x86_64"],"os":"linux"}
+{"platform":"linux-aarch64","docker-arch":"arm64","runner":"ubuntu-24.04-arm","os":"linux"}
+{"platform":"macos-arm64","docker-arch":"","runner":["self-hosted","macOS","ARM64"],"os":"macos"}
 PLATFORMS


### PR DESCRIPTION
## Description

Builds on flavor of docker image on it own architecture.

This assumes the caller knows which choices of platform, runner, and repo are valid.

The workflow_dispatch is primarily for manual testing.

## Related Issue

Part of the [Server]: Overhaul CI #819 effort.

