### PR TITLE
Use JSON for version info

### DIFF
--- a/villagesql/bld_matrix/README.md
+++ b/villagesql/bld_matrix/README.md
@@ -11,6 +11,7 @@ span lines. Pipe through `jq .` to read it.
 | -------------------- | ------------------------------------------------------------ |
 | `json_extensions.sh` | The bundled-extension manifest, parsed into an array of objects. |
 | `json_platforms.sh`  | The platforms built and tested on, as an array of objects.     |
+| `json_version.sh`    | The VSQL_VERSION file, parsed into a single object.            |
 | `json_build_matrix.sh` | The build-server matrix, one row per platform.                |
 | `json_test_extensions.sh` | The extension tests, one row per (platform, extension, abi). |
 
@@ -19,8 +20,8 @@ variables, and is the source of truth for them.
 
 ## Scope
 
-`json_extensions.sh` and `json_platforms.sh` are the data tables. They parse
-and shape but never select, and each prints its whole set.
+`json_extensions.sh`, `json_platforms.sh`, and `json_version.sh` are the data
+tables. They parse and shape but never select, and each prints its whole set.
 
 The rest select and combine. They call the tables they need and take filters
 as positional arguments; pass "" for a filter to keep everything.
@@ -41,6 +42,10 @@ MATRIX="$PWD/villagesql/bld_matrix"
 
 # A manifest from somewhere else.
 EXTENSIONS_FILE=/tmp/exts.txt "$MATRIX/json_extensions.sh"
+
+# The version, then the semver string built from its fields.
+"$MATRIX/json_version.sh" | jq .
+"$MATRIX/json_version.sh" | jq -r '"\(.major).\(.minor).\(.patch)"'
 
 # The build-server matrix, every platform and then just one.
 "$MATRIX/json_build_matrix.sh"

--- a/villagesql/bld_matrix/json_version.sh
+++ b/villagesql/bld_matrix/json_version.sh
@@ -24,8 +24,8 @@
 #                       (default: the copy in this script's own source tree)
 #
 # Testable locally:
-#   villagesql/bld_matrix/json_version.sh | jq .
 #   VSQL_VERSION_FILE=/tmp/version villagesql/bld_matrix/json_version.sh
+#   villagesql/bld_matrix/json_version.sh | jq .
 
 set -euo pipefail
 

--- a/villagesql/bld_matrix/json_version.sh
+++ b/villagesql/bld_matrix/json_version.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright (c) 2026 VillageSQL Contributors
+#
+# Print the VSQL_VERSION file as a compact JSON object, one record.
+#
+# This is the parsed form of the file; it applies no filtering and computes no
+# version strings. Callers assemble the strings they want from the fields.
+#
+# The record:
+#   code_base    — named fork the version belongs to, e.g. "mysql-8.4"
+#   major        — major version, a number
+#   minor        — minor version, a number
+#   patch        — patch version, a number
+#   pre_release  — pre-release suffix, "" when the file names none
+#
+# A line is a KEY=value pair with the value ending at the first whitespace,
+# matching how cmake/vsql_version.cmake reads the same file. Anything else,
+# comments included, is ignored. code_base and the three numbers must all be
+# present, and the numbers must parse as numbers; a file missing any of them
+# is an error. pre_release is the only optional field.
+#
+# Inputs (environment variables, all optional):
+#   VSQL_VERSION_FILE — path to VSQL_VERSION
+#                       (default: the copy in this script's own source tree)
+#
+# Testable locally:
+#   villagesql/bld_matrix/json_version.sh | jq .
+#   VSQL_VERSION_FILE=/tmp/version villagesql/bld_matrix/json_version.sh
+
+set -euo pipefail
+
+MATRIX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="$(cd "$MATRIX_DIR/../.." && pwd)"
+source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
+
+VSQL_VERSION_FILE="${VSQL_VERSION_FILE:-$SOURCE_DIR/VSQL_VERSION}"
+
+if [[ ! -f "$VSQL_VERSION_FILE" ]]; then
+    die "VSQL_VERSION file not found: $VSQL_VERSION_FILE"
+fi
+
+jq -Rcn '
+    (reduce (inputs | capture("^\\s*(?<k>[A-Za-z_]+)=(?<v>\\S*)")) as $e
+       ({}; .[$e.k] = $e.v)) as $file
+    | def number($key):
+        $file[$key] | tonumber? // error("VSQL_VERSION names no numeric \($key)");
+      if ($file.VSQL_CODE_BASE // "") == "" then
+        error("VSQL_VERSION names no VSQL_CODE_BASE")
+      else . end
+    | {
+        code_base:   $file.VSQL_CODE_BASE,
+        major:       number("VSQL_MAJOR_VERSION"),
+        minor:       number("VSQL_MINOR_VERSION"),
+        patch:       number("VSQL_PATCH_VERSION"),
+        pre_release: ($file.VSQL_PRE_RELEASE_VERSION // "")
+      }' "$VSQL_VERSION_FILE"

--- a/villagesql/bld_tools/build_info.sh
+++ b/villagesql/bld_tools/build_info.sh
@@ -6,6 +6,9 @@
 # Usage:
 #   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 #   source "$SCRIPT_DIR/build_info.sh"
+#
+# Expects a prior inclusion of the utities
+#   source "$SOURCE_DIR/villagesql/scripts/vsql_scripts_utils.sh"
 
 # Parse VSQL_VERSION file from <source_dir>.
 # Sets VSQL_MAJOR, VSQL_MINOR, VSQL_PATCH, VSQL_PRE, VSQL_VERSION.
@@ -27,6 +30,37 @@ vsql_parse_version() {
     if [[ -n "$VSQL_PRE" ]]; then
         VSQL_VERSION="${VSQL_VERSION}-${VSQL_PRE}"
     fi
+}
+
+# Print the VillageSQL version of <source_dir> as <major>.<minor>.<patch>,
+# with -<pre_release> appended when there is one.
+#
+# Usage: vsql_json_version <source_dir> [pre_release]
+#   The version comes from villagesql/bld_matrix/json_version.sh. With no
+#   pre_release argument the file's own suffix is used; passing one replaces it,
+#   and passing "" prints the version with no suffix, as a release build wants.
+#
+# Prints to stdout and sets nothing, so a caller captures it:
+#   VSQL_VERSION=$(vsql_json_version "$SOURCE_DIR")
+vsql_json_version() {
+    local source_dir="$1"
+    local json
+    json=$("$source_dir/villagesql/bld_matrix/json_version.sh") \
+        || die "Cannot read the version of $source_dir"
+
+    local pre
+    if [[ $# -ge 2 ]]; then
+        pre="$2"
+    else
+        pre=$(jq -r '.pre_release' <<<"$json")
+    fi
+
+    local version
+    version=$(jq -r '"\(.major).\(.minor).\(.patch)"' <<<"$json")
+    if [[ -n "$pre" ]]; then
+        version="${version}-${pre}"
+    fi
+    echo "$version"
 }
 
 # Set PLATFORM (linux|macos) and ARCH (x86_64|aarch64|arm64) for this machine.


### PR DESCRIPTION
## Description

Move version info into JSON structures for easy parsing.

The next step is to use this everywhere.

Update 

## Related Issue

Part of the [Server]: Overhaul CI #819 effort.