### PR TITLE
Rerecord perfschema.privilege_table_io

### DIFF
--- a/mysql-test/suite/perfschema/r/privilege_table_io.result
+++ b/mysql-test/suite/perfschema/r/privilege_table_io.result
@@ -117,6 +117,7 @@ wait/io/table/sql/handler	handler.cc:	TABLE	mysql	global_grants	fetch	1
 wait/io/table/sql/handler	handler.cc:	TABLE	mysql	global_grants	fetch	1
 wait/io/table/sql/handler	handler.cc:	TABLE	mysql	global_grants	fetch	1
 wait/io/table/sql/handler	handler.cc:	TABLE	mysql	global_grants	fetch	1
+wait/io/table/sql/handler	handler.cc:	TABLE	mysql	global_grants	fetch	1
 wait/io/table/sql/handler	handler.cc:	TABLE	mysql	role_edges	fetch	1
 wait/io/table/sql/handler	handler.cc:	TABLE	mysql	default_roles	fetch	1
 wait/io/table/sql/handler	handler.cc:	TABLE	mysql	tables_priv	fetch	1


### PR DESCRIPTION
## Description

Updates the perfschema.privilege_table_io to the current results.

Presumably EXTENSION_ADMIN created an additional global grants row.

## Related Issue

May involve [VEF Hook]: Expose authentication plugin interface through VEF ABI https://github.com/villagesql/villagesql-server/issues/639

## How was this tested?

<!-- Describe how you verified your changes. Include test commands you ran. -->

```bash
$ mysql-test/mysql-test-run.pl perfschema.privilege_table_io
```
