### PR TITLE
Nightly dispatch for full tests

### DIFF
--- a/.github/workflows/full-test-suite.yml
+++ b/.github/workflows/full-test-suite.yml
@@ -37,11 +37,6 @@ on:
         required: false
         type: string
         default: 'full-test'
-  # Runs after every Nightly run, as an independent workflow.
-  # Runs even if Nightly failed, as a source of nightly test results.
-  workflow_run:
-    workflows: ['Nightly Build and Test']
-    types: [completed]
 
 jobs:
   build-and-test:
@@ -53,11 +48,9 @@ jobs:
     env:
       SOURCE_DIR: ${{ github.workspace }}/source
       BUILD_DIR: ${{ github.workspace }}/build
-      # workflow_run supplies no inputs, so fall back to the commit the nightly
-      # run built.
-      REF: ${{ inputs.ref || github.event.workflow_run.head_sha || 'main' }}
-      BUILD_TYPE: ${{ inputs.build-type || 'debug' }}
-      ARTIFACT_PREFIX: ${{ inputs.artifact-prefix || 'nightly-full' }}
+      REF: ${{ inputs.ref }}
+      BUILD_TYPE: ${{ inputs.build-type }}
+      ARTIFACT_PREFIX: ${{ inputs.artifact-prefix }}
 
     steps:
     - name: Report Parameters

--- a/.github/workflows/nightly-dispatch.yml
+++ b/.github/workflows/nightly-dispatch.yml
@@ -113,6 +113,7 @@ jobs:
           echo "workflow_branch=$WORKFLOW_BRANCH" >> "$GITHUB_OUTPUT"
 
   start-full-test-release:
+    if: always()
     name: Start full test suite (release)
     needs: collect-info
     runs-on: ubuntu-latest
@@ -135,8 +136,7 @@ jobs:
           echo "Started full-test-suite (release) on $REF" >> "$GITHUB_STEP_SUMMARY"
 
   start-full-test-debug:
-    # Disable for now, demonstrate pattern and use of custom parameters
-    if: false
+    if: always()
     name: Start full test suite (debug)
     needs: collect-info
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

Dispatch the release build version of Full Test Suite from the nightly dispatch workflow.

This takes advantage of the nightly dispatch workflow's ability to launch multiple instances of the same workflow with different inputs.

## Related Issue

Part of the [Server]: Overhaul CI #819 effort.