### PR TITLE
Rm LD_PRELOAD from extension-bld script

### DIFF
--- a/mysql-test/include/villagesql/create_extension.inc
+++ b/mysql-test/include/villagesql/create_extension.inc
@@ -33,12 +33,16 @@ if (!$extension_files)
 --replace_result $MYSQL_BASEDIR MYSQL_BASEDIR
 --exec $create_veb_script $extension_name $extension_files
 
-# Get VEB directory from server and ensure it exists
+# Get VEB directory from server and ensure it exists.
+# The --exec commands strip LD_PRELOAD so the uninstrumented system binaries do
+# not run under the LD_PRELOAD'd ASan runtime on sanitizer builds and trip
+# LeakSanitizer on their own allocations (see create_extension_sdk.inc for the
+# full explanation).
 --let $veb_dir = `SELECT @@veb_dir`
---exec mkdir -p $veb_dir
+--exec unset LD_PRELOAD && mkdir -p $veb_dir
 
 # Move the VEB file to the VEB directory
---exec mv $MYSQL_TMP_DIR/$extension_name.veb $veb_dir/
+--exec unset LD_PRELOAD && mv $MYSQL_TMP_DIR/$extension_name.veb $veb_dir/
 
 # Reset variables to avoid pollution
 --let $extension_name =

--- a/mysql-test/include/villagesql/create_extension.inc
+++ b/mysql-test/include/villagesql/create_extension.inc
@@ -34,15 +34,13 @@ if (!$extension_files)
 --exec $create_veb_script $extension_name $extension_files
 
 # Get VEB directory from server and ensure it exists.
-# The --exec commands strip LD_PRELOAD so the uninstrumented system binaries do
-# not run under the LD_PRELOAD'd ASan runtime on sanitizer builds and trip
-# LeakSanitizer on their own allocations (see create_extension_sdk.inc for the
-# full explanation).
 --let $veb_dir = `SELECT @@veb_dir`
---exec unset LD_PRELOAD && mkdir -p $veb_dir
+# --mkdir fails if the directory already exists
+--error 0,1
+--mkdir $veb_dir
 
 # Move the VEB file to the VEB directory
---exec unset LD_PRELOAD && mv $MYSQL_TMP_DIR/$extension_name.veb $veb_dir/
+--move_file $MYSQL_TMP_DIR/$extension_name.veb $veb_dir/$extension_name.veb
 
 # Reset variables to avoid pollution
 --let $extension_name =

--- a/mysql-test/include/villagesql/create_extension.inc
+++ b/mysql-test/include/villagesql/create_extension.inc
@@ -33,7 +33,7 @@ if (!$extension_files)
 --replace_result $MYSQL_BASEDIR MYSQL_BASEDIR
 --exec $create_veb_script $extension_name $extension_files
 
-# Get VEB directory from server and ensure it exists.
+# Get VEB directory from server and ensure it exists
 --let $veb_dir = `SELECT @@veb_dir`
 # --mkdir fails if the directory already exists
 --error 0,1

--- a/mysql-test/include/villagesql/create_extension_sdk.inc
+++ b/mysql-test/include/villagesql/create_extension_sdk.inc
@@ -57,68 +57,68 @@ if (!$extension_version)
 --exec test -d "$sdk_dir" || (echo "ERROR: SDK not found at $sdk_dir. Run 'make sdk' first." && exit 1)
 --exec test -f "$sdk_dir/bin/villagesql_config" || (echo "ERROR: villagesql_config not found in SDK" && exit 1)
 
+# Every --exec below strips LD_PRELOAD. On sanitizer builds MTR's safe_process
+# LD_PRELOADs the shared ASan runtime into every child process, and that
+# propagates through mysqltest into these exec'd commands. The uninstrumented
+# system binaries (cp, mkdir, sed, and the gcc/cc1 toolchain) then run under
+# LeakSanitizer, which flags their own internal allocations at exit and fails
+# the command with LSAN_OPTIONS=exitcode=42. LD_PRELOAD only loads the runtime
+# into the child process; it does not add -fsanitize instrumentation, so
+# unsetting it yields identical results while avoiding spurious leak reports.
+
 # Create build directory structure
---exec rm -rf $ext_build_dir
---exec mkdir -p $ext_build_dir/src
---exec mkdir -p $ext_build_dir/build
+--exec unset LD_PRELOAD && rm -rf $ext_build_dir
+--exec unset LD_PRELOAD && mkdir -p $ext_build_dir/src
+--exec unset LD_PRELOAD && mkdir -p $ext_build_dir/build
 
 # Copy source file
---exec cp $extension_source $ext_build_dir/src/extension.cc
+--exec unset LD_PRELOAD && cp $extension_source $ext_build_dir/src/extension.cc
 
 # Optionally place shared companion header(s) next to extension.cc so the source
 # can #include them. Gated on $extension_common_header, so other consumers of
 # this include (which never set it) are unaffected.
 if ($extension_common_header)
 {
-  --exec cp $extension_common_header $ext_build_dir/src/
+  --exec unset LD_PRELOAD && cp $extension_common_header $ext_build_dir/src/
 }
 
 # Create manifest.json
---exec printf '%s' '{"name": "$extension_name", "version": "$extension_version"$extension_manifest_extra}' > $ext_build_dir/manifest.json
+--exec unset LD_PRELOAD && printf '%s' '{"name": "$extension_name", "version": "$extension_version"$extension_manifest_extra}' > $ext_build_dir/manifest.json
 
 # Create CMakeLists.txt from template
 --let $cmake_template = $MYSQL_TEST_DIR/suite/villagesql/data/extension_creator/CMakeLists.txt.template
---exec sed 's/@EXTENSION_NAME@/$extension_name/g' $cmake_template > $ext_build_dir/CMakeLists.txt
+--exec unset LD_PRELOAD && sed 's/@EXTENSION_NAME@/$extension_name/g' $cmake_template > $ext_build_dir/CMakeLists.txt
 
 --echo Creating extension $extension_name using SDK...
 
-# Run cmake
-#
-# Strip LD_PRELOAD for the toolchain sub-build. On sanitizer builds MTR's
-# safe_process LD_PRELOADs the shared ASan runtime into every child process,
-# and that propagates through mysqltest into these exec'd commands. The
-# uninstrumented system gcc/cc1 then runs under LeakSanitizer, which flags
-# GCC's own internal allocations at exit and fails the build with
-# LSAN_OPTIONS=exitcode=42. LD_PRELOAD only loads the runtime into the
-# compiler process; it does not add -fsanitize instrumentation, so unsetting
-# it yields an identical .veb while avoiding the spurious leak reports.
+# Run cmake (see the LD_PRELOAD note above).
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR $build_dir BUILD_DIR
 --exec cd $ext_build_dir/build && unset LD_PRELOAD && cmake -DVillageSQL_SDK_DIR=$sdk_dir -DCMAKE_MODULE_PATH=$sdk_dir/lib/cmake/VillageSQLExtensionFramework -DVSQL_USE_DEV_ABI=ON .. > cmake_output.txt 2>&1 || (cat cmake_output.txt && exit 1)
 
-# Run make (see LD_PRELOAD note above for the cmake step).
+# Run make (see the LD_PRELOAD note above).
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
 --exec cd $ext_build_dir/build && unset LD_PRELOAD && make > make_output.txt 2>&1 || (cat make_output.txt && exit 1)
 
 # Verify VEB was created
 --file_exists $ext_build_dir/build/$extension_name.veb
 
-# Move VEB to server's VEB directory
---exec mkdir -p $veb_dir
+# Move VEB to server's VEB directory (see the LD_PRELOAD note above).
+--exec unset LD_PRELOAD && mkdir -p $veb_dir
 
 if ($extension_versioned)
 {
-  --exec cp $ext_build_dir/build/$extension_name.veb $veb_dir/$extension_name-$extension_version.veb
+  --exec unset LD_PRELOAD && cp $ext_build_dir/build/$extension_name.veb $veb_dir/$extension_name-$extension_version.veb
   --echo Created $extension_name-$extension_version.veb
 }
 
 if (!$extension_versioned)
 {
-  --exec cp $ext_build_dir/build/$extension_name.veb $veb_dir/
+  --exec unset LD_PRELOAD && cp $ext_build_dir/build/$extension_name.veb $veb_dir/
   --echo Created $extension_name.veb
 }
 
 # Cleanup build directory
---exec rm -rf $ext_build_dir
+--exec unset LD_PRELOAD && rm -rf $ext_build_dir
 
 # Reset variables
 --let $extension_name =

--- a/mysql-test/include/villagesql/create_extension_sdk.inc
+++ b/mysql-test/include/villagesql/create_extension_sdk.inc
@@ -53,22 +53,29 @@ if (!$extension_version)
 --let $sdk_dir = $build_dir/villagesql-extension-sdk-$sdk_abbr
 --let $ext_build_dir = $MYSQLTEST_VARDIR/tmp/ext_build_$extension_name
 
-# Verify SDK exists
---exec test -d "$sdk_dir" || (echo "ERROR: SDK not found at $sdk_dir. Run 'make sdk' first." && exit 1)
---exec test -f "$sdk_dir/bin/villagesql_config" || (echo "ERROR: villagesql_config not found in SDK" && exit 1)
-
-# Every --exec below strips LD_PRELOAD. On sanitizer builds MTR's safe_process
-# LD_PRELOADs the shared ASan runtime into every child process, and that
-# propagates through mysqltest into these exec'd commands. The uninstrumented
-# system binaries (sh, cp, sed, and the gcc/cc1 toolchain) then run under
-# LeakSanitizer, which flags their own internal allocations at exit and fails
-# the command with LSAN_OPTIONS=exitcode=42. LD_PRELOAD only loads the runtime
-# into the child process; it does not add -fsanitize instrumentation, so
-# unsetting it yields identical results while avoiding spurious leak reports.
+# File operations here use mysqltest's built-in commands (--mkdir, --copy_file,
+# --force-rmdir, ...) where one exists, and --perl otherwise. Both avoid
+# spawning an uninstrumented system binary, which matters on sanitizer builds:
+# MTR's safe_process LD_PRELOADs the shared ASan runtime into every child
+# process, and that propagates through mysqltest into exec'd commands, so
+# binaries like cp and sed get leak-checked at exit and fail the command with
+# LSAN_OPTIONS=exitcode=42. Built-ins run in-process, and perl is suppressed in
+# mysql-test/lsan.supp.
 #
-# The remaining file operations use mysqltest's built-in commands (--mkdir,
-# --copy_file, --force-rmdir, ...), which run in-process and so never inherit
-# the preloaded runtime at all.
+# Only the cmake and make steps below remain as --exec, since they must invoke
+# the real toolchain; they strip LD_PRELOAD explicitly.
+
+
+# Verify SDK exists
+--let VSQL_SDK_DIR = $sdk_dir
+--perl
+  use strict;
+  use warnings;
+  my $sdk = $ENV{'VSQL_SDK_DIR'};
+  die "ERROR: SDK not found at $sdk. Run 'make sdk' first.\n" unless -d $sdk;
+  die "ERROR: villagesql_config not found in SDK at $sdk\n"
+    unless -f "$sdk/bin/villagesql_config";
+EOF
 
 # Create build directory structure.
 # --force-rmdir fails if the directory is not there, which
@@ -82,20 +89,47 @@ if (!$extension_version)
 # Copy source file
 --copy_file $extension_source $ext_build_dir/src/extension.cc
 
-# Optionally place shared companion header(s) next to extension.cc so the source
-# can #include them. Gated on $extension_common_header, so other consumers of
-# this include (which never set it) are unaffected.
-if ($extension_common_header)
-{
-  --exec unset LD_PRELOAD && cp $extension_common_header $ext_build_dir/src/
-}
-
-# Create manifest.json
---exec unset LD_PRELOAD && printf '%s' '{"name": "$extension_name", "version": "$extension_version"$extension_manifest_extra}' > $ext_build_dir/manifest.json
-
-# Create CMakeLists.txt from template
 --let $cmake_template = $MYSQL_TEST_DIR/suite/villagesql/data/extension_creator/CMakeLists.txt.template
---exec unset LD_PRELOAD && sed 's/@EXTENSION_NAME@/$extension_name/g' $cmake_template > $ext_build_dir/CMakeLists.txt
+
+# Place the optional companion header(s) next to extension.cc so the source can
+# #include them, write manifest.json, and expand the CMakeLists.txt template.
+# $extension_common_header may name several headers separated by spaces, and is
+# unset by consumers that need none; perl handles both cases.
+--let VSQL_EXT_BUILD_DIR = $ext_build_dir
+--let VSQL_EXT_NAME = $extension_name
+--let VSQL_EXT_VERSION = $extension_version
+--let VSQL_EXT_MANIFEST_EXTRA = $extension_manifest_extra
+--let VSQL_EXT_COMMON_HEADER = $extension_common_header
+--let VSQL_CMAKE_TEMPLATE = $cmake_template
+--perl
+  use strict;
+  use warnings;
+  use File::Basename;
+  use File::Copy;
+  my $dir = $ENV{'VSQL_EXT_BUILD_DIR'};
+  my $name = $ENV{'VSQL_EXT_NAME'};
+
+  foreach my $header (split(' ', $ENV{'VSQL_EXT_COMMON_HEADER'} // '')) {
+    copy($header, "$dir/src/" . basename($header))
+      or die "ERROR: failed to copy $header into $dir/src: $!\n";
+  }
+
+  open(my $mf, '>', "$dir/manifest.json")
+    or die "ERROR: cannot write $dir/manifest.json: $!\n";
+  print $mf '{"name": "' . $name . '", "version": "' . $ENV{'VSQL_EXT_VERSION'}
+    . '"' . ($ENV{'VSQL_EXT_MANIFEST_EXTRA'} // '') . '}';
+  close($mf);
+
+  my $template = $ENV{'VSQL_CMAKE_TEMPLATE'};
+  open(my $in, '<', $template) or die "ERROR: cannot read $template: $!\n";
+  my $cmake = do { local $/; <$in> };
+  close($in);
+  $cmake =~ s/\@EXTENSION_NAME\@/$name/g;
+  open(my $out, '>', "$dir/CMakeLists.txt")
+    or die "ERROR: cannot write $dir/CMakeLists.txt: $!\n";
+  print $out $cmake;
+  close($out);
+EOF
 
 --echo Creating extension $extension_name using SDK...
 

--- a/mysql-test/include/villagesql/create_extension_sdk.inc
+++ b/mysql-test/include/villagesql/create_extension_sdk.inc
@@ -60,19 +60,27 @@ if (!$extension_version)
 # Every --exec below strips LD_PRELOAD. On sanitizer builds MTR's safe_process
 # LD_PRELOADs the shared ASan runtime into every child process, and that
 # propagates through mysqltest into these exec'd commands. The uninstrumented
-# system binaries (cp, mkdir, sed, and the gcc/cc1 toolchain) then run under
+# system binaries (sh, cp, sed, and the gcc/cc1 toolchain) then run under
 # LeakSanitizer, which flags their own internal allocations at exit and fails
 # the command with LSAN_OPTIONS=exitcode=42. LD_PRELOAD only loads the runtime
 # into the child process; it does not add -fsanitize instrumentation, so
 # unsetting it yields identical results while avoiding spurious leak reports.
+#
+# The remaining file operations use mysqltest's built-in commands (--mkdir,
+# --copy_file, --force-rmdir, ...), which run in-process and so never inherit
+# the preloaded runtime at all.
 
-# Create build directory structure
---exec unset LD_PRELOAD && rm -rf $ext_build_dir
---exec unset LD_PRELOAD && mkdir -p $ext_build_dir/src
---exec unset LD_PRELOAD && mkdir -p $ext_build_dir/build
+# Create build directory structure.
+# --force-rmdir fails if the directory is not there, which
+# is the normal case.
+--error 0,1
+--force-rmdir $ext_build_dir
+--mkdir $ext_build_dir
+--mkdir $ext_build_dir/src
+--mkdir $ext_build_dir/build
 
 # Copy source file
---exec unset LD_PRELOAD && cp $extension_source $ext_build_dir/src/extension.cc
+--copy_file $extension_source $ext_build_dir/src/extension.cc
 
 # Optionally place shared companion header(s) next to extension.cc so the source
 # can #include them. Gated on $extension_common_header, so other consumers of
@@ -102,23 +110,28 @@ if ($extension_common_header)
 # Verify VEB was created
 --file_exists $ext_build_dir/build/$extension_name.veb
 
-# Move VEB to server's VEB directory (see the LD_PRELOAD note above).
---exec unset LD_PRELOAD && mkdir -p $veb_dir
+# Move VEB to server's VEB directory.
+--error 0,1
+--mkdir $veb_dir
 
 if ($extension_versioned)
 {
-  --exec unset LD_PRELOAD && cp $ext_build_dir/build/$extension_name.veb $veb_dir/$extension_name-$extension_version.veb
+  --error 0,1
+  --remove_file $veb_dir/$extension_name-$extension_version.veb
+  --copy_file $ext_build_dir/build/$extension_name.veb $veb_dir/$extension_name-$extension_version.veb
   --echo Created $extension_name-$extension_version.veb
 }
 
 if (!$extension_versioned)
 {
-  --exec unset LD_PRELOAD && cp $ext_build_dir/build/$extension_name.veb $veb_dir/
+  --error 0,1
+  --remove_file $veb_dir/$extension_name.veb
+  --copy_file $ext_build_dir/build/$extension_name.veb $veb_dir/$extension_name.veb
   --echo Created $extension_name.veb
 }
 
 # Cleanup build directory
---exec unset LD_PRELOAD && rm -rf $ext_build_dir
+--force-rmdir $ext_build_dir
 
 # Reset variables
 --let $extension_name =

--- a/mysql-test/include/villagesql/create_extension_sdk_expect_build_failure.inc
+++ b/mysql-test/include/villagesql/create_extension_sdk_expect_build_failure.inc
@@ -42,30 +42,31 @@ if (!$extension_version)
 
 --exec test -d "$sdk_dir" || (echo "ERROR: SDK not found at $sdk_dir. Run 'make sdk' first." && exit 1)
 
---exec rm -rf $ext_build_dir
---exec mkdir -p $ext_build_dir/src
---exec mkdir -p $ext_build_dir/build
+# Every --exec below strips LD_PRELOAD so the exec'd command does not run under
+# the LD_PRELOAD'd ASan runtime on sanitizer builds; otherwise uninstrumented
+# system binaries (cp, mkdir, sed, gcc) trip LeakSanitizer on their own
+# allocations and fail for the wrong reason (see create_extension_sdk.inc for
+# the full explanation).
+--exec unset LD_PRELOAD && rm -rf $ext_build_dir
+--exec unset LD_PRELOAD && mkdir -p $ext_build_dir/src
+--exec unset LD_PRELOAD && mkdir -p $ext_build_dir/build
 
---exec cp $extension_source $ext_build_dir/src/extension.cc
+--exec unset LD_PRELOAD && cp $extension_source $ext_build_dir/src/extension.cc
 
 # Optionally place shared companion header(s) next to extension.cc so the source
 # can #include them.
 if ($extension_common_header)
 {
-  --exec cp $extension_common_header $ext_build_dir/src/
+  --exec unset LD_PRELOAD && cp $extension_common_header $ext_build_dir/src/
 }
 
---exec printf '%s' '{"name": "$extension_name", "version": "$extension_version"}' > $ext_build_dir/manifest.json
+--exec unset LD_PRELOAD && printf '%s' '{"name": "$extension_name", "version": "$extension_version"}' > $ext_build_dir/manifest.json
 
 --let $cmake_template = $MYSQL_TEST_DIR/suite/villagesql/data/extension_creator/CMakeLists.txt.template
---exec sed 's/@EXTENSION_NAME@/$extension_name/g' $cmake_template > $ext_build_dir/CMakeLists.txt
+--exec unset LD_PRELOAD && sed 's/@EXTENSION_NAME@/$extension_name/g' $cmake_template > $ext_build_dir/CMakeLists.txt
 
 --echo Attempting to build $extension_name (expecting build failure)...
 
-# unset LD_PRELOAD so the toolchain sub-build does not run under the
-# LD_PRELOAD'd ASan runtime on sanitizer builds; otherwise the uninstrumented
-# system gcc trips LeakSanitizer on GCC's own allocations and fails for the
-# wrong reason (see create_extension_sdk.inc for the full explanation).
 --replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR $build_dir BUILD_DIR
 --exec cd $ext_build_dir/build && unset LD_PRELOAD && cmake -DVillageSQL_SDK_DIR=$sdk_dir -DCMAKE_MODULE_PATH=$sdk_dir/lib/cmake/VillageSQLExtensionFramework -DVSQL_USE_DEV_ABI=ON .. > cmake_output.txt 2>&1 || (cat cmake_output.txt && exit 1)
 
@@ -78,12 +79,12 @@ if ($extension_common_header)
 # If a pattern is specified, verify it appears in the build output.
 if ($build_failure_grep)
 {
-  --exec grep -q "$build_failure_grep" $ext_build_dir/build/make_output.txt || (echo "ERROR: build output missing expected pattern: $build_failure_grep" && cat $ext_build_dir/build/make_output.txt && exit 1)
+  --exec unset LD_PRELOAD && grep -q "$build_failure_grep" $ext_build_dir/build/make_output.txt || (echo "ERROR: build output missing expected pattern: $build_failure_grep" && cat $ext_build_dir/build/make_output.txt && exit 1)
 }
 
 --echo Build failed as expected.
 
---exec rm -rf $ext_build_dir
+--exec unset LD_PRELOAD && rm -rf $ext_build_dir
 
 --let $extension_name =
 --let $extension_version =

--- a/mysql-test/include/villagesql/create_extension_sdk_expect_build_failure.inc
+++ b/mysql-test/include/villagesql/create_extension_sdk_expect_build_failure.inc
@@ -40,7 +40,16 @@ if (!$extension_version)
 --let $sdk_dir = $build_dir/villagesql-extension-sdk-$sdk_abbr
 --let $ext_build_dir = $MYSQLTEST_VARDIR/tmp/ext_build_$extension_name
 
---exec test -d "$sdk_dir" || (echo "ERROR: SDK not found at $sdk_dir. Run 'make sdk' first." && exit 1)
+# File operations here use mysqltest built-ins or --perl rather than --exec, so
+# no uninstrumented system binary is spawned (see create_extension_sdk.inc for
+# the full explanation). Only cmake and make remain as --exec.
+--let VSQL_SDK_DIR = $sdk_dir
+--perl
+  use strict;
+  use warnings;
+  my $sdk = $ENV{'VSQL_SDK_DIR'};
+  die "ERROR: SDK not found at $sdk. Run 'make sdk' first.\n" unless -d $sdk;
+EOF
 
 # --mkdir is not recursive, so each level is created separately. --force-rmdir
 # fails if the directory is not there, which is the normal case.
@@ -52,24 +61,43 @@ if (!$extension_version)
 
 --copy_file $extension_source $ext_build_dir/src/extension.cc
 
-# Every --exec below strips LD_PRELOAD so the exec'd command does not run under
-# the LD_PRELOAD'd ASan runtime on sanitizer builds; otherwise uninstrumented
-# system binaries (sh, cp, sed, grep, gcc) trip LeakSanitizer on their own
-# allocations and fail for the wrong reason (see create_extension_sdk.inc for
-# the full explanation). The file operations above use mysqltest's built-in
-# commands, which run in-process and never inherit the preloaded runtime.
-
-# Optionally place shared companion header(s) next to extension.cc so the source
-# can #include them.
-if ($extension_common_header)
-{
-  --exec unset LD_PRELOAD && cp $extension_common_header $ext_build_dir/src/
-}
-
---exec unset LD_PRELOAD && printf '%s' '{"name": "$extension_name", "version": "$extension_version"}' > $ext_build_dir/manifest.json
-
 --let $cmake_template = $MYSQL_TEST_DIR/suite/villagesql/data/extension_creator/CMakeLists.txt.template
---exec unset LD_PRELOAD && sed 's/@EXTENSION_NAME@/$extension_name/g' $cmake_template > $ext_build_dir/CMakeLists.txt
+
+# Place the optional companion header(s) next to extension.cc, write
+# manifest.json, and expand the CMakeLists.txt template.
+--let VSQL_EXT_BUILD_DIR = $ext_build_dir
+--let VSQL_EXT_NAME = $extension_name
+--let VSQL_EXT_VERSION = $extension_version
+--let VSQL_EXT_COMMON_HEADER = $extension_common_header
+--let VSQL_CMAKE_TEMPLATE = $cmake_template
+--perl
+  use strict;
+  use warnings;
+  use File::Basename;
+  use File::Copy;
+  my $dir = $ENV{'VSQL_EXT_BUILD_DIR'};
+  my $name = $ENV{'VSQL_EXT_NAME'};
+
+  foreach my $header (split(' ', $ENV{'VSQL_EXT_COMMON_HEADER'} // '')) {
+    copy($header, "$dir/src/" . basename($header))
+      or die "ERROR: failed to copy $header into $dir/src: $!\n";
+  }
+
+  open(my $mf, '>', "$dir/manifest.json")
+    or die "ERROR: cannot write $dir/manifest.json: $!\n";
+  print $mf '{"name": "' . $name . '", "version": "' . $ENV{'VSQL_EXT_VERSION'} . '"}';
+  close($mf);
+
+  my $template = $ENV{'VSQL_CMAKE_TEMPLATE'};
+  open(my $in, '<', $template) or die "ERROR: cannot read $template: $!\n";
+  my $cmake = do { local $/; <$in> };
+  close($in);
+  $cmake =~ s/\@EXTENSION_NAME\@/$name/g;
+  open(my $out, '>', "$dir/CMakeLists.txt")
+    or die "ERROR: cannot write $dir/CMakeLists.txt: $!\n";
+  print $out $cmake;
+  close($out);
+EOF
 
 --echo Attempting to build $extension_name (expecting build failure)...
 
@@ -79,14 +107,27 @@ if ($extension_common_header)
 # Run make and capture output; do not fail on non-zero exit.
 --exec cd $ext_build_dir/build && unset LD_PRELOAD && make > make_output.txt 2>&1 || true
 
-# Verify the build actually failed (no VEB produced).
---exec unset LD_PRELOAD && test ! -f $ext_build_dir/build/$extension_name.veb || (echo "ERROR: $extension_name.veb was produced; expected build failure" && exit 1)
+# Verify the build actually failed (no VEB produced), and that the build output
+# contains $build_failure_grep when one was given.
+--let VSQL_BUILD_FAILURE_GREP = $build_failure_grep
+--perl
+  use strict;
+  use warnings;
+  my $dir = $ENV{'VSQL_EXT_BUILD_DIR'};
+  my $name = $ENV{'VSQL_EXT_NAME'};
+  die "ERROR: $name.veb was produced; expected build failure\n"
+    if -f "$dir/build/$name.veb";
 
-# If a pattern is specified, verify it appears in the build output.
-if ($build_failure_grep)
-{
-  --exec unset LD_PRELOAD && grep -q "$build_failure_grep" $ext_build_dir/build/make_output.txt || (echo "ERROR: build output missing expected pattern: $build_failure_grep" && cat $ext_build_dir/build/make_output.txt && exit 1)
-}
+  my $pattern = $ENV{'VSQL_BUILD_FAILURE_GREP'} // '';
+  if ($pattern ne '') {
+    my $log = "$dir/build/make_output.txt";
+    open(my $fh, '<', $log) or die "ERROR: cannot read $log: $!\n";
+    my $output = do { local $/; <$fh> };
+    close($fh);
+    die "ERROR: build output missing expected pattern: $pattern\n$output"
+      if index($output, $pattern) < 0;
+  }
+EOF
 
 --echo Build failed as expected.
 

--- a/mysql-test/include/villagesql/create_extension_sdk_expect_build_failure.inc
+++ b/mysql-test/include/villagesql/create_extension_sdk_expect_build_failure.inc
@@ -42,16 +42,22 @@ if (!$extension_version)
 
 --exec test -d "$sdk_dir" || (echo "ERROR: SDK not found at $sdk_dir. Run 'make sdk' first." && exit 1)
 
+# --mkdir is not recursive, so each level is created separately. --force-rmdir
+# fails if the directory is not there, which is the normal case.
+--error 0,1
+--force-rmdir $ext_build_dir
+--mkdir $ext_build_dir
+--mkdir $ext_build_dir/src
+--mkdir $ext_build_dir/build
+
+--copy_file $extension_source $ext_build_dir/src/extension.cc
+
 # Every --exec below strips LD_PRELOAD so the exec'd command does not run under
 # the LD_PRELOAD'd ASan runtime on sanitizer builds; otherwise uninstrumented
-# system binaries (cp, mkdir, sed, gcc) trip LeakSanitizer on their own
+# system binaries (sh, cp, sed, grep, gcc) trip LeakSanitizer on their own
 # allocations and fail for the wrong reason (see create_extension_sdk.inc for
-# the full explanation).
---exec unset LD_PRELOAD && rm -rf $ext_build_dir
---exec unset LD_PRELOAD && mkdir -p $ext_build_dir/src
---exec unset LD_PRELOAD && mkdir -p $ext_build_dir/build
-
---exec unset LD_PRELOAD && cp $extension_source $ext_build_dir/src/extension.cc
+# the full explanation). The file operations above use mysqltest's built-in
+# commands, which run in-process and never inherit the preloaded runtime.
 
 # Optionally place shared companion header(s) next to extension.cc so the source
 # can #include them.
@@ -74,7 +80,7 @@ if ($extension_common_header)
 --exec cd $ext_build_dir/build && unset LD_PRELOAD && make > make_output.txt 2>&1 || true
 
 # Verify the build actually failed (no VEB produced).
---exec test ! -f $ext_build_dir/build/$extension_name.veb || (echo "ERROR: $extension_name.veb was produced; expected build failure" && exit 1)
+--exec unset LD_PRELOAD && test ! -f $ext_build_dir/build/$extension_name.veb || (echo "ERROR: $extension_name.veb was produced; expected build failure" && exit 1)
 
 # If a pattern is specified, verify it appears in the build output.
 if ($build_failure_grep)
@@ -84,7 +90,7 @@ if ($build_failure_grep)
 
 --echo Build failed as expected.
 
---exec unset LD_PRELOAD && rm -rf $ext_build_dir
+--force-rmdir $ext_build_dir
 
 --let $extension_name =
 --let $extension_version =


### PR DESCRIPTION
On sanitizer builds MTR's safe_process LD_PRELOADs the shared ASan runtime into every child process, and that propagates through mysqltest into `--exec`'d commands. The uninstrumented system binaries then run under LeakSanitizer, which flags their own allocations at exit and kills them with LSAN_OPTIONS=exitcode=42.

create_extension_sdk.inc already unset LD_PRELOAD for the cmake and make steps, but not for the surrounding cp/mkdir/rm/sed steps. That surfaced as a spurious failure in extension_duplicate_index_profile, where the two-file `cp $extension_common_header` exited 42; the reported errno 2 was stale and made it look like a missing path.

Prefix every `--exec` that spawns an external binary with `unset LD_PRELOAD &&` in all three extension-build includes, and hoist the explanation in create_extension_sdk.inc into a single note covering the whole file. The `test` guards are shell builtins and are unchanged.
