### PR TITLE
sdk: fix sys_var descriptor comment

### DIFF
--- a/villagesql/sdk/include/villagesql/preview/sys_var.h
+++ b/villagesql/sdk/include/villagesql/preview/sys_var.h
@@ -91,17 +91,19 @@ class SysVarChange {
   vef_invalue_t v_;
 };
 
-// Aggregate descriptor for a single system variable. Use brace-init:
+// Aggregate descriptor for a single system variable. Construct one with the
+// type-specific factory functions declared below -- make_bool(), make_int(),
+// make_double(), make_str() -- not by brace-init: the storage pointer and the
+// default value live in an anonymous union whose first member is the bool pair,
+// so a braced initializer list cannot reach the int, double or string members.
 //
-//   {sv::BOOL,   "enabled",      "Enable feature",   &g_enabled,   true}
-//   {sv::INT,    "threshold_ms", "Threshold in ms",  &g_threshold, 1000, 0,
-//   3600000} {sv::DOUBLE, "ratio",        "Ratio", &g_ratio,     1.0,
-//   0.0, 10.0} {sv::STR,    "log_file",     "Log file path",    &g_log_file,
-//   "/tmp/myext.log"}
+//   sv::make_int("threshold_ms", "Threshold in ms", &g_threshold, 1000, 0,
+//                3600000)
 //
-// To register an on_change callback, use .on_change<&fn>() on the descriptor:
+// To register an on_change callback, chain .on_change<&fn>() onto the
+// descriptor a factory returns:
 //
-//   {sv::INT, "threshold_ms", "Threshold", &g_threshold, 1000, 0, 3600000}
+//   sv::make_int("threshold_ms", "Threshold", &g_threshold, 1000, 0, 3600000)
 //       .on_change<&my_on_change>()
 //
 // The callback runs while the server holds its global system-variable lock, so


### PR DESCRIPTION
## Description
The comment above `SysVarDescriptor` in `villagesql/sdk/include/villagesql/preview/sys_var.h` says "Use brace-init:" and shows four descriptor lines. Three of the four do not compile.

AI=CLAUDE

## Related Issue
n/a — found by the documentation-review sweep over `b0c08387ddf..1b4e2983ba8`. Nothing in that range touched this file; its last change was #995.

## How was this tested?
n/a

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate — comment-only
- [x] My changes maintain compatibility with upstream MySQL 8.4
