### PR TITLE
dev_server: add vsql-oauth2 to bundle

### DIFF
--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -29,6 +29,7 @@ https://github.com/villagesql/vsql-trgm main
 https://github.com/villagesql/vsql-cube main
 https://github.com/villagesql/vsql-http main
 https://github.com/villagesql/vsql-network-address main
+https://github.com/villagesql/vsql-oauth2 main abi=dev
 https://github.com/villagesql/vsql-rest main abi=dev
 https://github.com/villagesql/vsql-uuid main
 https://github.com/villagesql/vsql-vector main bundle=false


### PR DESCRIPTION
## Description
Add vsql-oauth2 to bundled list.

AI=CLAUDE

## Related Issue
n/a

## How was this tested?
vsql-oauth2 main **does not** compile against the current SDK. tomas/accept-select-client-plugins in the extension repo brings the extension current and adopts #912's accepts_client_plugin. Merge this after the extension fix lands, or the bundled extension build fails.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
