### PR TITLE
vdf: run postrun when fix_fields fails

### DIFF
--- a/mysql-test/suite/villagesql/extension/r/extension_vdf_postrun_leak.result
+++ b/mysql-test/suite/villagesql/extension/r/extension_vdf_postrun_leak.result
@@ -1,0 +1,29 @@
+Creating extension vdf_postrun_leak using SDK...
+Created vdf_postrun_leak.veb
+INSTALL EXTENSION vdf_postrun_leak;
+# Baseline
+SELECT vdf_postrun_leak.prerun_count() AS pre,
+vdf_postrun_leak.postrun_count() AS post,
+vdf_postrun_leak.live_state_count() AS live;
+pre	post	live
+0	0	0
+SET SESSION debug='+d,vdf_fail_after_prerun';
+SELECT vdf_postrun_leak.leak_probe() AS probe;
+ERROR HY000: Out of memory; check if mysqld or some other process uses all available memory; if not, you may have to use 'ulimit' to allow mysqld to use more memory or you can add more swap space
+SET SESSION debug='-d,vdf_fail_after_prerun';
+# After forced failure
+SELECT vdf_postrun_leak.prerun_count() AS pre,
+vdf_postrun_leak.postrun_count() AS post,
+vdf_postrun_leak.live_state_count() AS live;
+pre	post	live
+1	1	0
+# Happy path: prerun+postrun pair normally, no leak
+SELECT vdf_postrun_leak.leak_probe() AS probe;
+probe
+1
+SELECT vdf_postrun_leak.prerun_count() AS pre,
+vdf_postrun_leak.postrun_count() AS post,
+vdf_postrun_leak.live_state_count() AS live;
+pre	post	live
+2	2	0
+UNINSTALL EXTENSION vdf_postrun_leak;

--- a/mysql-test/suite/villagesql/extension/t/extension_vdf_postrun_leak.test
+++ b/mysql-test/suite/villagesql/extension/t/extension_vdf_postrun_leak.test
@@ -1,0 +1,36 @@
+# Regression: when VDF fix_fields fails after prerun allocated user_data,
+# postrun must still run to free it. The vdf_fail_after_prerun DBUG point
+# forces the post-prerun failure; the extension's global balance counter
+# (live_state_count) must return to zero.
+
+--source include/have_debug.inc
+
+--let $extension_name = vdf_postrun_leak
+--let $extension_version = 1.0.0
+--let $extension_source = $MYSQL_TEST_DIR/suite/villagesql/std_data/vdf_postrun_leak.cc
+--source include/villagesql/create_extension_sdk.inc
+
+INSTALL EXTENSION vdf_postrun_leak;
+
+--echo # Baseline
+SELECT vdf_postrun_leak.prerun_count() AS pre,
+       vdf_postrun_leak.postrun_count() AS post,
+       vdf_postrun_leak.live_state_count() AS live;
+
+SET SESSION debug='+d,vdf_fail_after_prerun';
+--error ER_OUT_OF_RESOURCES
+SELECT vdf_postrun_leak.leak_probe() AS probe;
+SET SESSION debug='-d,vdf_fail_after_prerun';
+
+--echo # After forced failure
+SELECT vdf_postrun_leak.prerun_count() AS pre,
+       vdf_postrun_leak.postrun_count() AS post,
+       vdf_postrun_leak.live_state_count() AS live;
+
+--echo # Happy path: prerun+postrun pair normally, no leak
+SELECT vdf_postrun_leak.leak_probe() AS probe;
+SELECT vdf_postrun_leak.prerun_count() AS pre,
+       vdf_postrun_leak.postrun_count() AS post,
+       vdf_postrun_leak.live_state_count() AS live;
+
+UNINSTALL EXTENSION vdf_postrun_leak;

--- a/mysql-test/suite/villagesql/std_data/vdf_postrun_leak.cc
+++ b/mysql-test/suite/villagesql/std_data/vdf_postrun_leak.cc
@@ -1,0 +1,83 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+// Test only extension for the VDF prerun/postrun leak regression.
+// leak_probe's prerun allocates heap state (tracked by a global balance
+// counter) AND requests a result buffer. When fix_fields fails after prerun
+// (forced via the vdf_fail_after_prerun DBUG point), postrun must still run to
+// free that state. live_state_count() reports the balance so the test can
+// assert it returns to zero.
+
+#include <villagesql/vsql.h>
+
+#include <atomic>
+#include <cstdio>
+
+using namespace vsql;
+
+static std::atomic<long long> g_live_state_count{0};
+static std::atomic<long long> g_prerun_count{0};
+static std::atomic<long long> g_postrun_count{0};
+
+struct LeakState {
+  long long n = 0;
+  LeakState() { g_live_state_count.fetch_add(1); }
+  ~LeakState() { g_live_state_count.fetch_sub(1); }
+};
+
+void leak_probe_prerun(PrerunArgs, PrerunResult out) {
+  g_prerun_count.fetch_add(1);
+  out.request_buffer_size(64);
+  out.set_user_data(new LeakState{});
+}
+
+void leak_probe(LeakState &state, StringResult out) {
+  state.n++;
+  auto out_buf = out.buffer();
+  int len = snprintf(reinterpret_cast<char *>(out_buf.data()), out_buf.size(),
+                     "%lld", state.n);
+  out.set_length(static_cast<size_t>(len));
+}
+
+void leak_probe_postrun(PostrunArgs args) {
+  g_postrun_count.fetch_add(1);
+  args.delete_state<LeakState>();
+}
+
+void live_state_count(IntResult out) { out.set(g_live_state_count.load()); }
+void prerun_count(IntResult out) { out.set(g_prerun_count.load()); }
+void postrun_count(IntResult out) { out.set(g_postrun_count.load()); }
+
+VEF_GENERATE_ENTRY_POINTS(
+    make_extension()
+        .func(make_func<&leak_probe>("leak_probe")
+                  .returns(STRING)
+                  .no_params()
+                  .prerun<&leak_probe_prerun>()
+                  .postrun<&leak_probe_postrun>()
+                  .build())
+        .func(make_func<&live_state_count>("live_state_count")
+                  .returns(INT)
+                  .no_params()
+                  .build())
+        .func(make_func<&prerun_count>("prerun_count")
+                  .returns(INT)
+                  .no_params()
+                  .build())
+        .func(make_func<&postrun_count>("postrun_count")
+                  .returns(INT)
+                  .no_params()
+                  .build()))

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -20,6 +20,7 @@
 #include "lex_string.h"
 #include "my_sys.h"
 #include "mysql/strings/m_ctype.h"
+#include "scope_guard.h"
 #include "sql/current_thd.h"
 #include "sql/derror.h"
 #include "sql/item.h"
@@ -211,6 +212,21 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
     }
   }
 
+  // If fix_fields bails out after prerun allocated user_data, the caller
+  // (Item_udf_func::fix_fields) drops this handler without calling cleanup(),
+  // so postrun would never run and prerun's allocation would leak. Run postrun
+  // on any such early return. On success, we release() this and cleanup() owns
+  // postrun as usual. Mirrors the cleanup_guard in udf_handler::fix_fields.
+  bool prerun_completed = false;
+  auto postrun_guard = create_scope_guard([&]() {
+    if (prerun_completed && m_udf->vdf_func_desc->postrun != nullptr) {
+      vef_postrun_args_t postrun_args{};
+      postrun_args.user_data = m_vdf_args.user_data;
+      vef_postrun_result_t postrun_result{};
+      m_udf->vdf_func_desc->postrun(&m_context, &postrun_args, &postrun_result);
+    }
+  });
+
   // Call prerun if present
   if (m_udf->vdf_func_desc->prerun) {
     vef_prerun_args_t prerun_args{};
@@ -265,8 +281,15 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
 
     // Store user_data for subsequent calls
     m_vdf_args.user_data = prerun_result.user_data;
+    prerun_completed = true;
 
     // Handle buffer size request
+    // debug point here to explicitly and deterministically test what it looks
+    // like if there is a post-prerun buffer allocation failure.
+    DBUG_EXECUTE_IF("vdf_fail_after_prerun", {
+      my_error(ER_OUT_OF_RESOURCES, MYF(0));
+      return true;
+    });
     if (MaybeResizeBuffer(prerun_result.result_buffer_size)) return true;
   }
 
@@ -300,6 +323,7 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
   }
 
   m_active = true;
+  postrun_guard.release();  // success: cleanup() owns postrun from here.
   return false;
 }
 

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -15,6 +15,7 @@
 
 #include "villagesql/vdf/vdf_handler.h"
 
+#include <optional>
 #include <type_traits>
 
 #include "lex_string.h"
@@ -218,14 +219,21 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
   // on any such early return. On success, we release() this and cleanup() owns
   // postrun as usual. Mirrors the cleanup_guard in udf_handler::fix_fields.
   bool prerun_completed = false;
-  auto postrun_guard = create_scope_guard([&]() {
-    if (prerun_completed && m_udf->vdf_func_desc->postrun != nullptr) {
+  auto run_postrun = [&]() {
+    if (prerun_completed) {
       vef_postrun_args_t postrun_args{};
       postrun_args.user_data = m_vdf_args.user_data;
       vef_postrun_result_t postrun_result{};
       m_udf->vdf_func_desc->postrun(&m_context, &postrun_args, &postrun_result);
     }
-  });
+  };
+  // Only arm the guard when the extension actually has a postrun. A prerun-only
+  // VDF has nothing to tear down, so we skip constructing the guard entirely
+  // instead of building one that no-ops.
+  std::optional<decltype(create_scope_guard(run_postrun))> postrun_guard;
+  if (m_udf->vdf_func_desc->postrun != nullptr) {
+    postrun_guard.emplace(create_scope_guard(run_postrun));
+  }
 
   // Call prerun if present
   if (m_udf->vdf_func_desc->prerun) {
@@ -323,7 +331,8 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
   }
 
   m_active = true;
-  postrun_guard.release();  // success: cleanup() owns postrun from here.
+  // success: cleanup() owns postrun from here (no-op if no guard was armed).
+  if (postrun_guard) postrun_guard->release();
   return false;
 }
 


### PR DESCRIPTION
## Description

I believe I found an issue where there was a leak in the case where there's a VDF whose prerun allocated user_data and requested a result buffer, but then later the fix_fields step failed. The state seems to be leaked in that case because postrun would no longer be triggered in that case. 

Mimicking the way this is done for UDFs, I added in a scope guard in vdf_handler::fix_fields that runs postrun if there is ever an early return once prerun has completed. The postrun_guard is released if fix_fields runs successfully, leading to cleanup() owning the postrun like it previously did. In udf_handler::fix_fields, this is done with cleanup_guard. 

## Related Issue

N/a

## How was this tested?

I added in a test extension vdf_postrun_leak where the prerun allocates heap state and requests a buffer. I added in a DBUG point within the vdf_handler.cc file which allowed me to force the post-prerun failure. Counters for how many times prerun and postrun run and a counter called live for things that leaked are then able to be recorded and sanity checked to make sure that prerun and postrun counts are equal and the live count is zero. I ran a test with and without the scope guard fix and confirmed that without the fix, there was a non-zero live count and non-equal prerun and postrun counts, but with the fix, it acts as desired.

## Checklist

- [X] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [X] I have added or updated tests as appropriate
- [X] My changes maintain compatibility with upstream MySQL 8.4
