### PR TITLE
Restore migrated method

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -82,6 +82,7 @@ jobs:
     - name: Record run parameters
       run: |
         source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
+        source "$SOURCE_DIR/villagesql/bld_tools/build_info.sh"
         vsql_parse_version "$SOURCE_DIR"
         vsql_platform_info
         BUILD_TARGET="${VSQL_CODE_BASE}_${VSQL_VERSION}-${PLATFORM}-${ARCH}"


### PR DESCRIPTION
## Description

Fixes a problem in Full Test Suite where a migrated function is no longer available.

The function `vsql_parse_version` was previously defined in `villagesql/scripts/vsql_script_utils.sh`, but moved to `villagesql/bld_tools/build_info.sh` as part of PR #969

This restores the definition of `vsql_parse_version` in the step context.

## Related Issue

Part of the [Server]: Overhaul CI #819 effort.
