### PR TITLE
Update perfschema auth plugin tests

### DIFF
--- a/mysql-test/suite/perfschema/r/hostcache_ipv4_auth_plugin.result
+++ b/mysql-test/suite/perfschema/r/hostcache_ipv4_auth_plugin.result
@@ -35,7 +35,7 @@ current_user()
 root@localhost
 set global debug= "+d,vio_peer_addr_fake_ipv4,getnameinfo_fake_ipv4,getaddrinfo_fake_good_ipv4";
 uninstall plugin test_plugin_server;
-ERROR HY000: Plugin 'test_plugin_server' is not loaded
+ERROR HY000: authentication method 'test_plugin_server' is not available (no such plugin or extension auth method)
 "Dumping performance_schema.host_cache"
 IP	192.0.2.4
 HOST	santa.claus.ipv4.example.com
@@ -64,7 +64,7 @@ COUNT_LOCAL_ERRORS	0
 COUNT_UNKNOWN_ERRORS	0
 FIRST_ERROR_SEEN	set
 LAST_ERROR_SEEN	set
-ERROR HY000: Plugin 'test_plugin_server' is not loaded
+ERROR HY000: authentication method 'test_plugin_server' is not available (no such plugin or extension auth method)
 "Dumping performance_schema.host_cache"
 IP	192.0.2.4
 HOST	santa.claus.ipv4.example.com

--- a/mysql-test/suite/perfschema/r/hostcache_ipv6_auth_plugin.result
+++ b/mysql-test/suite/perfschema/r/hostcache_ipv6_auth_plugin.result
@@ -35,7 +35,7 @@ current_user()
 root@localhost
 set global debug= "+d,vio_peer_addr_fake_ipv6,getnameinfo_fake_ipv6,getaddrinfo_fake_good_ipv6";
 uninstall plugin test_plugin_server;
-ERROR HY000: Plugin 'test_plugin_server' is not loaded
+ERROR HY000: authentication method 'test_plugin_server' is not available (no such plugin or extension auth method)
 "Dumping performance_schema.host_cache"
 IP	2001:db8::6:6
 HOST	santa.claus.ipv6.example.com
@@ -64,7 +64,7 @@ COUNT_LOCAL_ERRORS	0
 COUNT_UNKNOWN_ERRORS	0
 FIRST_ERROR_SEEN	set
 LAST_ERROR_SEEN	set
-ERROR HY000: Plugin 'test_plugin_server' is not loaded
+ERROR HY000: authentication method 'test_plugin_server' is not available (no such plugin or extension auth method)
 "Dumping performance_schema.host_cache"
 IP	2001:db8::6:6
 HOST	santa.claus.ipv6.example.com

--- a/mysql-test/suite/perfschema/t/hostcache_ipv4_auth_plugin.test
+++ b/mysql-test/suite/perfschema/t/hostcache_ipv4_auth_plugin.test
@@ -31,7 +31,7 @@ set global debug= "+d,vio_peer_addr_fake_ipv4,getnameinfo_fake_ipv4,getaddrinfo_
 uninstall plugin test_plugin_server;
 
 --disable_query_log
---error ER_PLUGIN_IS_NOT_LOADED
+--error ER_VILLAGESQL_GENERIC_ERROR
 connect (con2,"127.0.0.1",plug,plug_dest,test,$MASTER_MYPORT,,,auth_test_plugin);
 --enable_query_log
 
@@ -39,7 +39,7 @@ connect (con2,"127.0.0.1",plug,plug_dest,test,$MASTER_MYPORT,,,auth_test_plugin)
 --source ../include/hostcache_dump.inc
 
 --disable_query_log
---error ER_PLUGIN_IS_NOT_LOADED
+--error ER_VILLAGESQL_GENERIC_ERROR
 connect (con3,"127.0.0.1",plug,plug_dest,test,$MASTER_MYPORT,,,auth_test_plugin);
 --enable_query_log
 

--- a/mysql-test/suite/perfschema/t/hostcache_ipv6_auth_plugin.test
+++ b/mysql-test/suite/perfschema/t/hostcache_ipv6_auth_plugin.test
@@ -32,7 +32,7 @@ set global debug= "+d,vio_peer_addr_fake_ipv6,getnameinfo_fake_ipv6,getaddrinfo_
 uninstall plugin test_plugin_server;
 
 --disable_query_log
---error ER_PLUGIN_IS_NOT_LOADED
+--error ER_VILLAGESQL_GENERIC_ERROR
 connect (con2,"::1",plug,plug_dest,test,$MASTER_MYPORT,,,auth_test_plugin);
 --enable_query_log
 
@@ -40,7 +40,7 @@ connect (con2,"::1",plug,plug_dest,test,$MASTER_MYPORT,,,auth_test_plugin);
 --source ../include/hostcache_dump.inc
 
 --disable_query_log
---error ER_PLUGIN_IS_NOT_LOADED
+--error ER_VILLAGESQL_GENERIC_ERROR
 connect (con3,"::1",plug,plug_dest,test,$MASTER_MYPORT,,,auth_test_plugin);
 --enable_query_log
 


### PR DESCRIPTION
## Description

Update the `perfschema.hostcache_ipv4_auth_plugin` and `perfschema.hostcache_ipv6_auth_plugin` tests to the latest response codes and message texts.

These values changed as a result of auth capability #762

## Related Issue

part of #639

## How was this tested?

Manual runs with

```bash
$ mysql-test/mysql-test-run.pl perfschema.hostcache_ipv6_auth_plugin
$ mysql-test/mysql-test-run.pl perfschema.hostcache_ipv4_auth_plugin
```
