### PR TITLE
vef: improve mysql_services example

### DIFF
--- a/villagesql/sdk/include/villagesql/preview/mysql_services.h
+++ b/villagesql/sdk/include/villagesql/preview/mysql_services.h
@@ -45,6 +45,12 @@
 // DECLARE_*_METHOD) with doxygen @param/@retval docs. To consume it:
 //
 //   1. Include that MySQL header (for SERVICE_TYPE(NAME) and its method decls).
+//      Service definitions belong to MySQL's component framework, not to VEF,
+//      and the server does not install them: they exist only in a server source
+//      tree. An extension consuming services therefore builds against that tree
+//      (-I <source>/include), plus <build>/include for generated headers such
+//      as mysqld_error.h. The in-tree test extensions get both from the
+//      MYSQL_HEADERS flag on vsql_add_test_extension().
 //   2. VSQL_REQUIRE_SERVICE(services, NAME, var)  — acquires it into `var`.
 //      (The service-name string is derived from NAME; if a service's registry
 //      name differs from its SERVICE_TYPE name, use the explicit
@@ -64,25 +70,38 @@
 //
 // EXAMPLE
 // -------
+// keyring_ready() answers whether a keyring component is installed and
+// initialized, so an extension can check before attempting a keyring
+// operation rather than failing part-way through one.
 //
-//   #include <villagesql/vsql.h>
-//   #include <villagesql/preview/mysql_services.h>
+//   #include <cstddef>
+//
 //   #include <mysql/components/services/keyring_metadata_query.h>
+//   #include <villagesql/preview/mysql_services.h>
+//   #include <villagesql/vsql.h>
 //
 //   using namespace vsql;
 //
-//   static vsql::preview_mysql_services::MysqlServices services;
-//   VSQL_REQUIRE_SERVICE(services, keyring_component_status, status);
+//   static preview_mysql_services::MysqlServices services;
+//   VSQL_REQUIRE_SERVICE(services, keyring_component_status, keyring_status);
 //
-//   void f_impl(IntResult out) {
-//     // is_initialized() is MySQL's method, documented in the service's
-//     // header. Guard with valid() first, then call through with ->.
-//     out.set((status.valid() && status->is_initialized()) ? 1 : 0);
+//   void keyring_ready_impl(IntResult out) {
+//     // valid() is this SDK's "was it acquired". is_initialized() is MySQL's
+//     // own method, documented in the service's header. Guard, then call
+//     // through with ->.
+//     const bool ready =
+//         keyring_status.valid() && keyring_status->is_initialized();
+//     out.set(ready ? 1 : 0);
 //   }
 //
 //   VEF_GENERATE_ENTRY_POINTS(
 //     make_extension().with(services).func(
-//         make_func<&f_impl>("f").returns(INT).no_params().build()))
+//         make_func<&keyring_ready_impl>("keyring_ready")
+//             .returns(INT).no_params().build()))
+//
+// Include <cstddef> (or any villagesql header) before the MySQL service
+// header. Several service definitions use size_t without including it
+// themselves, and fail with "unknown type name 'size_t'" when they come first.
 
 #include <cstddef>
 #include <vector>

--- a/villagesql/sdk/include/villagesql/preview/mysql_services.h
+++ b/villagesql/sdk/include/villagesql/preview/mysql_services.h
@@ -69,6 +69,8 @@
 //   #include <villagesql/preview/mysql_services.h>
 //   #include <mysql/components/services/keyring_metadata_query.h>
 //
+//   using namespace vsql;
+//
 //   static vsql::preview_mysql_services::MysqlServices services;
 //   VSQL_REQUIRE_SERVICE(services, keyring_component_status, status);
 //


### PR DESCRIPTION
## Summary

Two changes to the `EXAMPLE` block and the surrounding notes in
`villagesql/sdk/include/villagesql/preview/mysql_services.h`. Comment-only; no
code, no ABI.

**The example did not compile.** It wrote `IntResult`, `make_extension()`,
`make_func<>` and `INT` unqualified, included `<villagesql/vsql.h>`, and had no
using-directive. All four live in namespace `vsql` (`vsql/func_types.h:158`,
`vsql/extension_builder.h:153`, and `vsql.h:97-112` re-exports `make_func` and
`INT` into `vsql`, not the global namespace). The same example fully qualified
`vsql::preview_mysql_services::MysqlServices`, which is what made the omission
read as intentional rather than shorthand. Adds `using namespace vsql;`,
matching every shipping test extension.

**The example was shaped like a test, not like something a reader would
write.** `f_impl` registered as `f` returned 1/0 from `keyring_component_status`
— an assertable scalar, which is what a test needs and not what a developer
builds. It is now `keyring_ready()`, which answers whether a keyring component
is installed and initialized, so an extension can check before starting a
keyring operation rather than failing part-way through one.

Also documents where the MySQL service headers come from, which the header
never said. Service definitions belong to MySQL's component framework rather
than to VEF, and the server does not install them: `include/CMakeLists.txt`
installs a flat list that has never included `mysql/components/services/**`, and
that file is untouched from upstream. So an extension consuming services builds
against a server source tree, plus the build tree for generated headers such as
`mysqld_error.h` — exactly what `MYSQL_HEADERS` on `vsql_add_test_extension()`
supplies to the in-tree tests (`villagesql/cmake/VsqlExtension.cmake:160-164`).
Without that note, a reader copying the example has no way to know why it will
not build.

Last, a line on include order. Several MySQL service definitions use `size_t`
without including `<cstddef>`, so a service header placed ahead of every
villagesql header fails inside MySQL's own header.

The two uses of the word "wrapper" are left for #898, which is removing that
term systematically.

## Test plan

Compiled with clang 17, `-std=c++20 -fsyntax-only -DVSQL_USE_DEV_ABI=1`, against
`/build/villagesql-extension-sdk-0.0.6-dev/include-dev` plus the server's
`include/` and the build tree's `include/`.

- [x] the example as documented before this PR → `error: 'IntResult' was not
  declared in this scope; did you mean 'vsql::IntResult'?`, plus `error:
  variable or field 'f_impl' declared void` and `error: 'f_impl' was not
  declared in this scope` (g++ 13, server@0fa175790cf)
- [x] the new example, extracted from the comment block verbatim and compiled →
  exit 0, no diagnostics
- [x] the include-order claim, reproduced: a MySQL service header ahead of every
  villagesql header → `error: unknown type name 'size_t'` inside
  `include/mysql/components/services/keyring_metadata_query.h`
- [x] `include/CMakeLists.txt` confirmed untouched from upstream —
  `git log -S"components/services" -- include/CMakeLists.txt` returns nothing,
  so this is MySQL's boundary rather than a VillageSQL packaging choice

`scripts/villint.sh` could not run in the review container: it requires
clang-format 22.1, which is not installed and cannot be installed there (no
pip). The change is inside an existing comment block and every line is under 80
columns, so there is no formatting surface — but the CI lint is the authority
here, not this note.

AI=CLAUDE
