### PR TITLE
VSQL upgrades with MINIMAL flag

### DIFF
--- a/mysql-test/suite/villagesql/startup/r/upgrade_minimal.result
+++ b/mysql-test/suite/villagesql/startup/r/upgrade_minimal.result
@@ -1,0 +1,8 @@
+SET SESSION debug='+d,skip_dd_table_access_check';
+call mtr.add_suppression("Server upgrade is required, but skipped");
+UPDATE villagesql.properties SET value = 'mysql-8.4_0.0.5' WHERE name = 'version';
+# restart: --upgrade=MINIMAL
+SET SESSION debug='+d,skip_dd_table_access_check';
+villagesql_upgrades_ran
+1
+# restart

--- a/mysql-test/suite/villagesql/startup/r/upgrade_minimal.result
+++ b/mysql-test/suite/villagesql/startup/r/upgrade_minimal.result
@@ -1,6 +1,9 @@
 SET SESSION debug='+d,skip_dd_table_access_check';
 call mtr.add_suppression("Server upgrade is required, but skipped");
 UPDATE villagesql.properties SET value = 'mysql-8.4_0.0.5' WHERE name = 'version';
+SELECT value FROM villagesql.properties WHERE name = 'version';
+value
+mysql-8.4_0.0.5
 # restart: --upgrade=MINIMAL
 SET SESSION debug='+d,skip_dd_table_access_check';
 villagesql_upgrades_ran

--- a/mysql-test/suite/villagesql/startup/t/upgrade_minimal.test
+++ b/mysql-test/suite/villagesql/startup/t/upgrade_minimal.test
@@ -10,6 +10,7 @@ call mtr.add_suppression("Server upgrade is required, but skipped");
 
 # Pretend the datadir is at schema version 0.0.5.
 UPDATE villagesql.properties SET value = 'mysql-8.4_0.0.5' WHERE name = 'version';
+SELECT value FROM villagesql.properties WHERE name = 'version';
 
 --let $restart_parameters = restart: --upgrade=MINIMAL
 --source include/restart_mysqld.inc

--- a/mysql-test/suite/villagesql/startup/t/upgrade_minimal.test
+++ b/mysql-test/suite/villagesql/startup/t/upgrade_minimal.test
@@ -1,0 +1,24 @@
+# --upgrade=MINIMAL skips the server upgrades but must still run the
+# VillageSQL schema upgrades.
+
+--source include/villagesql/internal_schema_test.inc
+
+# MINIMAL logs that it skipped the server upgrades.
+call mtr.add_suppression("Server upgrade is required, but skipped");
+
+--let $build_version= `SELECT value FROM villagesql.properties WHERE name = 'version'`
+
+# Pretend the datadir is at schema version 0.0.5.
+UPDATE villagesql.properties SET value = 'mysql-8.4_0.0.5' WHERE name = 'version';
+
+--let $restart_parameters = restart: --upgrade=MINIMAL
+--source include/restart_mysqld.inc
+
+# The stored version is back at the build version iff the upgrades ran.
+--source include/villagesql/internal_schema_test.inc
+--disable_query_log
+--eval SELECT value = '$build_version' AS villagesql_upgrades_ran FROM villagesql.properties WHERE name = 'version'
+--enable_query_log
+
+--let $restart_parameters = restart
+--source include/restart_mysqld.inc

--- a/sql/mysqld.cc
+++ b/sql/mysqld.cc
@@ -8386,11 +8386,22 @@ static int init_server_components() {
 #endif
 
   bool recreate_non_dd_based_system_view = dd::upgrade::I_S_upgrade_required();
+  bool villagesql_upgraded_in_minimal = false;
   if (!is_help_or_validate_option() && !opt_initialize &&
       !dd::upgrade::no_server_upgrade_required()) {
-    if (opt_upgrade_mode == UPGRADE_MINIMAL)
+    if (opt_upgrade_mode == UPGRADE_MINIMAL) {
       LogErr(WARNING_LEVEL, ER_SERVER_UPGRADE_SKIP);
-    else {
+      // VillageSQL system tables are dictionary state, so their upgrades
+      // run even in MINIMAL mode.
+      if (villagesql::SchemaManager::is_villagesql_upgrade_needed()) {
+        if (villagesql::SchemaManager::run_villagesql_upgrades_standalone()) {
+          LogErr(ERROR_LEVEL, ER_SERVER_UPGRADE_FAILED);
+          unireg_abort(MYSQLD_ABORT_EXIT);
+        }
+        recreate_non_dd_based_system_view = true;
+        villagesql_upgraded_in_minimal = true;
+      }
+    } else {
       init_optimizer_cost_module(true);
       if (bootstrap::run_bootstrap_thread(nullptr, nullptr,
                                           &dd::upgrade::upgrade_system_schemas,
@@ -8429,10 +8440,12 @@ static int init_server_components() {
     Re-create non DD based system views after a) if we upgraded system
     schemas b) I_S system view version is changed and server system views
     were recreated. c) If the database was upgraded. We do not update this
-    in upgrade-minimal mode.
+    in upgrade-minimal mode, except when VillageSQL schema upgrades ran.
+    The VillageSQL I_S view overrides are non DD based and must match the
+    upgraded schema.
    */
   if (!is_help_or_validate_option() && !opt_initialize &&
-      opt_upgrade_mode != UPGRADE_MINIMAL &&
+      (opt_upgrade_mode != UPGRADE_MINIMAL || villagesql_upgraded_in_minimal) &&
       recreate_non_dd_based_system_view) {
     if (dd::init(
             dd::enum_dd_init_type::DD_INITIALIZE_NON_DD_BASED_SYSTEM_VIEWS)) {

--- a/villagesql/schema/schema_manager.cc
+++ b/villagesql/schema/schema_manager.cc
@@ -641,6 +641,19 @@ bool install_villagesql_schema(THD *thd) {
   return false;
 }
 
+// Bootstrap-thread handler with the guards upgrade_villagesql_schema
+// normally inherits from dd::upgrade::upgrade_system_schemas.
+bool upgrade_villagesql_schema_in_bootstrap(THD *thd) {
+  const Disable_autocommit_guard autocommit_guard(thd);
+  dd::upgrade::Bootstrap_error_handler error_handler;
+  const Disable_binlog_guard disable_binlog(thd);
+  const Disable_sql_log_bin_guard disable_sql_log_bin(thd);
+
+  const bool err = SchemaManager::upgrade_villagesql_schema(thd);
+  clear_table_caches(thd);
+  return dd::end_transaction(thd, err);
+}
+
 }  // namespace
 
 bool SchemaManager::maybe_install_villagesql_schema_on_first_run(
@@ -672,6 +685,15 @@ bool SchemaManager::maybe_install_villagesql_schema_on_first_run(
   delete_optimizer_cost_module();
 
   return false;
+}
+
+bool SchemaManager::run_villagesql_upgrades_standalone() {
+  init_optimizer_cost_module(true);
+  const bool err = bootstrap::run_bootstrap_thread(
+      nullptr, nullptr, &upgrade_villagesql_schema_in_bootstrap,
+      SYSTEM_THREAD_SERVER_UPGRADE);
+  delete_optimizer_cost_module();
+  return err;
 }
 
 bool SchemaManager::upgrade_villagesql_schema(THD *thd) {

--- a/villagesql/schema/schema_manager.h
+++ b/villagesql/schema/schema_manager.h
@@ -121,6 +121,18 @@ class SchemaManager {
   static bool upgrade_villagesql_schema(THD *thd);
 
   /**
+   * Run upgrade_villagesql_schema() in its own bootstrap thread.
+   *
+   * Used with --upgrade=MINIMAL, which skips upgrade_system_schemas() where
+   * the upgrades normally run. VillageSQL system tables are dictionary
+   * state, so they are upgraded even in MINIMAL mode.
+   *
+   * @retval false  ON SUCCESS
+   * @retval true   ON FAILURE
+   */
+  static bool run_villagesql_upgrades_standalone();
+
+  /**
    * Returns true iff the version of the schema stored in the database
    * is less than the version of the binary currently running.
    */


### PR DESCRIPTION
## Description

The villagsql upgrade is currently skipped whenever the mysqld is started with --upgrade=MINIMAL flag. But even with the minimal flag, we want to run the upgrades since the server expects the villagesql tables to match the version it was built with. Skipping the upgrade will leave the server running against an older schema, which can break things or block startup entirely.

## Related Issue

Fixes #1003 

## How was this tested?

Created a test that sets the villagesql version to an older version and restarts with upgrade=MINIMAL flag and verifies the the data-dir version was the same as the build version.