### PR TITLE
Custom index: fix param encoding

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-index-test/r/index_metadata.result
+++ b/mysql-test/suite/villagesql/extension/vsql-index-test/r/index_metadata.result
@@ -31,7 +31,7 @@ CREATE INDEX idx_ext ON t (b) USING EXTENDED(vsql_index_test.dummy_index_hnsw)
 WITH (M = 16, ef_construction = 200, label = 'primary', mode = fast);
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
 test	t	idx_dummy_index_hnsw	vsql_index_test	0.0.1	dummy_index_hnsw	{}
-test	t	idx_ext	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 16, "mode": "fast", "label": "primary", "ef_construction": 200}
+test	t	idx_ext	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "16", "mode": "fast", "label": "primary", "ef_construction": "200"}
 table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
 t	idx_dummy_index_hnsw	0	a	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 t	idx_ext	0	b	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
@@ -39,7 +39,7 @@ t	idx_ext	0	b	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 CREATE INDEX idx_prof ON t (c dummy_profile_hnsw_l2) USING EXTENDED(dummy_index_hnsw);
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
 test	t	idx_dummy_index_hnsw	vsql_index_test	0.0.1	dummy_index_hnsw	{}
-test	t	idx_ext	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 16, "mode": "fast", "label": "primary", "ef_construction": 200}
+test	t	idx_ext	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "16", "mode": "fast", "label": "primary", "ef_construction": "200"}
 test	t	idx_prof	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
 t	idx_dummy_index_hnsw	0	a	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
@@ -49,7 +49,7 @@ t	idx_prof	0	c	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 CREATE INDEX idx_multi ON t (d, e) USING EXTENDED(dummy_index_hnsw);
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
 test	t	idx_dummy_index_hnsw	vsql_index_test	0.0.1	dummy_index_hnsw	{}
-test	t	idx_ext	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 16, "mode": "fast", "label": "primary", "ef_construction": 200}
+test	t	idx_ext	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "16", "mode": "fast", "label": "primary", "ef_construction": "200"}
 test	t	idx_multi	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 test	t	idx_prof	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
@@ -61,9 +61,9 @@ t	idx_prof	0	c	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 # --- ALTER TABLE ADD INDEX ---
 ALTER TABLE t ADD INDEX idx_alt (e) USING EXTENDED(dummy_index_hnsw) WITH (M = 8);
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
-test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 8}
+test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "8"}
 test	t	idx_dummy_index_hnsw	vsql_index_test	0.0.1	dummy_index_hnsw	{}
-test	t	idx_ext	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 16, "mode": "fast", "label": "primary", "ef_construction": 200}
+test	t	idx_ext	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "16", "mode": "fast", "label": "primary", "ef_construction": "200"}
 test	t	idx_multi	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 test	t	idx_prof	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
@@ -76,8 +76,8 @@ t	idx_prof	0	c	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 # --- DROP INDEX: removes metadata for that index ---
 DROP INDEX idx_dummy_index_hnsw ON t;
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
-test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 8}
-test	t	idx_ext	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 16, "mode": "fast", "label": "primary", "ef_construction": 200}
+test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "8"}
+test	t	idx_ext	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "16", "mode": "fast", "label": "primary", "ef_construction": "200"}
 test	t	idx_multi	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 test	t	idx_prof	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
@@ -89,7 +89,7 @@ t	idx_prof	0	c	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 # --- ALTER TABLE DROP INDEX ---
 ALTER TABLE t DROP INDEX idx_ext;
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
-test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 8}
+test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "8"}
 test	t	idx_multi	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 test	t	idx_prof	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
@@ -100,26 +100,26 @@ t	idx_prof	0	c	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 # --- ALTER TABLE DROP INDEX: multiple at once ---
 ALTER TABLE t DROP INDEX idx_prof, DROP INDEX idx_multi;
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
-test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 8}
+test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "8"}
 table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
 t	idx_alt	0	e	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 # --- DROP INDEX: mixed-case name removes metadata ---
 CREATE INDEX idx_case ON t (a) USING EXTENDED(dummy_index_hnsw);
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
-test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 8}
+test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "8"}
 test	t	idx_case	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
 t	idx_alt	0	e	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 t	idx_case	0	a	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 DROP INDEX IDX_CASE ON t;
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
-test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 8}
+test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "8"}
 table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
 t	idx_alt	0	e	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 # --- CREATE INDEX: qualified profile (unqualified type) ---
 CREATE INDEX idx_qprof ON t (a vsql_index_test.dummy_profile_hnsw_l2) USING EXTENDED(dummy_index_hnsw);
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
-test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 8}
+test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "8"}
 test	t	idx_qprof	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
 t	idx_alt	0	e	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
@@ -127,7 +127,7 @@ t	idx_qprof	0	a	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 # --- CREATE INDEX: qualified type + qualified profile ---
 CREATE INDEX idx_qq ON t (b vsql_index_test.dummy_profile_hnsw_l2) USING EXTENDED(vsql_index_test.dummy_index_hnsw);
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
-test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 8}
+test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "8"}
 test	t	idx_qprof	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 test	t	idx_qq	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
@@ -137,7 +137,7 @@ t	idx_qq	0	b	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 # --- ALTER TABLE ADD INDEX: qualified type ---
 ALTER TABLE t ADD INDEX idx_alt_q (c) USING EXTENDED(vsql_index_test.dummy_index_hnsw);
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
-test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 8}
+test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "8"}
 test	t	idx_alt_q	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 test	t	idx_qprof	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 test	t	idx_qq	vsql_index_test	0.0.1	dummy_index_hnsw	{}
@@ -153,7 +153,7 @@ DROP COLUMN a,
 ADD COLUMN a dummy_type_vector,
 ADD INDEX idx_new (a) USING EXTENDED(dummy_index_hnsw);
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
-test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 8}
+test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "8"}
 test	t	idx_alt_q	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 test	t	idx_qprof	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 test	t	idx_qq	vsql_index_test	0.0.1	dummy_index_hnsw	{}
@@ -166,7 +166,7 @@ t	idx_qq	0	b	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 t_drop_readd	idx_new	0	a	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 DROP TABLE t_drop_readd;
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
-test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 8}
+test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "8"}
 test	t	idx_alt_q	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 test	t	idx_qprof	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 test	t	idx_qq	vsql_index_test	0.0.1	dummy_index_hnsw	{}
@@ -181,7 +181,7 @@ ALTER TABLE t_dedup
 ADD INDEX idx_dedup1 (x dummy_profile_hnsw_l2) USING EXTENDED(dummy_index_hnsw),
 ADD INDEX idx_dedup2 (y dummy_profile_hnsw_l2) USING EXTENDED(dummy_index_hnsw);
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
-test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 8}
+test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "8"}
 test	t	idx_alt_q	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 test	t	idx_qprof	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 test	t	idx_qq	vsql_index_test	0.0.1	dummy_index_hnsw	{}
@@ -196,7 +196,7 @@ t_dedup	idx_dedup1	0	x	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 t_dedup	idx_dedup2	0	y	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 DROP TABLE t_dedup;
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
-test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": 8}
+test	t	idx_alt	vsql_index_test	0.0.1	dummy_index_hnsw	{"M": "8"}
 test	t	idx_alt_q	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 test	t	idx_qprof	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 test	t	idx_qq	vsql_index_test	0.0.1	dummy_index_hnsw	{}

--- a/villagesql/schema/systable/custom_indexes.cc
+++ b/villagesql/schema/systable/custom_indexes.cc
@@ -223,13 +223,13 @@ std::string params_to_json(const Mem_root_array<IndexWithParam> &params) {
   // deterministic canonical serialization order.
   for (const IndexWithParam &p : params) {
     std::string key(p.key.str, p.key.length);
-    Json_dom_ptr val;
-    if (p.is_string) {
-      val.reset(new (std::nothrow) Json_string(
-          std::string(p.value.str.str, p.value.str.length)));
-    } else {
-      val.reset(new (std::nothrow) Json_uint(p.value.num));
-    }
+    // TypeParameters::from_json() only accepts quoted string values (per its
+    // documented contract), so encode numeric WITH-clause values as JSON
+    // strings too, rather than bare JSON numbers.
+    std::string value = p.is_string
+                            ? std::string(p.value.str.str, p.value.str.length)
+                            : std::to_string(p.value.num);
+    Json_dom_ptr val(new (std::nothrow) Json_string(value));
     if (!val || obj->add_alias(key, std::move(val))) return "{}";  // OOM
   }
 

--- a/villagesql/test-extensions/vsql-index-test/src/extension.cc
+++ b/villagesql/test-extensions/vsql-index-test/src/extension.cc
@@ -235,7 +235,7 @@ static bool dummy_parse_options(const vef_index_param_t *params, uint32_t count,
     const char *key = params[i].key;
     const char *val = params[i].value;
     char *end;
-    if (strcmp(key, "M") == 0) {
+    if (strcmp(key, "m") == 0) {
       unsigned long v = strtoul(val, &end, 10);
       if (*end != '\0' || v == 0 || v > 65536) {
         snprintf(error_msg, error_msg_len,
@@ -251,7 +251,7 @@ static bool dummy_parse_options(const vef_index_param_t *params, uint32_t count,
         return true;
       }
       out->ef_construction = static_cast<uint32_t>(v);
-    } else {
+    } else if (strcmp(key, "label") != 0 && strcmp(key, "mode") != 0) {
       snprintf(error_msg, error_msg_len, "unknown option '%s'", key);
       return true;
     }


### PR DESCRIPTION
Encode numeric WITH-clause params as JSON strings, since TypeParameters::from_json() only accepts
quoted string values per its documented contract.

Part of #386