### PR TITLE
Use JSON extensions tables

### DIFF
--- a/villagesql/bld_tools/build_bundled_extensions.sh
+++ b/villagesql/bld_tools/build_bundled_extensions.sh
@@ -8,14 +8,15 @@
 # <sdk_dir>:        Path to an extracted villagesql-extension-sdk-* directory.
 #                   After 'make', this is $BUILD_DIR/villagesql-extension-sdk-<version>.
 # <veb_output_dir>: Directory where built .veb files are placed.
-# [extension]:      Optional repo name to build only one extension (e.g. vsql-ai).
-#                   Omit to build all extensions in bundled_extensions.txt.
+# [extension]:      Optional extension name to build only one extension (e.g.
+#                   vsql-ai). Omit to build every extension in the manifest.
 # [include_unbundled]: 0/no (default) to skip bundle=false extensions, 1/yes to
 #                   build them too. They ship with no dev server, but are still
 #                   built and tested (e.g. by the sanitizer workflow).
 #
-# The extension list is read from villagesql/dev_server/bundled_extensions.txt,
-# located relative to this script's source tree.
+# The manifest is parsed by villagesql/bld_matrix/json_extensions.sh, which
+# reads villagesql/dev_server/bundled_extensions.txt from this script's own
+# source tree.
 #
 # Env vars:
 #   CMAKE_EXTRA_FLAGS  - additional per-extension cmake flags appended verbatim
@@ -32,8 +33,6 @@ INCLUDE_UNBUNDLED="${5:-no}"
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
 
-EXTENSIONS_LIST="$SOURCE_DIR/villagesql/dev_server/bundled_extensions.txt"
-
 source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
 
 case "$INCLUDE_UNBUNDLED" in
@@ -43,13 +42,7 @@ case "$INCLUDE_UNBUNDLED" in
 esac
 
 if [[ ! -d "$SDK_DIR" ]]; then
-    log_error "SDK directory not found: $SDK_DIR"
-    exit 1
-fi
-
-if [[ ! -f "$EXTENSIONS_LIST" ]]; then
-    log_error "Extensions list not found: $EXTENSIONS_LIST"
-    exit 1
+    die "SDK directory not found: $SDK_DIR"
 fi
 
 if [[ ! -d "$EXTENSION_CLONES_DIR" ]]; then
@@ -78,60 +71,49 @@ NCORES=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo "4")
 BUILT=0
 FAILED=0
 
-while IFS= read -r line; do
-    [[ "$line" =~ ^[[:space:]]*# ]] && continue
-    [[ -z "${line// }" ]] && continue
+# One tab-separated row per manifest entry the filter keeps. Collected up front,
+# rather than piped into the loop, so a manifest error stops the script here.
+ENTRIES="$("$SOURCE_DIR/villagesql/bld_matrix/json_extensions.sh" \
+    | jq -r --arg f "$EXTENSION_FILTER" '
+        .[]
+        | select($f == "" or .extension == $f)
+        | [.extension, .url, .branch, .build, (.bundle | tostring), .path]
+        | @tsv')"
 
-    # Parse "url [branch-or-tag] [key=value ...]" — all fields after url are optional
-    read -ra FIELDS <<< "$line"
-    SOURCE="${FIELDS[0]%/}"
-    BRANCH="${FIELDS[1]:-}"
-    REPO_NAME="${SOURCE##*/}"
-
-    if [[ -n "$EXTENSION_FILTER" && "$REPO_NAME" != "$EXTENSION_FILTER" ]]; then
-        continue
-    fi
+while IFS=$'\t' read -r EXTENSION SOURCE BRANCH BUILD_TOOL BUNDLE EXT_PATH; do
+    [[ -z "$EXTENSION" ]] && continue
 
     # This script builds with cmake. Skip entries that use another build tool
-    # such as cargo. The real issue is that we try to clone the rust-sdk
-    # multiple times, leading to an error.
+    # such as cargo.
     # TODO(villagesql-rust): Let's consider doing a bigger rework of the
     # extension build system to support multiple build tools, but for now we just
     # skip non-cmake extensions.
-    BUILD_TOOL=cmake
-    for FIELD in "${FIELDS[@]:2}"; do
-        [[ "$FIELD" == build=* ]] && BUILD_TOOL="${FIELD#build=}"
-    done
     if [[ "$BUILD_TOOL" != "cmake" ]]; then
-        log_info "Skipping $REPO_NAME (build=$BUILD_TOOL not supported here)"
+        log_info "Skipping $EXTENSION (build=$BUILD_TOOL not supported here)"
         continue
     fi
 
-    if [[ "$INCLUDE_UNBUNDLED" == "no" ]]; then
-        BUNDLE=true
-        for FIELD in "${FIELDS[@]:2}"; do
-            [[ "$FIELD" == "bundle=false" || "$FIELD" == "bundle=no" ]] && BUNDLE=false
-        done
-        if [[ "$BUNDLE" == "false" ]]; then
-            log_info "Skipping $REPO_NAME (bundle=false)"
-            continue
-        fi
+    if [[ "$INCLUDE_UNBUNDLED" == "no" && "$BUNDLE" == "false" ]]; then
+        log_info "Skipping $EXTENSION (bundle=false)"
+        continue
     fi
 
-    log_step "Building $REPO_NAME ($SOURCE${BRANCH:+ @ $BRANCH})"
+    log_step "Building $EXTENSION ($SOURCE @ $BRANCH)"
 
-    CLONE_DIR="$EXTENSION_CLONES_DIR/$REPO_NAME"
-    EXT_BUILD_DIR="$BUILD_BASE/$REPO_NAME"
+    # The clone is named for the repo, not the extension, since one repo can
+    # hold several extensions; path= says where in the clone this one lives.
+    CLONE_DIR="$EXTENSION_CLONES_DIR/${SOURCE##*/}${EXT_PATH:+/$EXT_PATH}"
+    EXT_BUILD_DIR="$BUILD_BASE/$EXTENSION"
 
     if ! cmake -S "$CLONE_DIR" -B "$EXT_BUILD_DIR" \
             "${CMAKE_FLAGS[@]}" 2>&1; then
-        log_error "CMake configure failed for $REPO_NAME"
+        log_error "CMake configure failed for $EXTENSION"
         FAILED=$((FAILED + 1))
         continue
     fi
 
     if ! cmake --build "$EXT_BUILD_DIR" --parallel "$NCORES" 2>&1; then
-        log_error "Build failed for $REPO_NAME"
+        log_error "Build failed for $EXTENSION"
         FAILED=$((FAILED + 1))
         continue
     fi
@@ -144,18 +126,17 @@ while IFS= read -r line; do
     done < <(find "$EXT_BUILD_DIR" -maxdepth 1 -name "*.veb")
 
     if [[ $VEB_COUNT -eq 0 ]]; then
-        log_error "No .veb file found after building $REPO_NAME"
+        log_error "No .veb file found after building $EXTENSION"
         FAILED=$((FAILED + 1))
         continue
     fi
 
     BUILT=$((BUILT + 1))
-done < "$EXTENSIONS_LIST"
+done <<< "$ENTRIES"
 
 echo ""
 if [[ -n "$EXTENSION_FILTER" && $BUILT -eq 0 && $FAILED -eq 0 ]]; then
-    log_error "'$EXTENSION_FILTER' not found in $EXTENSIONS_LIST"
-    exit 1
+    die "'$EXTENSION_FILTER' matched no extension to build"
 fi
 echo "Extensions built: $BUILT, failed: $FAILED"
 [[ $FAILED -eq 0 ]] || exit 1

--- a/villagesql/bld_tools/checkout_bundled_extensions.sh
+++ b/villagesql/bld_tools/checkout_bundled_extensions.sh
@@ -5,14 +5,15 @@
 # Usage: checkout_bundled_extensions.sh <ext_dir> [extension] [include_unbundled]
 #
 # <ext_dir>:        Path for checked out extensions.  Should exist before calling.
-# [extension]:      Optional repo name to build only one extension (e.g. vsql-ai).
-#                   Omit to build all extensions in bundled_extensions.txt.
+# [extension]:      Optional extension name to clone only one extension (e.g.
+#                   vsql-ai). Omit to clone every extension in the manifest.
 # [include_unbundled]: 0/no (default) to skip bundle=false extensions, 1/yes to
 #                   clone them too. They ship with no dev server, but are still
 #                   built and tested (e.g. by the sanitizer workflow).
 #
-# The extension list is read from villagesql/dev_server/bundled_extensions.txt,
-# located relative to this script's source tree.
+# The manifest is parsed by villagesql/bld_matrix/json_extensions.sh, which
+# reads villagesql/dev_server/bundled_extensions.txt from this script's own
+# source tree.
 
 set -euo pipefail
 
@@ -23,8 +24,6 @@ INCLUDE_UNBUNDLED="${3:-no}"
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
 
-EXTENSIONS_LIST="$SOURCE_DIR/villagesql/dev_server/bundled_extensions.txt"
-
 source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
 
 case "$INCLUDE_UNBUNDLED" in
@@ -33,29 +32,24 @@ case "$INCLUDE_UNBUNDLED" in
     *) die "Invalid include_unbundled: $INCLUDE_UNBUNDLED (expected 0/no or 1/yes)" ;;
 esac
 
-if [[ ! -f "$EXTENSIONS_LIST" ]]; then
-    die "Extensions list not found: $EXTENSIONS_LIST"
-fi
-
 if [[ ! -d "$EXTENSION_CLONES_DIR" ]]; then
     die "Extension directory not found: $EXTENSION_CLONES_DIR (mkdir first)"
 fi
 
+# One tab-separated row per manifest entry the filter keeps. Collected up front,
+# rather than piped into the loop, so a manifest error stops the script here.
+ENTRIES="$("$SOURCE_DIR/villagesql/bld_matrix/json_extensions.sh" \
+    | jq -r --arg f "$EXTENSION_FILTER" '
+        .[]
+        | select($f == "" or .extension == $f)
+        | [.extension, .url, .branch, .build, (.bundle | tostring)]
+        | @tsv')"
+
+CLONED=0
 FAILED=0
 
-while IFS= read -r line; do
-    [[ "$line" =~ ^[[:space:]]*# ]] && continue
-    [[ -z "${line// }" ]] && continue
-
-    # Parse "url [branch-or-tag] [key=value ...]" — all fields after url are optional
-    read -ra FIELDS <<< "$line"
-    SOURCE="${FIELDS[0]%/}"
-    BRANCH="${FIELDS[1]:-}"
-    REPO_NAME="${SOURCE##*/}"
-
-    if [[ -n "$EXTENSION_FILTER" && "$REPO_NAME" != "$EXTENSION_FILTER" ]]; then
-        continue
-    fi
+while IFS=$'\t' read -r EXTENSION SOURCE BRANCH BUILD_TOOL BUNDLE; do
+    [[ -z "$EXTENSION" ]] && continue
 
     # This script builds with cmake. Skip entries that use another build tool
     # such as cargo. The real issue is that we try to clone the rust-sdk
@@ -63,37 +57,35 @@ while IFS= read -r line; do
     # TODO(villagesql-rust): Let's consider doing a bigger rework of the
     # extension build system to support multiple build tools, but for now we just
     # skip non-cmake extensions.
-    BUILD_TOOL=cmake
-    for FIELD in "${FIELDS[@]:2}"; do
-        [[ "$FIELD" == build=* ]] && BUILD_TOOL="${FIELD#build=}"
-    done
     if [[ "$BUILD_TOOL" != "cmake" ]]; then
-        log_info "Skipping $REPO_NAME (build=$BUILD_TOOL not supported here)"
+        log_info "Skipping $EXTENSION (build=$BUILD_TOOL not supported here)"
         continue
     fi
 
-    if [[ "$INCLUDE_UNBUNDLED" == "no" ]]; then
-        BUNDLE=true
-        for FIELD in "${FIELDS[@]:2}"; do
-            [[ "$FIELD" == "bundle=false" || "$FIELD" == "bundle=no" ]] && BUNDLE=false
-        done
-        if [[ "$BUNDLE" == "false" ]]; then
-            log_info "Skipping $REPO_NAME (bundle=false)"
-            continue
-        fi
+    if [[ "$INCLUDE_UNBUNDLED" == "no" && "$BUNDLE" == "false" ]]; then
+        log_info "Skipping $EXTENSION (bundle=false)"
+        continue
     fi
 
-    log_step "Cloning $REPO_NAME ($SOURCE${BRANCH:+ @ $BRANCH})"
+    log_step "Cloning $EXTENSION ($SOURCE @ $BRANCH)"
 
-    CLONE_DIR="$EXTENSION_CLONES_DIR/$REPO_NAME"
-
-    CLONE_ARGS=(--depth=1)
-    [[ -n "$BRANCH" ]] && CLONE_ARGS+=(--branch "$BRANCH")
+    # The clone is named for the repo, not the extension, since one repo can
+    # hold several extensions. build_bundled_extensions.sh expects that name.
+    CLONE_DIR="$EXTENSION_CLONES_DIR/${SOURCE##*/}"
 
     # git clone accepts both remote URLs and local filesystem paths
-    if ! git clone "${CLONE_ARGS[@]}" "$SOURCE" "$CLONE_DIR" 2>&1; then
+    if ! git clone --depth=1 --branch "$BRANCH" "$SOURCE" "$CLONE_DIR" 2>&1; then
         log_error "Failed to clone $SOURCE"
         FAILED=$((FAILED + 1))
         continue
     fi
-done < "$EXTENSIONS_LIST"
+
+    CLONED=$((CLONED + 1))
+done <<< "$ENTRIES"
+
+echo ""
+if [[ -n "$EXTENSION_FILTER" && $CLONED -eq 0 && $FAILED -eq 0 ]]; then
+    die "'$EXTENSION_FILTER' matched no extension to clone"
+fi
+echo "Extensions cloned: $CLONED, failed: $FAILED"
+[[ $FAILED -eq 0 ]] || exit 1

--- a/villagesql/bld_tools/include_bundled_extensions.sh
+++ b/villagesql/bld_tools/include_bundled_extensions.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 # Copyright (c) 2026 VillageSQL Contributors
-# Build VEB files for bundled VillageSQL extensions.
+# Copy the bundled VillageSQL extension VEB files into a package tree.
 #
 # Usage: include_bundled_extensions.sh <dst_dir> <veb_src_dir>
 #
 # <veb_src_dir>: Directory where built .veb files were placed.
 #
-# The extension list is read from villagesql/dev_server/bundled_extensions.txt,
-# located relative to this script's source tree.
+# The manifest is parsed by villagesql/bld_matrix/json_extensions.sh, which
+# reads villagesql/dev_server/bundled_extensions.txt from this script's own
+# source tree.
 
 set -euo pipefail
 DST_DIR="${1:?Usage: $0 <dst_dir> <veb_src_dir>}"
@@ -16,48 +17,31 @@ VEB_SRC_DIR="${2:?Usage: $0 <dst_dir> <veb_src_dir>}"
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
 
-EXTENSIONS_LIST="$SOURCE_DIR/villagesql/dev_server/bundled_extensions.txt"
-
 source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
 
-if [[ ! -f "$EXTENSIONS_LIST" ]]; then
-    log_error "Extensions list not found: $EXTENSIONS_LIST"
-    exit 1
-fi
-
 if [[ ! -d "$VEB_SRC_DIR" ]]; then
-    log_error "Missing extension source directory: $VEB_SRC_DIR"
-    exit 1
+    die "Missing extension source directory: $VEB_SRC_DIR"
 fi
 
-# Read and parse the list of extensions
-while IFS= read -r line; do
-    [[ "$line" =~ ^[[:space:]]*# ]] && continue
-    [[ -z "${line// }" ]] && continue
+# One tab-separated row per manifest entry. Collected up front, rather than
+# piped into the loop, so a manifest error stops the script here.
+ENTRIES="$("$SOURCE_DIR/villagesql/bld_matrix/json_extensions.sh" \
+    | jq -r '.[] | [.extension, (.bundle | tostring)] | @tsv')"
 
-    # Parse "url [branch-or-tag] [key=value ...]" — all fields after url are optional
-    read -ra FIELDS <<< "$line"
-    SOURCE="${FIELDS[0]%/}"
-    BRANCH="${FIELDS[1]:-}"
-    REPO_NAME="${SOURCE##*/}"
+while IFS=$'\t' read -r EXTENSION BUNDLE; do
+    [[ -z "$EXTENSION" ]] && continue
 
-    # Confirm the extension is bundled
-    BUNDLE=true
-    for FIELD in "${FIELDS[@]:2}"; do
-        [[ "$FIELD" == "bundle=false" || "$FIELD" == "bundle=no" ]] && BUNDLE=false
-    done
     if [[ "$BUNDLE" == "false" ]]; then
-        log_info "Skipping $REPO_NAME (bundle=false)"
+        log_info "Skipping $EXTENSION (bundle=false)"
         continue
     fi
 
     # Convert all dashes to underscores
-    EXT_FILE="${REPO_NAME//-/_}.veb"
+    EXT_FILE="${EXTENSION//-/_}.veb"
     EXT_SRC_VEB="$VEB_SRC_DIR/$EXT_FILE"
     if [[ ! -f "$EXT_SRC_VEB" ]]; then
-        log_error "Expected extension $REPO_NAME not found at $EXT_SRC_VEB"
-        exit 1
+        die "Expected extension $EXTENSION not found at $EXT_SRC_VEB"
     fi
 
-    cp "$EXT_SRC_VEB" "$DST_DIR/$EXT_FILE" || log_info "Duplicate $REPO_NAME already installed"
-done < "$EXTENSIONS_LIST"
+    cp "$EXT_SRC_VEB" "$DST_DIR/$EXT_FILE" || log_info "Duplicate $EXTENSION already installed"
+done <<< "$ENTRIES"


### PR DESCRIPTION
## Description

Revises the `bld_tools` for bundled extensions to use `villagesql/bld_matrix/json_extensions.sh`
as the source of truth for details about the extensions.

## Related Issue

Part of the [Server]: Overhaul CI #819 effort.

