### PR TITLE
Custom Index: Fix uncommitted cols

### DIFF
--- a/unittest/gunit/villagesql/custom_indexes-t.cc
+++ b/unittest/gunit/villagesql/custom_indexes-t.cc
@@ -252,4 +252,107 @@ TEST_F(CustomIndexesVictionaryTest, IndexOnlyHasUncommittedOnIndexMaps) {
   client_->rollback_all_tables(fake_thd);
 }
 
+// The THD-aware GetColumnsForIndex must see rows staged by this THD (the DDL
+// case, where index and column rows are staged together and not yet committed),
+// while the committed-only variant must not.
+TEST_F(CustomIndexesVictionaryTest, GetColumnsForIndexSeesUncommitted) {
+  // Use fake THD pointers for testing that are 8-byte aligned (for ubsan)
+  THD *fake_thd = reinterpret_cast<THD *>(0xB018);
+  THD *other_thd = reinterpret_cast<THD *>(0xB020);
+
+  {
+    auto guard = client_->get_write_lock();
+    client_->custom_index_columns().MarkForInsertion(
+        *fake_thd,
+        IndexColumnEntry(IndexColumnKey(77, 0), "c0", "ext", "1.0", "prof0"));
+    client_->custom_index_columns().MarkForInsertion(
+        *fake_thd,
+        IndexColumnEntry(IndexColumnKey(77, 1), "c1", "ext", "1.0", "prof1"));
+
+    auto staged = client_->GetColumnsForIndex(fake_thd, 77);
+    ASSERT_EQ(staged.size(), 2u);
+    EXPECT_EQ(staged[0]->column_name, "c0");
+    EXPECT_EQ(staged[1]->column_name, "c1");
+
+    // Committed-only view and other sessions see nothing.
+    EXPECT_TRUE(client_->GetColumnsForIndex(77).empty());
+    EXPECT_TRUE(client_->GetColumnsForIndex(other_thd, 77).empty());
+    EXPECT_TRUE(client_->GetColumnsForIndex(fake_thd, 7).empty());
+  }
+
+  client_->rollback_all_tables(fake_thd);
+
+  {
+    auto guard = client_->get_read_lock();
+    EXPECT_TRUE(client_->GetColumnsForIndex(fake_thd, 77).empty());
+  }
+}
+
+// A staged delete must hide the committed row from this THD's view, but not
+// from the committed-only view or from other sessions.
+TEST_F(CustomIndexesVictionaryTest, GetColumnsForIndexHidesStagedDelete) {
+  // Use fake THD pointers for testing that are 8-byte aligned (for ubsan)
+  THD *fake_thd = reinterpret_cast<THD *>(0xB028);
+  THD *other_thd = reinterpret_cast<THD *>(0xB030);
+
+  {
+    auto guard = client_->get_write_lock();
+    client_->custom_index_columns().MarkForInsertion(
+        *fake_thd,
+        IndexColumnEntry(IndexColumnKey(88, 0), "c0", "ext", "1.0", "prof0"));
+    client_->custom_index_columns().MarkForInsertion(
+        *fake_thd,
+        IndexColumnEntry(IndexColumnKey(88, 1), "c1", "ext", "1.0", "prof1"));
+  }
+  client_->commit_all_tables(fake_thd);
+
+  {
+    auto guard = client_->get_write_lock();
+    client_->custom_index_columns().MarkForDeletion(*fake_thd,
+                                                    IndexColumnKey(88, 0));
+
+    auto visible = client_->GetColumnsForIndex(fake_thd, 88);
+    ASSERT_EQ(visible.size(), 1u);
+    EXPECT_EQ(visible[0]->column_name, "c1");
+
+    EXPECT_EQ(client_->GetColumnsForIndex(88).size(), 2u);
+    EXPECT_EQ(client_->GetColumnsForIndex(other_thd, 88).size(), 2u);
+  }
+
+  client_->rollback_all_tables(fake_thd);
+
+  {
+    auto guard = client_->get_read_lock();
+    EXPECT_EQ(client_->GetColumnsForIndex(fake_thd, 88).size(), 2u);
+  }
+}
+
+// Staged rows for a different index must not leak into the prefix scan, and the
+// "42." prefix must still exclude "420.*" when the staged overlay is applied.
+TEST_F(CustomIndexesVictionaryTest, GetColumnsForIndexUncommittedPrefixBounds) {
+  // Use a fake THD pointer for testing that is 8-byte aligned (for ubsan)
+  THD *fake_thd = reinterpret_cast<THD *>(0xB038);
+
+  {
+    auto guard = client_->get_write_lock();
+    client_->custom_index_columns().MarkForInsertion(
+        *fake_thd,
+        IndexColumnEntry(IndexColumnKey(42, 0), "col_a", "ext", "1.0", "prof"));
+    client_->custom_index_columns().MarkForInsertion(
+        *fake_thd, IndexColumnEntry(IndexColumnKey(420, 0), "col_b", "ext",
+                                    "1.0", "prof"));
+    client_->custom_index_columns().MarkForInsertion(
+        *fake_thd,
+        IndexColumnEntry(IndexColumnKey(4, 2), "col_c", "ext", "1.0", "prof"));
+
+    auto results = client_->GetColumnsForIndex(fake_thd, 42);
+    ASSERT_EQ(results.size(), 1u);
+    EXPECT_EQ(results[0]->column_name, "col_a");
+    EXPECT_EQ(client_->GetColumnsForIndex(fake_thd, 420).size(), 1u);
+    EXPECT_EQ(client_->GetColumnsForIndex(fake_thd, 4).size(), 1u);
+  }
+
+  client_->rollback_all_tables(fake_thd);
+}
+
 }  // namespace villagesql_unittest

--- a/villagesql/schema/victionary_client.cc
+++ b/villagesql/schema/victionary_client.cc
@@ -307,6 +307,12 @@ std::vector<const IndexColumnEntry *> VictionaryClient::GetColumnsForIndex(
       IndexColumnKeyPrefix(index_id));
 }
 
+std::vector<const IndexColumnEntry *> VictionaryClient::GetColumnsForIndex(
+    THD *thd, uint64_t index_id) const {
+  if (!m_initialized.load()) return {};
+  return m_custom_index_columns.get_prefix(thd, IndexColumnKeyPrefix(index_id));
+}
+
 void VictionaryClient::init_index_id_counter() {
   // Must be called while holding write lock (reload_all_tables holds it).
   uint64_t max_id = 0;

--- a/villagesql/schema/victionary_client.h
+++ b/villagesql/schema/victionary_client.h
@@ -563,6 +563,63 @@ class SystemTableMap {
     return result;
   }
 
+  // Get all entries matching a prefix that are visible to this THD: committed
+  // entries with any uncommitted operations for this THD overlaid (inserts add,
+  // updates replace, deletes hide). Needed during DDL, where the rows staged by
+  // the current statement are not yet committed.
+  // REQUIRES: Caller must hold read lock
+  // WARNING: Returned pointers are only valid while lock is held
+  template <typename T = EntryType>
+  std::vector<const EntryType *> get_prefix(
+      THD *thd, const typename T::key_prefix_type &prefix) const {
+    assert_read_or_write_lock_held();
+    const std::string &prefix_str = prefix.str();
+    if (prefix_str.empty()) return {};
+    if (!thd) return get_prefix_committed<T>(prefix);
+
+    auto thd_it = m_uncommitted.find(thd);
+    if (thd_it == m_uncommitted.end() || thd_it->second.elements == 0) {
+      return get_prefix_committed<T>(prefix);
+    }
+
+    std::string upper = prefix_str;
+    upper.back() = upper.back() + 1;
+    auto in_range = [&](const std::string &k) {
+      return k >= prefix_str && k < upper;
+    };
+
+    // Walk staged ops in order; the most recent op per key wins. A nullptr
+    // entry means the key is hidden (DELETE, or the old key of a rename).
+    std::map<std::string, const EntryType *> staged;
+    for (const PendingOperation<EntryType> *op = thd_it->second.first; op;
+         op = op->next) {
+      if (op->op_type == OperationType::UPDATE) {
+        const std::string &old_key = op->key.str();
+        if (!old_key.empty() && in_range(old_key)) staged[old_key] = nullptr;
+      }
+      const std::string &k = op->entry ? op->entry->key().str() : op->key.str();
+      if (in_range(k)) staged[k] = op->entry.get();
+    }
+
+    std::map<std::string, const EntryType *> merged;
+    for (auto it = m_committed.lower_bound(prefix_str);
+         it != m_committed.end() && it->first < upper; ++it) {
+      merged[it->first] = it->second.get();
+    }
+    for (const auto &[key, entry] : staged) {
+      if (entry == nullptr) {
+        merged.erase(key);
+      } else {
+        merged[key] = entry;
+      }
+    }
+
+    std::vector<const EntryType *> result;
+    result.reserve(merged.size());
+    for (const auto &[key, entry] : merged) result.push_back(entry);
+    return result;
+  }
+
   // Get all committed entries in the map
   // Useful for iterating over all entries (e.g., during startup validation)
   // REQUIRES: Caller must hold read lock
@@ -837,6 +894,12 @@ class VictionaryClient {
   // Returns vector of pointers (valid while lock is held).
   std::vector<const IndexColumnEntry *> GetColumnsForIndex(
       uint64_t index_id) const;
+
+  // Same, but also sees the rows staged (uncommitted) by this THD. Use this on
+  // DDL paths, where the index and its column bindings are staged together and
+  // are not yet committed.
+  std::vector<const IndexColumnEntry *> GetColumnsForIndex(
+      THD *thd, uint64_t index_id) const;
 
   // Allocate a unique index_id for a new custom index. The counter is
   // initialized at startup from MAX(index_id) in custom_indexes so the

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -269,7 +269,7 @@ bool MaybeInjectCustomIndex(THD *thd, TABLE_SHARE &share, KEY *keyinfo) {
 
   // Inject per-column profile into each KEY_PART_INFO.
   std::vector<const IndexColumnEntry *> col_entries =
-      vclient.GetColumnsForIndex(index_entry->index_id);
+      vclient.GetColumnsForIndex(thd, index_entry->index_id);
   for (const IndexColumnEntry *col_entry : col_entries) {
     uint32_t pos = col_entry->key_position();
     if (pos >= keyinfo->user_defined_key_parts) {


### PR DESCRIPTION
GetColumnsForIndex only saw committed rows, so DDL that stages an index and its columns in the same transaction could not see its own uncommitted column bindings.

Add a THD-aware overload backed by a new get_prefix() overlay on SystemTableMap, mirroring get()/get_all(), and use it from MaybeInjectCustomIndex.

Part of #384
