### PR TITLE
Fix identifiers with dots in victionary

### DIFF
--- a/mysql-test/suite/villagesql/identifiers/r/dotted_identifiers.result
+++ b/mysql-test/suite/villagesql/identifiers/r/dotted_identifiers.result
@@ -1,0 +1,22 @@
+CREATE DATABASE dotted_db;
+USE dotted_db;
+CREATE TABLE `my.table` (
+`col.one` vsql_complex.COMPLEX,
+plain INT
+);
+SHOW FIELDS FROM `my.table`;
+Field	Type	Null	Key	Default	Extra
+col.one	vsql_complex.COMPLEX	YES		NULL	
+plain	int	YES		NULL	
+ALTER TABLE `my.table` RENAME COLUMN `col.one` TO `col.two`;
+SHOW FIELDS FROM `my.table`;
+Field	Type	Null	Key	Default	Extra
+col.two	vsql_complex.COMPLEX	YES		NULL	
+plain	int	YES		NULL	
+RENAME TABLE `my.table` TO `renamed.table`;
+SHOW FIELDS FROM `renamed.table`;
+Field	Type	Null	Key	Default	Extra
+col.two	vsql_complex.COMPLEX	YES		NULL	
+plain	int	YES		NULL	
+DROP TABLE `renamed.table`;
+DROP DATABASE dotted_db;

--- a/mysql-test/suite/villagesql/identifiers/t/dotted_identifiers.test
+++ b/mysql-test/suite/villagesql/identifiers/t/dotted_identifiers.test
@@ -1,0 +1,28 @@
+# Identifiers may contain dots. Victionary update and delete operations must
+# locate rows by the key components, not by re-splitting the dot-joined key
+# string.
+
+--source include/villagesql/install_complex_extension.inc
+
+CREATE DATABASE dotted_db;
+USE dotted_db;
+
+CREATE TABLE `my.table` (
+    `col.one` vsql_complex.COMPLEX,
+    plain INT
+);
+
+SHOW FIELDS FROM `my.table`;
+
+# Column rename updates the victionary row keyed by the dotted names.
+ALTER TABLE `my.table` RENAME COLUMN `col.one` TO `col.two`;
+SHOW FIELDS FROM `my.table`;
+
+# Table rename rewrites the keys of all column rows for the table.
+RENAME TABLE `my.table` TO `renamed.table`;
+SHOW FIELDS FROM `renamed.table`;
+
+DROP TABLE `renamed.table`;
+DROP DATABASE dotted_db;
+
+--source include/villagesql/uninstall_complex_extension.inc

--- a/villagesql/schema/ADDING_SYSTEM_TABLES.md
+++ b/villagesql/schema/ADDING_SYSTEM_TABLES.md
@@ -107,7 +107,7 @@ struct TableTraits<YourTableEntry> {
   static bool read_from_table(TABLE &table, YourTableEntry &entry);
   static bool write_to_table(TABLE &table, const YourTableEntry &entry);
   static bool update_in_table(TABLE &table, const YourTableEntry &entry,
-                              const std::string &old_key);
+                              const YourTableKey &old_key);
   static bool delete_from_table(TABLE &table, const YourTableEntry &entry);
 };
 ```

--- a/villagesql/schema/systable/custom_columns.cc
+++ b/villagesql/schema/systable/custom_columns.cc
@@ -99,8 +99,6 @@ bool TableTraits<ColumnEntry>::write_to_table(TABLE &table,
 bool TableTraits<ColumnEntry>::update_in_table(TABLE &table,
                                                const ColumnEntry &entry,
                                                const ColumnKey &old_key) {
-  // Probe with the as-entered components: the stored row holds the original
-  // bytes, not the normalized form.
   const ColumnKey &lookup_key = old_key.str().empty() ? entry.key() : old_key;
 
   // Set up the key fields for index lookup

--- a/villagesql/schema/systable/custom_columns.cc
+++ b/villagesql/schema/systable/custom_columns.cc
@@ -98,33 +98,19 @@ bool TableTraits<ColumnEntry>::write_to_table(TABLE &table,
 
 bool TableTraits<ColumnEntry>::update_in_table(TABLE &table,
                                                const ColumnEntry &entry,
-                                               const std::string &old_key) {
-  // Determine which key to use for lookup
-  std::string lookup_key = old_key.empty() ? entry.key().str() : old_key;
-
-  // Parse the lookup key to get db, table, column names
-  // Key format: "db.table.column"
-  size_t first_dot = lookup_key.find('.');
-  size_t second_dot = lookup_key.find('.', first_dot + 1);
-  if (should_assert_if_true(first_dot == std::string::npos ||
-                            second_dot == std::string::npos)) {
-    LogVSQL(ERROR_LEVEL, "Invalid key format for update: %s",
-            lookup_key.c_str());
-    return true;
-  }
-
-  std::string old_db = lookup_key.substr(0, first_dot);
-  std::string old_table =
-      lookup_key.substr(first_dot + 1, second_dot - first_dot - 1);
-  std::string old_column = lookup_key.substr(second_dot + 1);
+                                               const ColumnKey &old_key) {
+  // Probe with the as-entered components: the stored row holds the original
+  // bytes, not the normalized form.
+  const ColumnKey &lookup_key = old_key.str().empty() ? entry.key() : old_key;
 
   // Set up the key fields for index lookup
   Field **field = table.field;
 
-  field[0]->store(old_db.c_str(), old_db.length(), &my_charset_utf8mb4_bin);
-  field[1]->store(old_table.c_str(), old_table.length(),
+  field[0]->store(lookup_key.db().c_str(), lookup_key.db().length(),
                   &my_charset_utf8mb4_bin);
-  field[2]->store(old_column.c_str(), old_column.length(),
+  field[1]->store(lookup_key.table().c_str(), lookup_key.table().length(),
+                  &my_charset_utf8mb4_bin);
+  field[2]->store(lookup_key.column().c_str(), lookup_key.column().length(),
                   &my_charset_utf8mb4_bin);
 
   // Build the index key from the populated fields

--- a/villagesql/schema/systable/custom_columns.h
+++ b/villagesql/schema/systable/custom_columns.h
@@ -158,7 +158,7 @@ struct TableTraits<ColumnEntry> {
   // key columns changed)
   // Returns false on success, true on error
   static bool update_in_table(TABLE &table, const ColumnEntry &entry,
-                              const std::string &old_key);
+                              const ColumnKey &old_key);
 
   // Delete a ColumnEntry from villagesql.custom_columns table
   // Returns false on success, true on error

--- a/villagesql/schema/systable/custom_index_columns.cc
+++ b/villagesql/schema/systable/custom_index_columns.cc
@@ -87,27 +87,16 @@ bool TableTraits<IndexColumnEntry>::write_to_table(
 }
 
 bool TableTraits<IndexColumnEntry>::update_in_table(
-    TABLE &table, const IndexColumnEntry &entry, const std::string &old_key) {
-  std::string lookup_key = old_key.empty() ? entry.key().str() : old_key;
-
-  // Parse key "index_id.key_position"
-  size_t dot = lookup_key.find('.');
-  if (should_assert_if_true(dot == std::string::npos)) {
-    LogVSQL(ERROR_LEVEL, "Invalid key format for index column update: %s",
-            lookup_key.c_str());
-    return true;
-  }
-
-  uint64_t old_index_id =
-      static_cast<uint64_t>(std::stoull(lookup_key.substr(0, dot)));
-  uint32_t old_key_position =
-      static_cast<uint32_t>(std::stoul(lookup_key.substr(dot + 1)));
+    TABLE &table, const IndexColumnEntry &entry,
+    const IndexColumnKey &old_key) {
+  const IndexColumnKey &lookup_key =
+      old_key.str().empty() ? entry.key() : old_key;
 
   Field **field = table.field;
 
   // Set fields[0-1] for primary key lookup (key_info[0])
-  field[0]->store(static_cast<longlong>(old_index_id), true);
-  field[1]->store(static_cast<longlong>(old_key_position), true);
+  field[0]->store(static_cast<longlong>(lookup_key.index_id()), true);
+  field[1]->store(static_cast<longlong>(lookup_key.key_position()), true);
 
   uchar key_buf[MAX_KEY_LENGTH];
   key_copy(key_buf, table.record[0], table.key_info,

--- a/villagesql/schema/systable/custom_index_columns.h
+++ b/villagesql/schema/systable/custom_index_columns.h
@@ -119,7 +119,7 @@ struct TableTraits<IndexColumnEntry> {
   static bool read_from_table(TABLE &table, IndexColumnEntry &entry);
   static bool write_to_table(TABLE &table, const IndexColumnEntry &entry);
   static bool update_in_table(TABLE &table, const IndexColumnEntry &entry,
-                              const std::string &old_key);
+                              const IndexColumnKey &old_key);
   static bool delete_from_table(TABLE &table, const IndexColumnEntry &entry);
 };
 

--- a/villagesql/schema/systable/custom_indexes.cc
+++ b/villagesql/schema/systable/custom_indexes.cc
@@ -102,8 +102,6 @@ bool TableTraits<IndexEntry>::write_to_table(TABLE &table,
 bool TableTraits<IndexEntry>::update_in_table(TABLE &table,
                                               const IndexEntry &entry,
                                               const IndexKey &old_key) {
-  // Probe with the as-entered components: the stored row holds the original
-  // bytes, not the normalized form.
   const IndexKey &lookup_key = old_key.str().empty() ? entry.key() : old_key;
 
   Field **field = table.field;

--- a/villagesql/schema/systable/custom_indexes.cc
+++ b/villagesql/schema/systable/custom_indexes.cc
@@ -101,32 +101,20 @@ bool TableTraits<IndexEntry>::write_to_table(TABLE &table,
 
 bool TableTraits<IndexEntry>::update_in_table(TABLE &table,
                                               const IndexEntry &entry,
-                                              const std::string &old_key) {
-  std::string lookup_key = old_key.empty() ? entry.key().str() : old_key;
-
-  // Parse natural key "db.table.index_name"
-  size_t first_dot = lookup_key.find('.');
-  size_t second_dot = lookup_key.find('.', first_dot + 1);
-  if (should_assert_if_true(first_dot == std::string::npos ||
-                            second_dot == std::string::npos)) {
-    LogVSQL(ERROR_LEVEL, "Invalid key format for index update: %s",
-            lookup_key.c_str());
-    return true;
-  }
-
-  std::string old_db = lookup_key.substr(0, first_dot);
-  std::string old_table =
-      lookup_key.substr(first_dot + 1, second_dot - first_dot - 1);
-  std::string old_index = lookup_key.substr(second_dot + 1);
+                                              const IndexKey &old_key) {
+  // Probe with the as-entered components: the stored row holds the original
+  // bytes, not the normalized form.
+  const IndexKey &lookup_key = old_key.str().empty() ? entry.key() : old_key;
 
   Field **field = table.field;
 
   // Set fields[1-3] for natural unique key lookup (key_info[1])
-  field[1]->store(old_db.c_str(), old_db.length(), &my_charset_utf8mb4_bin);
-  field[2]->store(old_table.c_str(), old_table.length(),
+  field[1]->store(lookup_key.db().c_str(), lookup_key.db().length(),
                   &my_charset_utf8mb4_bin);
-  field[3]->store(old_index.c_str(), old_index.length(),
+  field[2]->store(lookup_key.table().c_str(), lookup_key.table().length(),
                   &my_charset_utf8mb4_bin);
+  field[3]->store(lookup_key.index_name().c_str(),
+                  lookup_key.index_name().length(), &my_charset_utf8mb4_bin);
 
   uchar key_buf[MAX_KEY_LENGTH];
   key_copy(key_buf, table.record[0], &table.key_info[1],

--- a/villagesql/schema/systable/custom_indexes.h
+++ b/villagesql/schema/systable/custom_indexes.h
@@ -142,7 +142,7 @@ struct TableTraits<IndexEntry> {
   static bool read_from_table(TABLE &table, IndexEntry &entry);
   static bool write_to_table(TABLE &table, const IndexEntry &entry);
   static bool update_in_table(TABLE &table, const IndexEntry &entry,
-                              const std::string &old_key);
+                              const IndexKey &old_key);
   static bool delete_from_table(TABLE &table, const IndexEntry &entry);
 };
 

--- a/villagesql/schema/systable/custom_sp_params.cc
+++ b/villagesql/schema/systable/custom_sp_params.cc
@@ -98,8 +98,6 @@ bool TableTraits<SpParamEntry>::write_to_table(TABLE &table,
 bool TableTraits<SpParamEntry>::update_in_table(TABLE &table,
                                                 const SpParamEntry &entry,
                                                 const SpParamKey &old_key) {
-  // Probe with the as-entered components: the stored row holds the original
-  // bytes, not the normalized form.
   const SpParamKey &lookup_key = old_key.str().empty() ? entry.key() : old_key;
 
   Field **field = table.field;

--- a/villagesql/schema/systable/custom_sp_params.cc
+++ b/villagesql/schema/systable/custom_sp_params.cc
@@ -97,29 +97,18 @@ bool TableTraits<SpParamEntry>::write_to_table(TABLE &table,
 
 bool TableTraits<SpParamEntry>::update_in_table(TABLE &table,
                                                 const SpParamEntry &entry,
-                                                const std::string &old_key) {
-  std::string lookup_key = old_key.empty() ? entry.key().str() : old_key;
-
-  // Key format: "db.sp_name.param"
-  size_t first_dot = lookup_key.find('.');
-  size_t second_dot = lookup_key.find('.', first_dot + 1);
-  if (should_assert_if_true(first_dot == std::string::npos ||
-                            second_dot == std::string::npos)) {
-    LogVSQL(ERROR_LEVEL, "Invalid key format for update: %s",
-            lookup_key.c_str());
-    return true;
-  }
-
-  std::string old_db = lookup_key.substr(0, first_dot);
-  std::string old_sp =
-      lookup_key.substr(first_dot + 1, second_dot - first_dot - 1);
-  std::string old_param = lookup_key.substr(second_dot + 1);
+                                                const SpParamKey &old_key) {
+  // Probe with the as-entered components: the stored row holds the original
+  // bytes, not the normalized form.
+  const SpParamKey &lookup_key = old_key.str().empty() ? entry.key() : old_key;
 
   Field **field = table.field;
 
-  field[0]->store(old_db.c_str(), old_db.length(), &my_charset_utf8mb4_bin);
-  field[1]->store(old_sp.c_str(), old_sp.length(), &my_charset_utf8mb4_bin);
-  field[2]->store(old_param.c_str(), old_param.length(),
+  field[0]->store(lookup_key.db().c_str(), lookup_key.db().length(),
+                  &my_charset_utf8mb4_bin);
+  field[1]->store(lookup_key.sp_name().c_str(), lookup_key.sp_name().length(),
+                  &my_charset_utf8mb4_bin);
+  field[2]->store(lookup_key.param().c_str(), lookup_key.param().length(),
                   &my_charset_utf8mb4_bin);
 
   uchar key_buf[MAX_KEY_LENGTH];

--- a/villagesql/schema/systable/custom_sp_params.h
+++ b/villagesql/schema/systable/custom_sp_params.h
@@ -142,7 +142,7 @@ struct TableTraits<SpParamEntry> {
   static bool write_to_table(TABLE &table, const SpParamEntry &entry);
 
   static bool update_in_table(TABLE &table, const SpParamEntry &entry,
-                              const std::string &old_key);
+                              const SpParamKey &old_key);
 
   static bool delete_from_table(TABLE &table, const SpParamEntry &entry);
 };

--- a/villagesql/schema/systable/extensions.cc
+++ b/villagesql/schema/systable/extensions.cc
@@ -355,8 +355,6 @@ bool TableTraits<ExtensionEntry>::write_to_table(TABLE &table,
 bool TableTraits<ExtensionEntry>::update_in_table(TABLE &table,
                                                   const ExtensionEntry &entry,
                                                   const ExtensionKey &old_key) {
-  // Probe with the as-entered name: the stored row holds the original bytes,
-  // not the normalized form.
   const ExtensionKey &lookup_key =
       old_key.str().empty() ? entry.key() : old_key;
 

--- a/villagesql/schema/systable/extensions.cc
+++ b/villagesql/schema/systable/extensions.cc
@@ -354,16 +354,19 @@ bool TableTraits<ExtensionEntry>::write_to_table(TABLE &table,
 
 bool TableTraits<ExtensionEntry>::update_in_table(TABLE &table,
                                                   const ExtensionEntry &entry,
-                                                  const std::string &old_key) {
-  // Determine which key to use for lookup
-  std::string lookup_key = old_key.empty() ? entry.key().str() : old_key;
+                                                  const ExtensionKey &old_key) {
+  // Probe with the as-entered name: the stored row holds the original bytes,
+  // not the normalized form.
+  const ExtensionKey &lookup_key =
+      old_key.str().empty() ? entry.key() : old_key;
 
   // Build index scan on primary key (extension_name)
   uchar key_buf[MAX_KEY_LENGTH];
 
   // Set up the key for index scan
   Field **field = table.field;
-  field[0]->store(lookup_key.c_str(), lookup_key.length(),
+  field[0]->store(lookup_key.extension_name().c_str(),
+                  lookup_key.extension_name().length(),
                   &my_charset_utf8mb4_bin);
 
   // Copy the key for index read

--- a/villagesql/schema/systable/extensions.h
+++ b/villagesql/schema/systable/extensions.h
@@ -212,7 +212,7 @@ struct TableTraits<ExtensionEntry> {
   // set in old_key; otherwise, entry.key() is used.
   // Returns false on success, true on error
   static bool update_in_table(TABLE &table, const ExtensionEntry &entry,
-                              const std::string &old_key);
+                              const ExtensionKey &old_key);
 
   // Delete an ExtensionEntry from villagesql.extensions table
   // Returns false on success, true on error

--- a/villagesql/schema/systable/properties.h
+++ b/villagesql/schema/systable/properties.h
@@ -108,7 +108,7 @@ struct TableTraits<PropertyEntry> {
   // properties)
   static bool update_in_table(TABLE & /*table*/,
                               const PropertyEntry & /*entry*/,
-                              const std::string & /*old_key*/) {
+                              const PropertyKey & /*old_key*/) {
     assert(VILLAGESQL_NOT_IMPLEMENTED);
     return true;  // Not implemented - return error
   }

--- a/villagesql/schema/victionary_client-impl.h
+++ b/villagesql/schema/victionary_client-impl.h
@@ -88,8 +88,17 @@ bool SystemTableMap<EntryType, Mode>::reload_from_table(
     // Use entry's key() method
     std::string key_str = entry.key().str();
 
-    // Add to committed map
-    m_committed[key_str] = std::make_shared<EntryType>(std::move(entry));
+    // Add to committed map. Two distinct rows must never share a canonical
+    // key; overwriting would silently drop one of them.
+    auto inserted = m_committed.emplace(
+        key_str, std::make_shared<EntryType>(std::move(entry)));
+    if (should_assert_if_true(!inserted.second)) {
+      LogVSQL(ERROR_LEVEL,
+              "Duplicate canonical key '%s' while loading %s.%s; row ignored",
+              key_str.c_str(), schema_name, table_name);
+      error = true;
+      continue;
+    }
     loaded_count++;
   }
 
@@ -152,7 +161,7 @@ bool SystemTableMap<EntryType, Mode>::write_uncommitted_to_table(
       case OperationType::UPDATE:
         // Use TableTraits to update the row
         if (should_assert_if_true(TableTraits<EntryType>::update_in_table(
-                *sys_table, *op->entry, op->key.str()))) {
+                *sys_table, *op->entry, op->key))) {
           LogVSQL(ERROR_LEVEL, "Error updating %s.%s from key %s to %s",
                   schema_name, table_name, op->entry->key().str().c_str(),
                   op->key.str().c_str());

--- a/villagesql/schema/victionary_client-impl.h
+++ b/villagesql/schema/victionary_client-impl.h
@@ -88,17 +88,8 @@ bool SystemTableMap<EntryType, Mode>::reload_from_table(
     // Use entry's key() method
     std::string key_str = entry.key().str();
 
-    // Add to committed map. Two distinct rows must never share a canonical
-    // key; overwriting would silently drop one of them.
-    auto inserted = m_committed.emplace(
-        key_str, std::make_shared<EntryType>(std::move(entry)));
-    if (should_assert_if_true(!inserted.second)) {
-      LogVSQL(ERROR_LEVEL,
-              "Duplicate canonical key '%s' while loading %s.%s; row ignored",
-              key_str.c_str(), schema_name, table_name);
-      error = true;
-      continue;
-    }
+    // Add to committed map
+    m_committed[key_str] = std::make_shared<EntryType>(std::move(entry));
     loaded_count++;
   }
 


### PR DESCRIPTION
## Description

Renaming a custom type column fails and crashes debug builds when the table or column name contains a dot, because victionary update lookups split the dot-joined "db.table.column" key instead of using the key components. 

Fixed it by replacing the lookups with the existing key components (ColumnKey, IndexColumnKey, IndexKey, SpParamKey, ExtensionKey, PropertyKey).

## Related Issue

Fixes #978 

## How was this tested?

Added an MTR test that creates a table and column with a dotted db name and custom columns. The ALTER TABLE commands fail without the fix and succeed with the fix.