### PR TITLE
SAN: fix deadlock during callback

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-thread-worker/r/lifecycle_enable_disable_race.result
+++ b/mysql-test/suite/villagesql/extension/vsql-thread-worker/r/lifecycle_enable_disable_race.result
@@ -1,0 +1,9 @@
+INSTALL EXTENSION vsql_lifecycle_test;
+# 20 ON/OFF cycles with no wait between them, so an OFF lands while the
+# worker is still starting up.
+# Worker is stopped and the server still answers queries
+SELECT COUNT(*) FROM performance_schema.processlist
+WHERE user = 'vef_worker' AND info = 'vsql_lifecycle_test/monitor';
+COUNT(*)
+0
+UNINSTALL EXTENSION vsql_lifecycle_test;

--- a/mysql-test/suite/villagesql/extension/vsql-thread-worker/t/lifecycle_enable_disable_race.test
+++ b/mysql-test/suite/villagesql/extension/vsql-thread-worker/t/lifecycle_enable_disable_race.test
@@ -1,0 +1,39 @@
+# Test thread_worker lifecycle: disabling a worker must not wedge the server.
+#
+# The enabled-var callback runs from a sys var update function, which the server
+# calls with LOCK_global_system_variables held. The disable path waits for the
+# worker to publish its handle and then joins it, and a starting worker needs
+# that same mutex to construct its THD. Holding the mutex across the wait made
+# an OFF that landed in the worker's startup window deadlock permanently: the
+# server stopped answering any query needing the mutex, and the test only failed
+# once the MTR testcase timeout expired.
+#
+# Verifies:
+# - Rapid ON/OFF cycles complete, with no wait between them
+# - The worker is stopped and the server still answers queries afterwards
+
+# The processlist check requires PSI thread instrumentation.
+if (`SELECT COUNT(*)=0 FROM performance_schema.threads`)
+{
+  skip Needs PSI thread instrumentation (DISABLE_PSI_THREAD must be 0);
+}
+
+INSTALL EXTENSION vsql_lifecycle_test;
+
+--echo # 20 ON/OFF cycles with no wait between them, so an OFF lands while the
+--echo # worker is still starting up.
+--disable_query_log
+let $counter=20;
+while ($counter>0)
+{
+  SET GLOBAL vsql_lifecycle_test.monitor_enabled = ON;
+  SET GLOBAL vsql_lifecycle_test.monitor_enabled = OFF;
+  dec $counter;
+}
+--enable_query_log
+
+--echo # Worker is stopped and the server still answers queries
+SELECT COUNT(*) FROM performance_schema.processlist
+WHERE user = 'vef_worker' AND info = 'vsql_lifecycle_test/monitor';
+
+UNINSTALL EXTENSION vsql_lifecycle_test;

--- a/villagesql/sdk/include/villagesql/abi/preview/sys_var.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/sys_var.h
@@ -72,6 +72,15 @@ typedef struct {
 } vef_sys_var_change_t;
 
 // Callback invoked after the server writes a new value for a system variable.
+//
+// Runs while the server holds its global system-variable lock, which has two
+// consequences. Reading or writing another of this extension's variables
+// through its storage pointer is safe and immediately visible to other
+// sessions, because the server reads those under the same lock. But anything
+// that re-enters the server to touch a system variable will deadlock on that
+// lock: do not call sys_var get/set, do not execute SQL, and do not wait on a
+// thread that does either. Keep the callback short and non-blocking; use a
+// thread_worker if the work needs SQL or can block.
 typedef void (*vef_sys_var_on_change_func_t)(const vef_sys_var_change_t *);
 
 // TODO(villagesql-beta): rename vef_sys_var_desc_t to vef_sys_var_cc_t

--- a/villagesql/sdk/include/villagesql/abi/preview/thread_worker.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/thread_worker.h
@@ -108,6 +108,9 @@ typedef struct {
 // extension's behalf at load time. The var name is descriptor->var_name if set,
 // otherwise
 // "{suffix}_enabled". Setting it ON starts the background thread; OFF stops it.
+// Both are synchronous: ON returns after work_fn(ENABLE), OFF after the thread
+// has exited. Neither holds a server sys var lock, so work_fn may read sys vars
+// and run SQL.
 //
 // Capability name: VEF_PREVIEW_THREAD_WORKER_NAME
 

--- a/villagesql/sdk/include/villagesql/preview/sys_var.h
+++ b/villagesql/sdk/include/villagesql/preview/sys_var.h
@@ -103,6 +103,14 @@ class SysVarChange {
 //
 //   {sv::INT, "threshold_ms", "Threshold", &g_threshold, 1000, 0, 3600000}
 //       .on_change<&my_on_change>()
+//
+// The callback runs while the server holds its global system-variable lock, so
+// it must stay short and non-blocking. Reading or writing another of this
+// extension's variables through its storage pointer is safe and immediately
+// visible to other sessions. Calling sys var get/set, running SQL, or waiting
+// on a thread that does either deadlocks on that lock; do that work in a
+// thread_worker instead. See vef_sys_var_on_change_func_t in
+// villagesql/abi/preview/sys_var.h.
 struct SysVarDescriptor {
   Type type;
   const char *name;

--- a/villagesql/services/preview/thread_worker.cc
+++ b/villagesql/services/preview/thread_worker.cc
@@ -86,6 +86,11 @@ struct WorkerState {
   // which outlives the handle, so it stays valid across the teardown.
   std::mutex stop_mu;
 
+  // Serializes worker_start()/worker_stop(). LOCK_global_system_variables is
+  // released around the enabled-var callback, so concurrent SET GLOBALs (or a
+  // SET racing UNINSTALL EXTENSION) can reach the lifecycle code at once.
+  std::mutex lifecycle_mu;
+
   // Current dynamic wakeup config, updated from work_fn return values.
   int current_poll_fd{-1};
   unsigned int current_sleep_ms{0};
@@ -313,6 +318,7 @@ static void thread_main(WorkerState *state) {
 }
 
 static void worker_start(WorkerState *state) {
+  std::lock_guard<std::mutex> lifecycle(state->lifecycle_mu);
   if (state->thread.joinable()) return;
 
   const vef_thread_worker_descriptor_t *desc = state->descriptor;
@@ -330,8 +336,11 @@ static void worker_start(WorkerState *state) {
 }
 
 static void worker_stop(WorkerState *state) {
+  std::lock_guard<std::mutex> lifecycle(state->lifecycle_mu);
   if (!state->thread.joinable()) return;
 
+  // TODO(villagesql-performance): replace this spin with a condition variable
+  // signaled when thread_main publishes the handle.
   vef_thread_handle_t *handle;
   while ((handle = state->handle.load(std::memory_order_acquire)) ==
          kHandlePending) {

--- a/villagesql/services/preview/thread_worker.cc
+++ b/villagesql/services/preview/thread_worker.cc
@@ -372,11 +372,24 @@ static void on_enabled_change(const char *var_name, bool new_val) {
   }
   if (state == nullptr) return;
 
+  // MySQL calls sys var update functions with LOCK_global_system_variables
+  // held, and worker_start()/worker_stop() block: the worker thread needs that
+  // same mutex to construct its THD, and the extension code it runs needs it to
+  // read a sys var or execute SQL. Release it around the lifecycle call and
+  // re-acquire before returning, the way event_scheduler_update() does for the
+  // event scheduler in sql/sys_vars.cc.
+  //
+  // As with the event scheduler, dropping the mutex means two concurrent SET
+  // GLOBALs can interleave here, so the variable can end up out of sync with
+  // the real worker state; lifecycle_mu keeps the start/stop itself serialized.
+  mysql_mutex_assert_owner(&LOCK_global_system_variables);
+  mysql_mutex_unlock(&LOCK_global_system_variables);
   if (new_val) {
     worker_start(state);
   } else {
     worker_stop(state);
   }
+  mysql_mutex_lock(&LOCK_global_system_variables);
 }
 
 bool on_populate_thread_worker(const PopulateContext &ctx,

--- a/villagesql/services/sys_var_access.cc
+++ b/villagesql/services/sys_var_access.cc
@@ -27,7 +27,9 @@
 #include "mysql/components/services/component_sys_var_service.h"
 #include "mysql/components/services/mysql_string.h"
 #include "mysql/components/services/mysql_system_variable.h"
+#include "mysql/psi/mysql_mutex.h"
 #include "mysql/service_plugin_registry.h"
+#include "sql/mysqld.h"
 #include "villagesql/include/error.h"
 
 namespace villagesql::services {
@@ -61,7 +63,20 @@ static void one_var_update_trampoline(MYSQL_THD, SYS_VAR *, void *val_ptr,
       }
     }
   }
-  if (on_change != nullptr) on_change(var_name_copy.c_str(), new_val);
+  if (on_change == nullptr) return;
+
+  // sys_var::update() holds LOCK_global_system_variables across this callback
+  // (asserted in sys_var_pluginvar::global_update()), and an on_change callback
+  // can block: stopping a background worker joins a thread that may need the
+  // same mutex to create a THD, run SQL, or read a sys var. Release it around
+  // the callback, the way event_scheduler_update() does in sql/sys_vars.cc.
+  //
+  // The new value is published above, so the callback sees it. Dropping the
+  // mutex lets two SET GLOBALs interleave here; callbacks serialize themselves.
+  mysql_mutex_assert_owner(&LOCK_global_system_variables);
+  mysql_mutex_unlock(&LOCK_global_system_variables);
+  on_change(var_name_copy.c_str(), new_val);
+  mysql_mutex_lock(&LOCK_global_system_variables);
 }
 
 }  // namespace

--- a/villagesql/services/sys_var_access.cc
+++ b/villagesql/services/sys_var_access.cc
@@ -27,9 +27,7 @@
 #include "mysql/components/services/component_sys_var_service.h"
 #include "mysql/components/services/mysql_string.h"
 #include "mysql/components/services/mysql_system_variable.h"
-#include "mysql/psi/mysql_mutex.h"
 #include "mysql/service_plugin_registry.h"
-#include "sql/mysqld.h"
 #include "villagesql/include/error.h"
 
 namespace villagesql::services {
@@ -63,20 +61,7 @@ static void one_var_update_trampoline(MYSQL_THD, SYS_VAR *, void *val_ptr,
       }
     }
   }
-  if (on_change == nullptr) return;
-
-  // sys_var::update() holds LOCK_global_system_variables across this callback
-  // (asserted in sys_var_pluginvar::global_update()), and an on_change callback
-  // can block: stopping a background worker joins a thread that may need the
-  // same mutex to create a THD, run SQL, or read a sys var. Release it around
-  // the callback, the way event_scheduler_update() does in sql/sys_vars.cc.
-  //
-  // The new value is published above, so the callback sees it. Dropping the
-  // mutex lets two SET GLOBALs interleave here; callbacks serialize themselves.
-  mysql_mutex_assert_owner(&LOCK_global_system_variables);
-  mysql_mutex_unlock(&LOCK_global_system_variables);
-  on_change(var_name_copy.c_str(), new_val);
-  mysql_mutex_lock(&LOCK_global_system_variables);
+  if (on_change != nullptr) on_change(var_name_copy.c_str(), new_val);
 }
 
 }  // namespace

--- a/villagesql/services/sys_var_access.h
+++ b/villagesql/services/sys_var_access.h
@@ -32,6 +32,15 @@ struct SysVarDesc {
   bool def_val;
   // Called after the server writes a new value. May be null.
   // var_name is the variable name without the extension prefix.
+  //
+  // Runs with LOCK_global_system_variables held, as MySQL calls sys var update
+  // functions (see sys_var::update and sys_var_pluginvar::global_update). A
+  // callback may therefore read or write another variable's storage directly,
+  // but must not call anything that re-acquires that mutex (reading a sys var
+  // through the component service, creating a THD, or running SQL) and must
+  // not wait on a thread that does. A callback that needs to block has to
+  // release the mutex around the blocking part and re-acquire it before
+  // returning, the way event_scheduler_update() does in sql/sys_vars.cc.
   void (*on_change)(const char *var_name, bool new_val);
 };
 


### PR DESCRIPTION
While the callback is being run, drop the global sys var lock. The callback can block and cause a deadlock.

Introduce a lifecycle mutex to cause start/stop serialization that was happening because of the global lock.

This had caused some tests to flake under sanitizer runs due to deadlock/timeout.

