### PR TITLE
dev_server: add vsql-mcp to bundle

### DIFF
--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -28,6 +28,7 @@ https://github.com/villagesql/vsql-fuzzystrmatch main
 https://github.com/villagesql/vsql-trgm main
 https://github.com/villagesql/vsql-cube main
 https://github.com/villagesql/vsql-http main
+https://github.com/villagesql/vsql-mcp main build=cargo abi=stable bundle=false
 https://github.com/villagesql/vsql-network-address main
 https://github.com/villagesql/vsql-rest main abi=dev
 https://github.com/villagesql/vsql-uuid main


### PR DESCRIPTION
## Description
bundle=false because the tarball build only runs cmake. The compat suite does pick it up, and will fail there until the cargo path can build a standalone Rust repo.

**hold for now (same reason as vsql-currency)**

AI=CLAUDE
## Related Issue
n/a

## How was this tested?
n/a

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
