### PR TITLE
test: note the lock fix in worker test

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-thread-worker/t/lifecycle_enable_disable_race.test
+++ b/mysql-test/suite/villagesql/extension/vsql-thread-worker/t/lifecycle_enable_disable_race.test
@@ -6,7 +6,9 @@
 # that same mutex to construct its THD. Holding the mutex across the wait made
 # an OFF that landed in the worker's startup window deadlock permanently: the
 # server stopped answering any query needing the mutex, and the test only failed
-# once the MTR testcase timeout expired.
+# once the MTR testcase timeout expired. on_enabled_change() now releases the
+# mutex around the start/stop and re-acquires it before returning, so the wait
+# no longer happens under it and a work function may read sys vars and run SQL.
 #
 # Verifies:
 # - Rapid ON/OFF cycles complete, with no wait between them


### PR DESCRIPTION
## Description
The header comment explained the deadlock but stopped before the fix, so it read as current behavior. A reader reaching for the contract found the mutex held across the wait, which on_enabled_change() no longer does.

AI=CLAUDE

## Related Issue
n/a

## How was this tested?
n/a

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
