### PR TITLE
Normalize arch spelling in runs-on

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ concurrency:
 jobs:
   build-and-test:
     name: Build and Test VillageSQL
-    runs-on: [self-hosted, linux, X64]
+    runs-on: [self-hosted, linux, x86_64]
     permissions:
       actions: write  # Required to read/write caches
       contents: read


### PR DESCRIPTION
## Description

Sets build.yml to use the same self-hosted runs-on spelling for architecture that the action runners use.

## Related Issue

Part of the [Server]: Overhaul CI #819 effort.
