### PR TITLE
docs: point README at the setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,26 +46,12 @@ For quick installation, visit [villagesql.com/install](https://villagesql.com/in
 
 ### Prerequisites
 
-- **CMake** (3.14.6 or higher; macOS requires 3.19 or higher)
-- **C++20 Compiler** (GCC 10+ or Clang 14+)
-- **OpenSSL 3.0+**
-- **Bison** (3.0.4 or higher)
-- **pkg-config**
-- **ncurses development libraries**
-- **libtirpc and rpcsvc-proto**
+- **Git**
+- **A supported platform**: Debian or Ubuntu Linux, or macOS with Homebrew
 
-#### Installing Dependencies
-
-**Linux (Debian/Ubuntu):**
-```bash
-sudo apt install cmake libssl-dev libncurses5-dev pkg-config bison \
-                 libtirpc-dev rpcsvc-proto build-essential zlib1g-dev
-```
-
-**macOS (Homebrew):**
-```bash
-brew install cmake openssl@3 pkgconf bison libtirpc rpcsvc-proto
-```
+The build also needs a C++20 compiler, CMake 3.14.6 or newer (3.19 on macOS),
+Bison 3.0.4 or newer, OpenSSL 3, and several development libraries. Step 2
+below installs all of them.
 
 ### Build Steps (Linux & macOS)
 
@@ -78,21 +64,37 @@ brew install cmake openssl@3 pkgconf bison libtirpc rpcsvc-proto
 1. **Clone the repository into `$HOME`:**
 
    The steps below assume the clone is at `$HOME/villagesql-server`. If you put
-   it elsewhere, use that path in step 3.
+   it elsewhere, use that path in step 4.
 
    ```bash
    cd "$HOME"
    git clone --depth 1 https://github.com/villagesql/villagesql-server.git
    ```
 
-2. **Create a build directory (outside the repository):**
+2. **Install the build dependencies:**
+
+   ```bash
+   cd "$HOME/villagesql-server"
+   villagesql/bld_tools/setup_build_env.sh
+   ```
+
+   The script detects the operating system and runs
+   `villagesql/bld_tools/setup_linux_build_env.sh` or
+   `villagesql/bld_tools/setup_macos_build_env.sh`. Those two scripts are the
+   definitive dependency lists, and VillageSQL CI installs from the same ones.
+   On Linux the script uses `apt-get` and asks for `sudo`; on macOS it uses
+   Homebrew. On a Linux distribution that is not Debian or Ubuntu, read
+   `villagesql/bld_tools/setup_linux_build_env.sh` and install the equivalent
+   packages with your own package manager.
+
+3. **Create a build directory (outside the repository):**
 
    ```bash
    mkdir -p "$HOME/build/villagesql"
    cd "$HOME/build/villagesql"
    ```
 
-3. **Configure with CMake:**
+4. **Configure with CMake:**
 
    ```bash
    # Standard build
@@ -102,15 +104,15 @@ brew install cmake openssl@3 pkgconf bison libtirpc rpcsvc-proto
    cmake "$HOME/villagesql-server" -DWITH_DEBUG=1 -DWITH_SSL=system
    ```
 
-4. **Build:**
+5. **Build:**
    ```bash
    make -j $(getconf _NPROCESSORS_ONLN)
    ```
 
-   This builds every target, including the `mysql` client that Step 5 uses to
-   connect. A build limited to the `mysqld` target leaves Step 5 with no client.
+   This builds every target, including the `mysql` client that step 6 uses to
+   connect. A build limited to the `mysqld` target leaves step 6 with no client.
 
-5. **Initialize and Start the Server:**
+6. **Initialize and Start the Server:**
 
    ```bash
    # Create the data directory

--- a/scripts/setup_linux_ext_deps.sh
+++ b/scripts/setup_linux_ext_deps.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
-# Installs the minimal build dependencies needed to compile a VillageSQL
-# extension VEB on a Linux host. Intentionally lighter than
-# setup_linux_build_env.sh, which pulls in server-only tools (valgrind, bison,
-# Perl libs, etc.) that extensions do not need.
+# Installs the build dependencies needed to compile a VillageSQL extension VEB
+# on a Linux host. Intentionally lighter than setup_linux_build_env.sh, which
+# pulls in server-only tools (valgrind, bison, Perl libs, etc.) that extensions
+# do not need.
+#
+# libcurl4-openssl-dev is not a general extension requirement. It is here
+# because this script also prepares the bundled-extension build, and vsql_http
+# links libcurl. An extension with its own third-party dependency installs it
+# in its own CI, not here.
 
 set -e
 

--- a/scripts/setup_macos_ext_deps.sh
+++ b/scripts/setup_macos_ext_deps.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
-# Installs the minimal build dependencies needed to compile a VillageSQL
-# extension VEB on a macOS host. Mirrors setup_linux_ext_deps.sh for macOS;
-# Xcode Command Line Tools (build-essential equivalent) are pre-installed on
-# GitHub Actions runners.
+# Installs the build dependencies needed to compile a VillageSQL extension VEB
+# on a macOS host. Mirrors setup_linux_ext_deps.sh for macOS; Xcode Command Line
+# Tools (build-essential equivalent) are pre-installed on GitHub Actions
+# runners.
+#
+# curl is not a general extension requirement. It is here because this script
+# also prepares the bundled-extension build, and vsql_http links libcurl. An
+# extension with its own third-party dependency installs it in its own CI, not
+# here.
 
 set -e
 


### PR DESCRIPTION
## Description
The README carried its own copy of the apt and brew package lists. That copy
had drifted from `villagesql/bld_tools/`, and nothing checks it. 
Instead, point the README at the script instead of maintaining a list that can drift.

AI=CLAUDE
## Related Issue
n/a

## How was this tested?
Built the server in a clean `ubuntu:24.04` container using only the steps the README now gives.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
