### PR TITLE
Set all self-hosted to linux x86_64

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   build-and-test:
     name: Build and Test VillageSQL
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: [self-hosted, linux, X64]
     permissions:
       actions: write  # Required to read/write caches
       contents: read

--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -46,7 +46,7 @@ on:
 jobs:
   build-and-test:
     name: Build and Run All Tests
-    runs-on: self-hosted
+    runs-on: [self-hosted, linux, x86_64]
     permissions:
       contents: read
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test-and-tag:
     name: Nightly Build and Test
-    runs-on: self-hosted
+    runs-on: [self-hosted, linux, x86_64]
     permissions:
       contents: write  # Required to push tags
       actions: write   # Required to read/write caches

--- a/.github/workflows/release-server-branch.yml
+++ b/.github/workflows/release-server-branch.yml
@@ -48,7 +48,7 @@ permissions:
 jobs:
   report-parameters:
     name: Report Parameters
-    runs-on: self-hosted
+    runs-on: [self-hosted, linux, x86_64]
     steps:
     - name: Report Parameters
       run: |

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -24,7 +24,7 @@ on:
 jobs:
   valgrind-test:
     name: Build and Run Valgrind Tests
-    runs-on: self-hosted
+    runs-on: [self-hosted, linux, x86_64]
     permissions:
       contents: read
 


### PR DESCRIPTION
## Description

Parks all self-hosted workflows on our linux amd64 github runners.

As currently configured, these are ephemeral "e2-standard-32" hardware with 32 virtual cores and 128 GB of memory.  So still larger than most of our laptops.

Also points out the need for more structured runner tagging, maybe `vsql-build-worker`

## Related Issue

Part of the [Server]: Overhaul CI #819 effort.
