### PR TITLE
Custom index: fix error path issues

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-index-test/r/index_errors.result
+++ b/mysql-test/suite/villagesql/extension/vsql-index-test/r/index_errors.result
@@ -29,6 +29,11 @@ ERROR HY000: No default index profile found: column 'id' is not a custom type
 # --- Explicit profile for wrong column type ---
 CREATE INDEX idx ON t (id dummy_profile_hnsw_l2) USING EXTENDED(dummy_index_hnsw);
 ERROR HY000: Column 'id' is not of type 'dummy_type_vector' (extension 'vsql_index_test') required by index profile 'dummy_profile_hnsw_l2'
+# --- CREATE INDEX: WITH incorrect parameter N ---
+CREATE INDEX idx_ext ON t (b) USING EXTENDED(dummy_index_hnsw)
+WITH (N = 16, ef_construction = 200);
+ERROR HY000: InnoDB: Custom type operation failed. See server error log for details.
+Pattern "VillageSQL: Error parsing custom index options" found
 # --- Drop+re-add: old type matches profile but new type does not (error) ---
 CREATE TABLE t_readd (id INT PRIMARY KEY, a dummy_type_vector);
 ALTER TABLE t_readd DROP COLUMN a, ADD COLUMN a INT,

--- a/mysql-test/suite/villagesql/extension/vsql-index-test/t/index_errors.test
+++ b/mysql-test/suite/villagesql/extension/vsql-index-test/t/index_errors.test
@@ -17,6 +17,9 @@
 # custom index execution is fully implemented and the guard in
 # PT_custom_index_type::do_contextualize() is removed.
 --source include/have_debug.inc
+--disable_query_log
+call mtr.add_suppression("\\[ERROR\\] .*MY-\\d+.* VillageSQL: Error parsing custom index options");
+--enable_query_log
 
 SET PERSIST vsql_allow_preview_extensions = ON;
 INSTALL EXTENSION vsql_index_test;
@@ -58,6 +61,15 @@ CREATE INDEX idx ON t (id) USING EXTENDED(dummy_index_hnsw);
 --echo # --- Explicit profile for wrong column type ---
 --error ER_VILLAGESQL_GENERIC_ERROR
 CREATE INDEX idx ON t (id dummy_profile_hnsw_l2) USING EXTENDED(dummy_index_hnsw);
+
+--echo # --- CREATE INDEX: WITH incorrect parameter N ---
+--error ER_VILLAGESQL_GENERIC_ERROR
+CREATE INDEX idx_ext ON t (b) USING EXTENDED(dummy_index_hnsw)
+  WITH (N = 16, ef_construction = 200);
+
+let SEARCH_FILE= $MYSQLTEST_VARDIR/log/mysqld.1.err;
+let SEARCH_PATTERN= VillageSQL: Error parsing custom index options;
+--source include/search_pattern.inc
 
 --echo # --- Drop+re-add: old type matches profile but new type does not (error) ---
 # Column a was dummy_type_vector (T1); re-added as INT (T2). Profile requires

--- a/storage/innobase/dict/dict0dict.cc
+++ b/storage/innobase/dict/dict0dict.cc
@@ -2574,6 +2574,7 @@ dberr_t dict_index_add_to_cache_w_vcol(dict_table_t *table, dict_index_t *index,
   {
     dberr_t cerr = villagesql::innodb::Custom_index::load(new_index, index);
     if (cerr != DB_SUCCESS) {
+      rw_lock_free(&new_index->lock);
       dict_mem_index_free(new_index);
       dict_mem_index_free(index);
       return cerr;

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -5176,8 +5176,15 @@ error_handling:
       my_error(ER_TABLE_CANT_HANDLE_SPKEYS, MYF(0));
       break;
     case DB_VILLAGESQL_ERROR:
-      ut_ad(ctx->trx->error_state == DB_VILLAGESQL_ERROR);
-      villagesql_error("%s", MYF(0), ctx->trx->detailed_error);
+      if (ctx->trx->error_state == DB_VILLAGESQL_ERROR &&
+          *ctx->trx->detailed_error != 0) {
+        villagesql_error("%s", MYF(0), ctx->trx->detailed_error);
+      } else {
+        villagesql_error(
+            "InnoDB: Custom type operation failed. See server"
+            " error log for details.",
+            MYF(0));
+      }
       break;
     default:
       my_error_innodb(error, table_name, user_table->flags);


### PR DESCRIPTION
Free new_index's rw_lock before freeing it on the
Custom_index::load() failure path, avoiding a leak.

Replace the ut_ad assert on DB_VILLAGESQL_ERROR with a graceful fallback message.

Part of #386