### PR TITLE
Flaky test fix for query plan

### DIFF
--- a/mysql-test/suite/villagesql/create_temporary_table/r/create_temporary_table_join.result
+++ b/mysql-test/suite/villagesql/create_temporary_table/r/create_temporary_table_join.result
@@ -62,11 +62,11 @@ id	val	category	amount
 1	(2,0)	Category A	100.50
 2	(10,0)	Category B	150.00
 2	(10,0)	Category B	200.75
-EXPLAIN SELECT * FROM t_perm INNER JOIN t_temp ON t_perm.val = t_temp.val;
+EXPLAIN SELECT * FROM t_perm STRAIGHT_JOIN t_temp ON t_perm.val = t_temp.val;
 id	select_type	table	partitions	type	possible_keys	key	key_len	ref	rows	filtered	Extra
-1	SIMPLE	t_perm	NULL	ALL	NULL	NULL	NULL	NULL	4	100.00	NULL
-1	SIMPLE	t_temp	NULL	ALL	NULL	NULL	NULL	NULL	4	25.00	Using where; Using join buffer (hash join)
+1	SIMPLE	t_perm	NULL	ALL	NULL	NULL	NULL	NULL	#	#	NULL
+1	SIMPLE	t_temp	NULL	ALL	NULL	NULL	NULL	NULL	#	#	Using where; Using join buffer (hash join)
 Warnings:
-Note	1003	/* select#1 */ select `test`.`t_perm`.`id` AS `id`,`test`.`t_perm`.`val` AS `val`,`test`.`t_perm`.`category` AS `category`,`test`.`t_temp`.`id` AS `id`,`test`.`t_temp`.`val` AS `val`,`test`.`t_temp`.`amount` AS `amount` from `test`.`t_perm` join `test`.`t_temp` where (`test`.`t_temp`.`val` = `test`.`t_perm`.`val`)
+Note	1003	/* select#1 */ select `test`.`t_perm`.`id` AS `id`,`test`.`t_perm`.`val` AS `val`,`test`.`t_perm`.`category` AS `category`,`test`.`t_temp`.`id` AS `id`,`test`.`t_temp`.`val` AS `val`,`test`.`t_temp`.`amount` AS `amount` from `test`.`t_perm` straight_join `test`.`t_temp` where (`test`.`t_temp`.`val` = `test`.`t_perm`.`val`)
 DROP TABLE t_temp;
 DROP TABLE t_perm;

--- a/mysql-test/suite/villagesql/create_temporary_table/t/create_temporary_table_join.test
+++ b/mysql-test/suite/villagesql/create_temporary_table/t/create_temporary_table_join.test
@@ -62,7 +62,11 @@ WHERE t_temp.amount > 100
 ORDER BY t_temp.amount;
 
 # Test 6: Verify EXPLAIN shows join plan
-EXPLAIN SELECT * FROM t_perm INNER JOIN t_temp ON t_perm.val = t_temp.val;
+# STRAIGHT_JOIN pins the join order: the row-count estimates for these tiny
+# tables vary between runs, which otherwise flips which table is scanned first.
+# rows and filtered are optimizer estimates that vary by platform/run
+--replace_column 10 # 11 #
+EXPLAIN SELECT * FROM t_perm STRAIGHT_JOIN t_temp ON t_perm.val = t_temp.val;
 
 DROP TABLE t_temp;
 DROP TABLE t_perm;


### PR DESCRIPTION
On slower runs, the stats update might happen later than usual, and for small tables, innodb might have different estimates. Use a straight join to fix the order of the join and also replace the columns that might differ from run to run.

Passed 500/500 runs

