### PR TITLE
Fix dotted identifier collisions

### DIFF
--- a/mysql-test/suite/villagesql/identifiers/r/dotted_identifiers.result
+++ b/mysql-test/suite/villagesql/identifiers/r/dotted_identifiers.result
@@ -30,4 +30,31 @@ SHOW FIELDS FROM `my.table.col`;
 Field	Type	Null	Key	Default	Extra
 one	vsql_complex.COMPLEX	YES		NULL	
 DROP TABLE `my.table`, `my.table.col`;
+CREATE TABLE `a\` (`b.c` vsql_complex.COMPLEX, plain INT);
+CREATE TABLE `a.b\` (`c` vsql_complex.COMPLEX);
+# restart
+USE dotted_db;
+SHOW FIELDS FROM `a\`;
+SHOW FIELDS FROM `a.b\`;
+Field	Type	Null	Key	Default	Extra
+b.c	vsql_complex.COMPLEX	YES		NULL	
+plain	int	YES		NULL	
+Field	Type	Null	Key	Default	Extra
+c	vsql_complex.COMPLEX	YES		NULL	
+ALTER TABLE `a\` RENAME COLUMN `b.c` TO `b\c`;
+SHOW FIELDS FROM `a\`;
+Field	Type	Null	Key	Default	Extra
+b\c	vsql_complex.COMPLEX	YES		NULL	
+plain	int	YES		NULL	
+SHOW FIELDS FROM `a.b\`;
+ALTER TABLE `a\` DROP COLUMN `b\c`;
+Field	Type	Null	Key	Default	Extra
+c	vsql_complex.COMPLEX	YES		NULL	
+SHOW FIELDS FROM `a\`;
+SHOW FIELDS FROM `a.b\`;
+Field	Type	Null	Key	Default	Extra
+plain	int	YES		NULL	
+Field	Type	Null	Key	Default	Extra
+c	vsql_complex.COMPLEX	YES		NULL	
+DROP TABLE `a\`, `a.b\`;
 DROP DATABASE dotted_db;

--- a/mysql-test/suite/villagesql/identifiers/r/dotted_identifiers.result
+++ b/mysql-test/suite/villagesql/identifiers/r/dotted_identifiers.result
@@ -19,4 +19,15 @@ Field	Type	Null	Key	Default	Extra
 col.two	vsql_complex.COMPLEX	YES		NULL	
 plain	int	YES		NULL	
 DROP TABLE `renamed.table`;
+CREATE TABLE `my.table` (`col.one` vsql_complex.COMPLEX);
+CREATE TABLE `my.table.col` (`one` vsql_complex.COMPLEX);
+# restart
+USE dotted_db;
+SHOW FIELDS FROM `my.table`;
+Field	Type	Null	Key	Default	Extra
+col.one	vsql_complex.COMPLEX	YES		NULL	
+SHOW FIELDS FROM `my.table.col`;
+Field	Type	Null	Key	Default	Extra
+one	vsql_complex.COMPLEX	YES		NULL	
+DROP TABLE `my.table`, `my.table.col`;
 DROP DATABASE dotted_db;

--- a/mysql-test/suite/villagesql/identifiers/t/dotted_identifiers.test
+++ b/mysql-test/suite/villagesql/identifiers/t/dotted_identifiers.test
@@ -36,6 +36,29 @@ SHOW FIELDS FROM `my.table`;
 SHOW FIELDS FROM `my.table.col`;
 
 DROP TABLE `my.table`, `my.table.col`;
+
+# Backslashes must be escaped in the key too: with dot-only escaping,
+# "a\" + "b.c" and "a.b\" + "c" would join to the same key.
+CREATE TABLE `a\` (`b.c` vsql_complex.COMPLEX, plain INT);
+CREATE TABLE `a.b\` (`c` vsql_complex.COMPLEX);
+
+--source include/restart_mysqld.inc
+
+USE dotted_db;
+SHOW FIELDS FROM `a\`;
+SHOW FIELDS FROM `a.b\`;
+
+# Rename and drop must update only the intended table's row; the colliding
+# table's column keeps its type.
+ALTER TABLE `a\` RENAME COLUMN `b.c` TO `b\c`;
+SHOW FIELDS FROM `a\`;
+SHOW FIELDS FROM `a.b\`;
+
+ALTER TABLE `a\` DROP COLUMN `b\c`;
+SHOW FIELDS FROM `a\`;
+SHOW FIELDS FROM `a.b\`;
+
+DROP TABLE `a\`, `a.b\`;
 DROP DATABASE dotted_db;
 
 --source include/villagesql/uninstall_complex_extension.inc

--- a/mysql-test/suite/villagesql/identifiers/t/dotted_identifiers.test
+++ b/mysql-test/suite/villagesql/identifiers/t/dotted_identifiers.test
@@ -23,6 +23,19 @@ RENAME TABLE `my.table` TO `renamed.table`;
 SHOW FIELDS FROM `renamed.table`;
 
 DROP TABLE `renamed.table`;
+
+# Two tables whose dot-joined names read the same ("my.table" + "col.one" vs
+# "my.table.col" + "one") are distinct objects; both must survive a restart.
+CREATE TABLE `my.table` (`col.one` vsql_complex.COMPLEX);
+CREATE TABLE `my.table.col` (`one` vsql_complex.COMPLEX);
+
+--source include/restart_mysqld.inc
+
+USE dotted_db;
+SHOW FIELDS FROM `my.table`;
+SHOW FIELDS FROM `my.table.col`;
+
+DROP TABLE `my.table`, `my.table.col`;
 DROP DATABASE dotted_db;
 
 --source include/villagesql/uninstall_complex_extension.inc

--- a/unittest/gunit/villagesql/identifier_names-t.cc
+++ b/unittest/gunit/villagesql/identifier_names-t.cc
@@ -193,6 +193,13 @@ TEST_F(IdentifierNamesTest, JoinKeyComponentsIsUnambiguous) {
             join_key_components({"db", "my.table.col", "one"}));
   EXPECT_NE(join_key_components({"db", "a\\", "b"}),
             join_key_components({"db", "a", "\\b"}));
+
+  // Backslashes must be escaped too: with dot-only escaping, ("a\", "b.c")
+  // and ("a.b\", "c") would both join to "db.a\.b\.c".
+  EXPECT_EQ(join_key_components({"db", "a\\", "b.c"}), "db.a\\\\.b\\.c");
+  EXPECT_EQ(join_key_components({"db", "a.b\\", "c"}), "db.a\\.b\\\\.c");
+  EXPECT_NE(join_key_components({"db", "a\\", "b.c"}),
+            join_key_components({"db", "a.b\\", "c"}));
 }
 
 }  // namespace villagesql_unittest

--- a/unittest/gunit/villagesql/identifier_names-t.cc
+++ b/unittest/gunit/villagesql/identifier_names-t.cc
@@ -183,4 +183,16 @@ TEST_F(IdentifierNamesTest, ViewMatchSqlFollowsIdentifierRules) {
   }
 }
 
+// Identifiers may contain dots; joining must keep distinct component tuples
+// distinct.
+TEST_F(IdentifierNamesTest, JoinKeyComponentsIsUnambiguous) {
+  EXPECT_EQ(join_key_components({"db", "table", "column"}), "db.table.column");
+  EXPECT_EQ(join_key_components({"db", "my.table", "col.one"}),
+            "db.my\\.table.col\\.one");
+  EXPECT_NE(join_key_components({"db", "my.table", "col.one"}),
+            join_key_components({"db", "my.table.col", "one"}));
+  EXPECT_NE(join_key_components({"db", "a\\", "b"}),
+            join_key_components({"db", "a", "\\b"}));
+}
+
 }  // namespace villagesql_unittest

--- a/villagesql/schema/identifier_names.cc
+++ b/villagesql/schema/identifier_names.cc
@@ -129,4 +129,18 @@ const CHARSET_INFO *type_parameter_collation() {
   return &my_charset_utf8mb4_0900_ai_ci;
 }
 
+std::string join_key_components(std::initializer_list<std::string> parts) {
+  std::string key;
+  bool first = true;
+  for (const std::string &part : parts) {
+    if (!first) key += '.';
+    first = false;
+    for (char c : part) {
+      if (c == '.' || c == '\\') key += '\\';
+      key += c;
+    }
+  }
+  return key;
+}
+
 }  // namespace villagesql

--- a/villagesql/schema/identifier_names.h
+++ b/villagesql/schema/identifier_names.h
@@ -17,6 +17,7 @@
 #ifndef VILLAGESQL_SCHEMA_IDENTIFIER_NAMES_H_
 #define VILLAGESQL_SCHEMA_IDENTIFIER_NAMES_H_
 
+#include <initializer_list>
 #include <string>
 
 struct CHARSET_INFO;
@@ -70,6 +71,11 @@ std::string column_name_match_sql(const std::string &vsql_name,
 
 // Collation canonicalizing custom-type parameter strings
 const CHARSET_INFO *type_parameter_collation();
+
+// Joins canonical key components with '.', escaping '.' and '\' inside
+// components so distinct component tuples never produce the same key
+// (identifiers may contain dots).
+std::string join_key_components(std::initializer_list<std::string> parts);
 
 }  // namespace villagesql
 

--- a/villagesql/schema/systable/custom_columns.h
+++ b/villagesql/schema/systable/custom_columns.h
@@ -40,8 +40,11 @@ struct ColumnKeyPrefix {
       : db_(std::move(db_name)),
         table_(std::move(table_name)),
         normalized_prefix_(
-            canonical_database_name(db_) + "." +
-            (table_.empty() ? "" : canonical_table_name(table_) + ".")) {}
+            join_key_components({canonical_database_name(db_)}) + "." +
+            (table_.empty()
+                 ? ""
+                 : join_key_components({canonical_table_name(table_)}) + ".")) {
+  }
 
   const std::string &str() const { return normalized_prefix_; }
 
@@ -68,9 +71,9 @@ struct ColumnKey {
       : db_(std::move(db_name)),
         table_(std::move(table_name)),
         column_(std::move(column_name)),
-        normalized_key_(canonical_database_name(db_) + "." +
-                        canonical_table_name(table_) + "." +
-                        canonical_column_name(column_)) {}
+        normalized_key_(join_key_components(
+            {canonical_database_name(db_), canonical_table_name(table_),
+             canonical_column_name(column_)})) {}
 
   const std::string &str() const { return normalized_key_; }
 

--- a/villagesql/schema/systable/custom_indexes.h
+++ b/villagesql/schema/systable/custom_indexes.h
@@ -39,8 +39,11 @@ struct IndexKeyPrefix {
       : db_(std::move(db_name)),
         table_(std::move(table_name)),
         normalized_prefix_(
-            canonical_database_name(db_) + "." +
-            (table_.empty() ? "" : canonical_table_name(table_) + ".")) {}
+            join_key_components({canonical_database_name(db_)}) + "." +
+            (table_.empty()
+                 ? ""
+                 : join_key_components({canonical_table_name(table_)}) + ".")) {
+  }
 
   const std::string &str() const { return normalized_prefix_; }
   const std::string &db() const { return db_; }
@@ -62,9 +65,9 @@ struct IndexKey {
       : db_(std::move(db_name)),
         table_(std::move(table_name)),
         index_(std::move(index_name)),
-        normalized_key_(canonical_database_name(db_) + "." +
-                        canonical_table_name(table_) + "." +
-                        canonical_index_name(index_)) {}
+        normalized_key_(join_key_components({canonical_database_name(db_),
+                                             canonical_table_name(table_),
+                                             canonical_index_name(index_)})) {}
 
   const std::string &str() const { return normalized_key_; }
 

--- a/villagesql/schema/systable/custom_sp_params.h
+++ b/villagesql/schema/systable/custom_sp_params.h
@@ -42,8 +42,10 @@ struct SpParamKeyPrefix {
   SpParamKeyPrefix(std::string db_name, std::string sp_name)
       : db_(std::move(db_name)),
         sp_name_(std::move(sp_name)),
-        normalized_prefix_(canonical_database_name(db_) + "." +
-                           canonical_table_name(sp_name_) + ".") {}
+        normalized_prefix_(
+            join_key_components({canonical_database_name(db_),
+                                 canonical_table_name(sp_name_)}) +
+            ".") {}
 
   // TODO(villagesql-beta): Add a db-only constructor (no sp_name) to support
   // bulk deletion of all sp params for a given database, needed for DROP
@@ -69,9 +71,9 @@ struct SpParamKey {
       : db_(std::move(db_name)),
         sp_name_(std::move(sp_name)),
         param_(std::move(param_name)),
-        normalized_key_(canonical_database_name(db_) + "." +
-                        canonical_table_name(sp_name_) + "." +
-                        canonical_column_name(param_)) {}
+        normalized_key_(join_key_components({canonical_database_name(db_),
+                                             canonical_table_name(sp_name_),
+                                             canonical_column_name(param_)})) {}
 
   const std::string &str() const { return normalized_key_; }
 


### PR DESCRIPTION
## Description
Prior to the encoding standardization work, `old_key.str()`[(villagesql/schema/systable/custom_columns.cc:99)](https://github.com/villagesql/villagesql-server/pull/981/changes#diff-8439e8cbe7d58b0b51dea56fcf9262eeaf7f0d944b2e92a7498e8b0872822afaL99) returned the normalized form of `db_name.table_name.col_name`. The entire string was lowercased and passed to `update_in_table()`, which split it back into db_name, table_name and col_name using '.' as the delimiter and looked those values up in the underlying villagesql system tables. This worked because the system tables used utf8mb4_0900_ai_ci, so the lowercased values still matched. But we learned that that collation folds differently from mysql dd's collations (MySQL identifiers use the utf8mb3) which is one of the reasons why the schema is moving to utf8mb4_bin + lookups/comparisons using new canonicalisation libarary.

This was fixed in PR (#981). It addressed two things:

1. Passing the normalized form to `update_in_table()` becomes incorrect under the new schema: with utf8mb4_bin, table lookups must match byte-by-byte. To get the as-stored spellings, we now pass the key components (ColumnKey, SpParamKey, IndexKey, etc.), which hold the as-entered identifiers. Note: This change is backwards compatible. It doesn't impact the lookups with old schema. 
2. It also fixed identifiers containing dots. Splitting the db_name.table_name.col_name string produced wrong names whenever a component contained a dot. Passing key components avoids splitting entirely.

However, there is still a bug. The victionary uses `canonical_db_name.canonical_table_name.canonical_col_name` as its map key, and distinct components can still produce the same key e.g., db_name = my.db with table_name = tab.one joins to the same string as db_name = my.db.tab with table_name = one. Today that means one entry silently overwrites the other in the victionary. To fix this, we escape dots inside each component when building the key, so distinct component tuples can never join to the same string.

## Related Issue

Closes #1023 

## How was this tested?

Added an MTR test + unit test that verifies the example shared above.