### PR TITLE
Custom index: add ref/data conversion

### DIFF
--- a/storage/innobase/villagesql/custom_index.cc
+++ b/storage/innobase/villagesql/custom_index.cc
@@ -187,6 +187,127 @@ static uint32_t vef_index_max_key_len_impl(vef_index_ref_t index_ref,
   return max_size;
 }
 
+// The key_pos'th key column of the index. Column references only address
+// columns held in extension-managed column storage; returns nullptr and fills
+// error_msg for any other column.
+static const dict_col_t *ref_column(const dict_index_t *index, uint32_t key_pos,
+                                    char *error_msg, uint32_t error_msg_len) {
+  if (key_pos >= index->n_user_defined_cols) {
+    ut_ad(false);
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len,
+               "Key position %u is out of range for index %s with %u key "
+               "columns",
+               key_pos, index->name(),
+               static_cast<uint32_t>(index->n_user_defined_cols));
+    }
+    return nullptr;
+  }
+
+  const dict_col_t *col = index->get_field(key_pos)->col;
+  if (!col->stored_by_extn()) {
+    ut_ad(false);
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len,
+               "Column %s at key position %u of index %s is not in extension "
+               "managed column storage",
+               index->table->get_col_name(col->ind), key_pos, index->name());
+    }
+    return nullptr;
+  }
+  return col;
+}
+
+// Reads the value a column reference points to out of the column store into the
+// caller's buffer. The extension gets the same layout as any other value of the
+// custom type: the reference header followed by the data held by the store.
+// Runs its own mini-transaction, so the extension must not call this while
+// holding page latches in a mini-transaction of its own.
+static bool vef_index_col_ref_to_data_impl(
+    vef_index_ref_t index_ref, uint32_t key_pos, vef_storage_col_ref_t col_ref,
+    vef_storage_col_data_t *col_data, char *error_msg, uint32_t error_msg_len) {
+  const auto *index = static_cast<const dict_index_t *>(index_ref);
+  const dict_col_t *col = ref_column(index, key_pos, error_msg, error_msg_len);
+  if (col == nullptr) return true;
+
+  if (col_ref == Custom_column::EMPTY_REF) {
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len, "Empty column reference for column %s",
+               index->table->get_col_name(col->ind));
+    }
+    return true;
+  }
+
+  constexpr uint32_t ref_size =
+      static_cast<uint32_t>(dfield_t::extended_ref_size());
+  const uint32_t value_len = col->len;
+  ut_a(value_len > ref_size);
+
+  if (col_data->data == nullptr || col_data->length < value_len) {
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len,
+               "Buffer of %u bytes is too small for column %s, %u bytes needed",
+               col_data->length, index->table->get_col_name(col->ind),
+               value_len);
+    }
+    return true;
+  }
+
+  auto *value = const_cast<byte *>(col_data->data);
+  mach_write_to_8(value, col_ref);
+
+  dberr_t err = Custom_column::fetch(index->table, col, value + ref_size,
+                                     value_len - ref_size, value, ref_size);
+  if (err != DB_SUCCESS) {
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len,
+               "Failed to fetch column %s from column storage",
+               index->table->get_col_name(col->ind));
+    }
+    return true;
+  }
+
+  col_data->length = value_len;
+  return false;
+}
+
+// Extracts the column reference from a stored value of an extension-managed
+// column. Every such value carries its reference in the header, so this needs
+// no column store lookup.
+static bool vef_index_col_data_to_ref_impl(vef_index_ref_t index_ref,
+                                           uint32_t key_pos,
+                                           vef_storage_col_data_t col_data,
+                                           vef_storage_col_ref_t *col_ref,
+                                           char *error_msg,
+                                           uint32_t error_msg_len) {
+  const auto *index = static_cast<const dict_index_t *>(index_ref);
+  const dict_col_t *col = ref_column(index, key_pos, error_msg, error_msg_len);
+  if (col == nullptr) return true;
+
+  constexpr uint32_t ref_size =
+      static_cast<uint32_t>(dfield_t::extended_ref_size());
+  if (col_data.data == nullptr || col_data.length < ref_size) {
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len,
+               "Column %s value of %u bytes carries no reference header",
+               index->table->get_col_name(col->ind), col_data.length);
+    }
+    return true;
+  }
+
+  *col_ref = mach_read_from_8(col_data.data);
+
+  if (*col_ref == Custom_column::EMPTY_REF) {
+    if (error_msg != nullptr && error_msg_len > 0) {
+      snprintf(error_msg, error_msg_len,
+               "Column %s value is not in column storage yet",
+               index->table->get_col_name(col->ind));
+    }
+    return true;
+  }
+  return false;
+}
+
 // Calls intf.parse to validate the WITH (...) parameters. Allocates the
 // options struct on index->heap, writes the parsed result into it, and sets
 // *options_out to point to it. No-op (leaves *options_out unchanged) when
@@ -238,6 +359,17 @@ static dberr_t init_index_ctx(dict_index_t *index) {
   ctx->options = nullptr;
 
   const auto &intf = index->custom_index->interface();
+
+  // Column reference conversion is only meaningful for an index type that
+  // stores column references in its entries.
+  if (intf.storage_props & VEF_INDEX_STORAGE_HAS_COLUMN_REF) {
+    ctx->col_ref_to_data_fn = vef_index_col_ref_to_data_impl;
+    ctx->col_data_to_ref_fn = vef_index_col_data_to_ref_impl;
+  } else {
+    ctx->col_ref_to_data_fn = nullptr;
+    ctx->col_data_to_ref_fn = nullptr;
+  }
+
   return parse_index_options(index, intf, &ctx->options);
 }
 

--- a/villagesql/sdk/include/villagesql/abi/preview/index.h
+++ b/villagesql/sdk/include/villagesql/abi/preview/index.h
@@ -95,20 +95,29 @@ typedef uint32_t (*vef_index_max_key_len_fn)(vef_index_ref_t index_ref,
                                              uint32_t key_pos, bool is_primary);
 
 // Resolve a column reference to column data.
-// The caller pre-allocates col_data; the server fills in its data pointer and
-// length to reference the stored column value.
+// key_pos is the 0-based index key column the reference belongs to; its column
+// must be held in extension-managed column storage.
+// The caller sets col_data->data to a buffer of col_data->length bytes, at
+// least the column's maximum key length as reported by
+// vef_index_max_key_len_fn. The server copies the stored value into that
+// buffer and sets col_data->length to the value length.
+// The server reads the value under a mini-transaction of its own, so the
+// extension must not call this while holding page latches in a mini-transaction
+// it started.
 // Returns false on success, true on error (writes to error_msg).
-typedef bool (*vef_index_col_ref_to_data_fn)(vef_index_ref_t index_ref,
-                                             vef_storage_col_ref_t col_ref,
-                                             vef_storage_col_data_t *col_data,
-                                             char *error_msg,
-                                             uint32_t error_msg_len);
+typedef bool (*vef_index_col_ref_to_data_fn)(
+    vef_index_ref_t index_ref, uint32_t key_pos, vef_storage_col_ref_t col_ref,
+    vef_storage_col_data_t *col_data, char *error_msg, uint32_t error_msg_len);
 
 // Derive a stable column reference from column data.
+// key_pos is the 0-based index key column col_data holds a value of; its column
+// must be held in extension-managed column storage.
 // col_data must describe a value that was previously inserted into column
-// storage; the server computes the stable col_ref for that stored value.
+// storage; the server computes the stable col_ref for that stored value. This
+// call does not read the column storage.
 // Returns false on success, true on error (writes to error_msg).
 typedef bool (*vef_index_col_data_to_ref_fn)(vef_index_ref_t index_ref,
+                                             uint32_t key_pos,
                                              vef_storage_col_data_t col_data,
                                              vef_storage_col_ref_t *col_ref,
                                              char *error_msg,

--- a/villagesql/sdk/include/villagesql/preview/index_builder.h
+++ b/villagesql/sdk/include/villagesql/preview/index_builder.h
@@ -411,15 +411,21 @@ class Index {
                    result);
   }
 
-  bool get_key_data(IndexScanKey::KeyPartRef key_ref,
+  // Reads the value key_ref points to for the key column at key_pos. key_data
+  // must point at a buffer of key_data->length bytes, at least
+  // get_max_col_len(key_pos); on success key_data->length is the value length.
+  // Must not be called while holding page latches.
+  bool get_key_data(uint32_t key_pos, IndexScanKey::KeyPartRef key_ref,
                     IndexScanKey::KeyPartData *key_data) const {
-    return ctx_.col_ref_to_data_fn(ctx_.index_ref, key_ref, key_data,
+    return ctx_.col_ref_to_data_fn(ctx_.index_ref, key_pos, key_ref, key_data,
                                    tl_error_msg, ERROR_MSG_SIZE);
   }
 
-  bool get_key_ref(IndexScanKey::KeyPartData key_data,
+  // Derives the column reference for a value of the key column at key_pos that
+  // is already in the column store, e.g. a key column handed to insert().
+  bool get_key_ref(uint32_t key_pos, IndexScanKey::KeyPartData key_data,
                    IndexScanKey::KeyPartRef *key_ref) const {
-    return ctx_.col_data_to_ref_fn(ctx_.index_ref, key_data, key_ref,
+    return ctx_.col_data_to_ref_fn(ctx_.index_ref, key_pos, key_data, key_ref,
                                    tl_error_msg, ERROR_MSG_SIZE);
   }
 

--- a/villagesql/sdk/include/villagesql/preview/storage_api.h
+++ b/villagesql/sdk/include/villagesql/preview/storage_api.h
@@ -472,7 +472,8 @@ inline Error Segment::create(Space::Ref space, uint8_t num_segments,
 }
 
 inline Segment::Ref Segment::get_header(Page &root_page, size_t seg_no) {
-  assert(root_page.is_loaded(Page::Latch::EXCLUSIVE));
+  assert(root_page.is_loaded(Page::Latch::EXCLUSIVE) ||
+         root_page.is_loaded(Page::Latch::SHARED_EXCLUSIVE));
   if (!root_page.is_loaded()) return nullptr;
 
   uint8_t num_segments = root_page.read_num_segments();


### PR DESCRIPTION
Implement col_ref_to_data and col_data_to_ref for
extension-managed column storage, with a key_pos parameter to locate the correct key column.

Allow SX locks when allocating pages from a segment.

This commit modifies the SDK API, so existing extensions will need to be updated and will no longer compile against the old API.

Part of #386