### PR TITLE
Organize docker images per branch

### DIFF
--- a/.github/workflows/build-docker-branch.yml
+++ b/.github/workflows/build-docker-branch.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Log in to Docker Hub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # The default buildx 'docker' driver is what we want: a native

--- a/.github/workflows/build-docker-branch.yml
+++ b/.github/workflows/build-docker-branch.yml
@@ -139,7 +139,7 @@ jobs:
           docker image rm -f "$IMAGE" || true
 
       # The default buildx 'docker' driver is what we want: a native
-      # single-platform build. 
+      # single-platform build.
       #
       # There is no layer cache to speak of: these run on ephemeral
       # GitHub-hosted runners, so every build compiles the server from cold.

--- a/.github/workflows/build-docker-branch.yml
+++ b/.github/workflows/build-docker-branch.yml
@@ -98,6 +98,12 @@ jobs:
           echo "Git SHA1: $(git -C source rev-parse ${{ inputs.ref }})"
           echo "Git Commit: $(git -C source log -n1 --oneline)"
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # Drop any local copy of the exact tag we are about to build.
       - name: Clean prior image for this tag
         run: |
@@ -106,12 +112,6 @@ jobs:
           IMAGE="$(arch_tag '${{ inputs.repo }}' '${{ inputs.tag }}' '${{ inputs.platform }}')"
           echo "Removing $IMAGE if present"
           docker image rm -f "$IMAGE" || true
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       # The default buildx 'docker' driver is what we want: a native
       # single-platform build whose layer cache lives in the daemon and so

--- a/.github/workflows/build-docker-branch.yml
+++ b/.github/workflows/build-docker-branch.yml
@@ -37,6 +37,16 @@ on:
         required: false
         type: string
         default: 'villagesql/server'
+      pre_release_version:
+        description: 'Pre-release suffix for the version. Empty (the default) is a release build; set e.g. dev or rc1 otherwise.'
+        required: false
+        type: string
+        default: ''
+      dev_abi:
+        description: 'Expose the development ABI: ON or OFF.'
+        required: false
+        type: string
+        default: 'ON'
   workflow_dispatch:
     inputs:
       ref:
@@ -57,15 +67,28 @@ on:
           - linux/arm64
         default: linux/amd64
       runner:
-        description: 'JSON-encoded runs-on value, e.g. ["self-hosted","linux","x86_64"] or "ubuntu-24.04-arm".'
+        description: 'JSON-encoded runs-on value, e.g. "ubuntu-latest" or "ubuntu-24.04-arm".'
         required: true
         type: string
-        default: '["self-hosted","linux","x86_64"]'
+        default: '"ubuntu-latest"'
       repo:
         description: 'Image repository to push to.'
         required: false
         type: string
         default: 'villagesql/server'
+      pre_release_version:
+        description: 'Pre-release suffix for the version. Empty (the default) is a release build; set e.g. dev or rc1 otherwise.'
+        required: false
+        type: string
+        default: ''
+      dev_abi:
+        description: 'Expose the development ABI: ON or OFF.'
+        required: true
+        type: choice
+        options:
+          - 'ON'
+          - 'OFF'
+        default: 'ON'
 
 permissions:
   contents: read
@@ -75,7 +98,7 @@ jobs:
   build-image:
     name: Build Image (${{ inputs.platform }})
     runs-on: ${{ fromJSON(inputs.runner) }}
-    timeout-minutes: 60
+    timeout-minutes: 360
 
     steps:
       - name: Report Parameters
@@ -85,6 +108,8 @@ jobs:
           echo "Platform: ${{ inputs.platform }}"
           echo "Runner: ${{ inputs.runner }}"
           echo "Repository: ${{ inputs.repo }}"
+          echo "Pre-release Version: '${{ inputs.pre_release_version }}'"
+          echo "Dev ABI: ${{ inputs.dev_abi }}"
 
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -114,14 +139,16 @@ jobs:
           docker image rm -f "$IMAGE" || true
 
       # The default buildx 'docker' driver is what we want: a native
-      # single-platform build whose layer cache lives in the daemon and so
-      # outlives the job. Creating a docker-container builder would only buy
-      # multi-platform and cache export, neither of which applies, at the cost
-      # of a cold source compile every run.
+      # single-platform build. 
       #
-      # Build args (VSQL_PRE_RELEASE_VERSION, VSQL_DEV_ABI) are left at the
-      # publish_image.sh defaults: a release build against the dev ABI.
+      # There is no layer cache to speak of: these run on ephemeral
+      # GitHub-hosted runners, so every build compiles the server from cold.
+      # If that wall-clock becomes the problem, a registry-backed cache is the
+      # lever, and it needs the docker-container driver.
       - name: Build and push image
+        env:
+          VSQL_PRE_RELEASE_VERSION: ${{ inputs.pre_release_version }}
+          VSQL_DEV_ABI: ${{ inputs.dev_abi }}
         run: |
           source/docker/server/publish_image.sh \
             --tag "${{ inputs.tag }}" \

--- a/.github/workflows/release-docker-branch.yml
+++ b/.github/workflows/release-docker-branch.yml
@@ -1,0 +1,176 @@
+name: Release Docker Branch
+
+# Publishes the multi-arch VillageSQL Server Docker image for one tag by
+# fanning out over build-docker-branch (one call per image), then stitching the
+# per-arch tags into a manifest list.
+#
+# This workflow handles the multi-arch case only; single-image builds live in
+# build-docker-branch.
+#
+# The set of images is a data table, villagesql/bld_matrix/json_docker.sh, so
+# the choices and their parameters can be read and run outside CI.
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git tag, branch, or SHA to build from.'
+        required: true
+        type: string
+      tag:
+        description: 'Image tag to publish, e.g. 0.0.5. Defaults to "ref". Use a distinguishable value (e.g. 0.0.5-test) for test pushes.'
+        required: false
+        type: string
+        default: ''
+      repo:
+        description: 'Image repository to push to.'
+        required: false
+        type: string
+        default: 'villagesql/server'
+      pre_release_version:
+        description: 'Pre-release suffix for the version. Empty (the default) is a release build; set e.g. dev or rc1 otherwise.'
+        required: false
+        type: string
+        default: ''
+      dev_abi:
+        description: 'Expose the development ABI: ON or OFF.'
+        required: false
+        type: string
+        default: 'ON'
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git tag, branch, or SHA to build from (e.g. 0.0.5 or main).'
+        required: true
+        type: string
+        default: 'main'
+      tag:
+        description: 'Image tag to publish. Leave blank to use "ref". Use a distinguishable value (e.g. 0.0.5-test) for test pushes — the shared tags (latest, stable) move to whatever is published here.'
+        required: false
+        type: string
+        default: ''
+      repo:
+        description: 'Image repository to push to.'
+        required: false
+        type: string
+        default: 'villagesql/server'
+      pre_release_version:
+        description: 'Pre-release suffix for the version. Leave blank for a release build; set e.g. dev or rc1 otherwise.'
+        required: false
+        type: string
+        default: ''
+      dev_abi:
+        description: 'Expose the development ABI.'
+        required: true
+        type: choice
+        options:
+          - 'ON'
+          - 'OFF'
+        default: 'ON'
+
+permissions:
+  contents: read
+
+jobs:
+  # Reports what is being built and reads the image table. The report describes
+  # the commit named by 'ref' — the thing being built — which is not the branch
+  # the workflow file itself came from.
+  report-parameters:
+    name: Report Parameters
+    runs-on: ubuntu-latest
+    outputs:
+      image-matrix: ${{ steps.images.outputs.image-matrix }}
+      platforms: ${{ steps.images.outputs.platforms }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+          sparse-checkout: villagesql/bld_matrix/
+          ref: ${{ inputs.ref }}
+
+      - name: Report Parameters
+        run: |
+          echo "Git Rev: ${{ inputs.ref }}"
+          echo "Git SHA1: $(git rev-parse HEAD)"
+          echo "Git Commit: $(git log -n1 --oneline)"
+          echo "Image Tag: ${{ inputs.tag || inputs.ref }}"
+          echo "Repository: ${{ inputs.repo }}"
+          echo "Pre-release Version: '${{ inputs.pre_release_version }}'"
+          echo "Dev ABI: ${{ inputs.dev_abi }}"
+
+      # Matrix logic lives in villagesql/bld_matrix, so it can be run locally
+      # exactly as it runs here:
+      #   villagesql/bld_matrix/json_docker.sh | jq .
+      #
+      # The manifest's platform list is derived from the same table as the
+      # build matrix, rather than left to the publish_manifest.sh default, so
+      # adding an image cannot produce a manifest that silently omits it.
+      - name: Read image table
+        id: images
+        run: |
+          IMAGES=$(villagesql/bld_matrix/json_docker.sh)
+
+          COUNT=$(jq 'length' <<<"$IMAGES")
+          if [ "$COUNT" -eq 0 ]; then
+            echo "::error::json_docker.sh listed no images. Nothing to build."
+            exit 1
+          fi
+
+          # json_docker.sh prints a bare array; the strategy matrix wants it
+          # under "include".
+          echo "image-matrix=$(jq -c '{include: .}' <<<"$IMAGES")" >> "$GITHUB_OUTPUT"
+          echo "platforms=$(jq -r '[.[].docker_platform] | join(",")' <<<"$IMAGES")" >> "$GITHUB_OUTPUT"
+
+  # One image per row of the table, each built natively and pushed under its
+  # arch-specific tag.
+  build-image:
+    needs: report-parameters
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.report-parameters.outputs.image-matrix) }}
+    uses: ./.github/workflows/build-docker-branch.yml
+    # build-docker-branch reads secrets.DOCKERHUB_TOKEN, which a called
+    # workflow does not otherwise receive.
+    secrets: inherit
+    with:
+      ref: ${{ inputs.ref }}
+      tag: ${{ inputs.tag || inputs.ref }}
+      platform: ${{ matrix.docker_platform }}
+      runner: ${{ toJSON(matrix.runner) }}
+      repo: ${{ inputs.repo }}
+      pre_release_version: ${{ inputs.pre_release_version }}
+      dev_abi: ${{ inputs.dev_abi }}
+
+  # Stitches the arch tags into the manifest list. A plain 'needs' with no
+  # 'if', so a failed image skips this job: a manifest must never be published
+  # over a partial set. publish_manifest.sh verifies the arch images again
+  # before it writes anything.
+  publish-manifest:
+    name: Publish Manifest
+    needs: [report-parameters, build-image]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 1
+          sparse-checkout: docker/server/
+          ref: ${{ inputs.ref }}
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # The shared tags (latest, stable) are left at the publish_manifest.sh
+      # default, and move to this tag.
+      - name: Publish manifest
+        run: |
+          docker/server/publish_manifest.sh \
+            --tag "${{ inputs.tag || inputs.ref }}" \
+            --repo "${{ inputs.repo }}" \
+            --platforms "${{ needs.report-parameters.outputs.platforms }}"

--- a/.github/workflows/release-docker-branch.yml
+++ b/.github/workflows/release-docker-branch.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
         default: 'ON'
+      shared_tags:
+        description: 'Comma-separated tags the manifest is published under in addition to "tag". Empty publishes only "tag", which is what a test push wants.'
+        required: false
+        type: string
+        default: 'latest,stable'
   workflow_dispatch:
     inputs:
       ref:
@@ -67,6 +72,11 @@ on:
           - 'ON'
           - 'OFF'
         default: 'ON'
+      shared_tags:
+        description: 'Comma-separated tags the manifest is published under in addition to "tag". Clear this for a test push, so latest and stable do not move.'
+        required: false
+        type: string
+        default: 'latest,stable'
 
 permissions:
   contents: read
@@ -99,6 +109,7 @@ jobs:
           echo "Repository: ${{ inputs.repo }}"
           echo "Pre-release Version: '${{ inputs.pre_release_version }}'"
           echo "Dev ABI: ${{ inputs.dev_abi }}"
+          echo "Shared Tags: '${{ inputs.shared_tags }}'"
 
       # Matrix logic lives in villagesql/bld_matrix, so it can be run locally
       # exactly as it runs here:
@@ -166,11 +177,12 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # The shared tags (latest, stable) are left at the publish_manifest.sh
-      # default, and move to this tag.
+      # The shared tags move to this manifest. A test push clears them, so
+      # that a 'docker pull villagesql/server' cannot see the result.
       - name: Publish manifest
         run: |
           docker/server/publish_manifest.sh \
             --tag "${{ inputs.tag || inputs.ref }}" \
             --repo "${{ inputs.repo }}" \
-            --platforms "${{ needs.report-parameters.outputs.platforms }}"
+            --platforms "${{ needs.report-parameters.outputs.platforms }}" \
+            --shared-tags "${{ inputs.shared_tags }}"

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1-labs
 # Copyright (c) 2026 VillageSQL Contributors
 #
 # This program is free software; you can redistribute it and/or
@@ -29,7 +30,10 @@ COPY villagesql/bld_tools/setup_linux_build_env.sh /tmp/
 RUN /tmp/setup_linux_build_env.sh && rm -rf /var/lib/apt/lists/*
 
 # Copy source tree (excluding docker/ so script changes don't invalidate the
-# expensive server build cache)
+# expensive server build cache). COPY --exclude is a labs-channel feature, so
+# it needs the syntax directive at the top of this file; without it the build
+# uses whatever Dockerfile parser is compiled into the local daemon, and older
+# ones reject the flag.
 COPY --exclude=docker . /source
 
 # Build and install

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -1,4 +1,3 @@
-# syntax=docker/dockerfile:1-labs
 # Copyright (c) 2026 VillageSQL Contributors
 #
 # This program is free software; you can redistribute it and/or
@@ -34,7 +33,8 @@ RUN /tmp/setup_linux_build_env.sh && rm -rf /var/lib/apt/lists/*
 # it needs the syntax directive at the top of this file; without it the build
 # uses whatever Dockerfile parser is compiled into the local daemon, and older
 # ones reject the flag.
-COPY --exclude=docker . /source
+# COPY --exclude=docker . /source
+COPY . /source
 
 # Build and install
 # VSQL_PRE_RELEASE_VERSION defaults to "dev"; set to "" for release builds

--- a/docker/server/docker_release_lib.sh
+++ b/docker/server/docker_release_lib.sh
@@ -72,6 +72,10 @@ split_list() {
     local raw="$1"
     local item
     SPLIT_RESULT=()
+    # An empty list leaves _split_raw unset rather than empty, which "$@" on
+    # it treats as an unbound variable under bash 3.2 and so macOS. Return
+    # before read rather than relying on the bash 4.4 behaviour.
+    [ -n "$raw" ] || return 0
     IFS=',' read -ra _split_raw <<< "$raw"
     for item in "${_split_raw[@]}"; do
         [ -n "$item" ] && SPLIT_RESULT+=("$item")

--- a/docker/server/publish_manifest.sh
+++ b/docker/server/publish_manifest.sh
@@ -88,9 +88,13 @@ verify_arch_images() {
 publish_manifest() {
     local manifest_args=() shared_tag
     manifest_args+=(-t "$REPO:$TAG")
-    for shared_tag in "${SHARED_TAG_LIST[@]}"; do
-        manifest_args+=(-t "$REPO:$shared_tag")
-    done
+    # Guarded by the count: bash 3.2, and so macOS, treats "${arr[@]}" on an
+    # empty array as an unbound variable under set -u.
+    if [ "${#SHARED_TAG_LIST[@]}" -gt 0 ]; then
+        for shared_tag in "${SHARED_TAG_LIST[@]}"; do
+            manifest_args+=(-t "$REPO:$shared_tag")
+        done
+    fi
 
     echo "--- Publishing manifest tags ---"
     run docker buildx imagetools create "${manifest_args[@]}" "${ARCH_TAGS[@]}"

--- a/villagesql/bld_matrix/README.md
+++ b/villagesql/bld_matrix/README.md
@@ -11,6 +11,7 @@ span lines. Pipe through `jq .` to read it.
 | -------------------- | ------------------------------------------------------------ |
 | `json_extensions.sh` | The bundled-extension manifest, parsed into an array of objects. |
 | `json_platforms.sh`  | The platforms built and tested on, as an array of objects.     |
+| `json_docker.sh`     | The Docker images published, as an array of objects.           |
 | `json_build_matrix.sh` | The build-server matrix, one row per platform.                |
 | `json_test_extensions.sh` | The extension tests, one row per (platform, extension, abi). |
 
@@ -19,7 +20,8 @@ variables, and is the source of truth for them.
 
 ## Scope
 
-`json_extensions.sh` and `json_platforms.sh` are the data tables. They parse
+`json_extensions.sh`, `json_platforms.sh`, and `json_docker.sh` are the data
+tables. They parse
 and shape but never select, and each prints its whole set.
 
 The rest select and combine. They call the tables they need and take filters
@@ -41,6 +43,10 @@ MATRIX="$PWD/villagesql/bld_matrix"
 
 # A manifest from somewhere else.
 EXTENSIONS_FILE=/tmp/exts.txt "$MATRIX/json_extensions.sh"
+
+# The Docker images published, and the same wrapped as an Actions matrix.
+"$MATRIX/json_docker.sh" | jq .
+"$MATRIX/json_docker.sh" | jq -c '{include: .}'
 
 # The build-server matrix, every platform and then just one.
 "$MATRIX/json_build_matrix.sh"

--- a/villagesql/bld_matrix/json_docker.sh
+++ b/villagesql/bld_matrix/json_docker.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright (c) 2026 VillageSQL Contributors
+#
+# Print the Docker images VillageSQL publishes, as a compact JSON array.
+#
+# This is the whole set; it applies no filtering. Callers select the rows they
+# want from the array.
+#
+# Each object:
+#   docker_platform — docker platform to build, e.g. linux/amd64
+#   runner          — GitHub Actions runs-on value: a label array for a
+#                     self-hosted runner, a plain string for a GitHub-hosted one
+#
+# The runner must be native to docker_platform. The image is always built
+# natively, never under QEMU emulation, because compiling the server under
+# emulation takes hours.
+#
+# This table is deliberately separate from json_platforms.sh. The platforms we
+# build a server for and the platforms we publish an image for are different
+# questions with different answers: macOS is a build target and will never be a
+# Docker target, and the runners differ too, because the self-hosted Linux
+# runners have no docker.
+#
+# The objects are written out by hand below, one per line, and jq assembles
+# them into the array. Add an image by adding a line.
+#
+# Testable locally:
+#   villagesql/bld_matrix/json_docker.sh | jq .
+
+set -euo pipefail
+
+jq -sc . <<'IMAGES'
+{"docker_platform":"linux/amd64","runner":"ubuntu-latest"}
+{"docker_platform":"linux/arm64","runner":"ubuntu-24.04-arm"}
+IMAGES

--- a/villagesql/bld_matrix/json_platforms.sh
+++ b/villagesql/bld_matrix/json_platforms.sh
@@ -21,7 +21,7 @@
 set -euo pipefail
 
 jq -sc . <<'PLATFORMS'
-{"platform":"linux-x86_64","docker-arch":"amd64","runner":["self-hosted","linux","x86_64"],"os":"linux"}
-{"platform":"linux-aarch64","docker-arch":"arm64","runner":"ubuntu-24.04-arm","os":"linux"}
-{"platform":"macos-arm64","docker-arch":"","runner":["self-hosted","macOS","ARM64"],"os":"macos"}
+{"platform":"linux-x86_64","runner":["self-hosted","linux","x86_64"],"os":"linux"}
+{"platform":"linux-aarch64","runner":"ubuntu-24.04-arm","os":"linux"}
+{"platform":"macos-arm64","runner":["self-hosted","macOS","ARM64"],"os":"macos"}
 PLATFORMS


### PR DESCRIPTION
## Description

Adds a `release-docker-branch` workflow that orchestra's the construction of each docker image for a release branch.  After the docker images are published, a manifest to encompass all of the images is published to docker.

## Related Issue

Part of the [Server]: Overhaul CI #819 effort.
