### PR TITLE
build: fix comment path in build_info.sh

### DIFF
--- a/villagesql/bld_tools/build_info.sh
+++ b/villagesql/bld_tools/build_info.sh
@@ -7,8 +7,8 @@
 #   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 #   source "$SCRIPT_DIR/build_info.sh"
 #
-# Expects a prior inclusion of the utities
-#   source "$SOURCE_DIR/villagesql/scripts/vsql_scripts_utils.sh"
+# Expects a prior inclusion of the utilities
+#   source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
 
 # Parse VSQL_VERSION file from <source_dir>.
 # Sets VSQL_MAJOR, VSQL_MINOR, VSQL_PATCH, VSQL_PRE, VSQL_VERSION.


### PR DESCRIPTION
## Description
`villagesql/bld_tools/build_info.sh` tells the reader to source a file that does not exist.

Lines 10-11, added by #1006, read:

```
# Expects a prior inclusion of the utities
#   source "$SOURCE_DIR/villagesql/scripts/vsql_scripts_utils.sh"
```

The file is `vsql_script_utils.sh` — "script", singular. Every other build script sources it under that name; there are eight hits for the two spellings across `villagesql/`, and the seven that are real `source` lines are all singular. Only this one, a comment, is plural.

Nothing executes a comment, so no build has ever failed on it. The cost falls on a reader who copies the line:

```
$ bash -c 'SOURCE_DIR=/path/to/villagesql-server; source "$SOURCE_DIR/villagesql/scripts/vsql_scripts_utils.sh"'
bash: line 1: /path/to/villagesql-server/villagesql/scripts/vsql_scripts_utils.sh: No such file or directory

$ bash -c 'SOURCE_DIR=/path/to/villagesql-server; source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh" && echo sourced-ok'
sourced-ok
```

The advice the comment gives is correct: `vsql_json_version()`, added to this script by the same commit, calls `die`, which `vsql_script_utils.sh` defines, and `villagesql/bld_matrix/json_version.sh:34` sources that file for the same reason. Correct advice with the wrong filename in it.

Also fixes "utities" on the line above.

AI=CLAUDE

## Related Issue
n/a — found by the documentation-review sweep over `b0c08387ddf..1b4e2983ba8`, in a file that range touched.

## How was this tested?
Comment-only change, so there is nothing to run. `bash -n villagesql/bld_tools/build_info.sh` is clean, and the two source paths above were executed to confirm which one resolves.

`./scripts/villint.sh` could NOT be run: the documentation-review container has no `clang-format` and no `pip` to install it, so the script exits 1 at its dependency check rather than at a finding. The change is two comment lines; both are under 80 columns and neither carries trailing whitespace.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate — comment-only
- [x] My changes maintain compatibility with upstream MySQL 8.4
