### PR TITLE
bld: install jq in build env setup

### DIFF
--- a/villagesql/bld_tools/setup_linux_build_env.sh
+++ b/villagesql/bld_tools/setup_linux_build_env.sh
@@ -39,4 +39,5 @@ $SUDO apt-get "${APT_OPTS[@]}" install -y --no-install-recommends \
     openssl \
     libdbd-mysql-perl \
     zip \
-    unzip
+    unzip \
+    jq

--- a/villagesql/bld_tools/setup_linux_build_env.sh
+++ b/villagesql/bld_tools/setup_linux_build_env.sh
@@ -16,28 +16,28 @@ fi
 APT_OPTS=(-o Acquire::Retries=5)
 $SUDO apt-get "${APT_OPTS[@]}" update
 $SUDO apt-get "${APT_OPTS[@]}" install -y --no-install-recommends \
-    build-essential \
-    cmake \
-    libssl-dev \
-    pkg-config \
-    bison \
-    libncurses5-dev \
-    libaio-dev \
-    libmecab-dev \
-    libnuma-dev \
-    libjson-perl \
-    libz-dev \
-    g++ \
-    make \
-    git \
-    curl \
     bash \
-    valgrind \
-    libtirpc-dev \
+    bison \
+    build-essential \
     ccache \
-    perl \
-    openssl \
+    cmake \
+    curl \
+    g++ \
+    git \
+    jq \
+    libaio-dev \
     libdbd-mysql-perl \
-    zip \
+    libjson-perl \
+    libmecab-dev \
+    libncurses5-dev \
+    libnuma-dev \
+    libssl-dev \
+    libtirpc-dev \
+    libz-dev \
+    make \
+    openssl \
+    perl \
+    pkg-config \
     unzip \
-    jq
+    valgrind \
+    zip

--- a/villagesql/bld_tools/setup_macos_build_env.sh
+++ b/villagesql/bld_tools/setup_macos_build_env.sh
@@ -7,4 +7,4 @@
 
 set -e
 
-brew install bison cmake openssl
+brew install bison cmake openssl jq

--- a/villagesql/bld_tools/setup_macos_build_env.sh
+++ b/villagesql/bld_tools/setup_macos_build_env.sh
@@ -7,4 +7,4 @@
 
 set -e
 
-brew install bison cmake openssl jq
+brew install bison cmake jq openssl


### PR DESCRIPTION
## Description
The bundled extension tools read the JSON extensions table with jq as of #975. GitHub runners ship jq, so CI passes while a plain Debian or macOS box fails the checkout with "jq: command not found".

AI=CLAUDE

## Related Issue
#975 

## How was this tested?
n/a

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
