### PR TITLE
Standardize encodings - Cleanup

### DIFF
--- a/unittest/gunit/villagesql/victionary_client-t.cc
+++ b/unittest/gunit/villagesql/victionary_client-t.cc
@@ -460,52 +460,6 @@ TEST_F(VictionaryClientTest, PrefixQueriesBasic) {
   client_->clear_all_tables();
 }
 
-// Test normalization functions with all lower_case_table_names settings
-TEST_F(VictionaryClientTest, NormalizationFunctionsAllSettings) {
-  int original_setting = lower_case_table_names;
-
-  // Column names should ALWAYS be case-insensitive regardless of setting
-  for (int setting : {0, 1, 2}) {
-    lower_case_table_names = setting;
-    EXPECT_EQ(normalize_column_name("MyColumn"), "mycolumn");
-    EXPECT_EQ(normalize_column_name("MYCOLUMN"), "mycolumn");
-    EXPECT_EQ(normalize_column_name("mycolumn"), "mycolumn");
-  }
-
-  // Extension names should ALWAYS be case-insensitive regardless of setting
-  for (int setting : {0, 1, 2}) {
-    lower_case_table_names = setting;
-    EXPECT_EQ(normalize_extension_name("MyExt"), "myext");
-    EXPECT_EQ(normalize_extension_name("MYEXT"), "myext");
-    EXPECT_EQ(normalize_extension_name("myext"), "myext");
-  }
-
-  // Type names should ALWAYS be case-insensitive regardless of setting
-  for (int setting : {0, 1, 2}) {
-    lower_case_table_names = setting;
-    EXPECT_EQ(normalize_type_name("COMPLEX"), "complex");
-    EXPECT_EQ(normalize_type_name("Complex"), "complex");
-    EXPECT_EQ(normalize_type_name("complex"), "complex");
-  }
-
-  // Setting 0: Case-sensitive (preserve case)
-  test_set_lower_case_table_names(0);
-  EXPECT_EQ(normalize_database_name("MyDB"), "MyDB");     // Preserved
-  EXPECT_EQ(normalize_table_name("MyTable"), "MyTable");  // Preserved
-
-  // Setting 1: Case-insensitive (convert to lowercase)
-  test_set_lower_case_table_names(1);
-  EXPECT_EQ(normalize_database_name("MyDB"), "mydb");     // Lowercased
-  EXPECT_EQ(normalize_table_name("MyTable"), "mytable");  // Lowercased
-
-  // Setting 2: Case-insensitive (convert to lowercase)
-  test_set_lower_case_table_names(2);
-  EXPECT_EQ(normalize_database_name("MyDB"), "mydb");     // Lowercased
-  EXPECT_EQ(normalize_table_name("MyTable"), "mytable");  // Lowercased
-
-  test_set_lower_case_table_names(original_setting);
-}
-
 // ===== Phase 1: Operation Tracking Tests =====
 
 // Test basic DELETE operation

--- a/villagesql/schema/systable/helpers.cc
+++ b/villagesql/schema/systable/helpers.cc
@@ -26,7 +26,6 @@
 #include "sql/mysqld.h"
 #include "sql/sql_class.h"
 #include "sql/statement/ed_connection.h"
-#include "sql/strfunc.h"
 #include "villagesql/include/error.h"
 
 namespace villagesql {
@@ -155,55 +154,6 @@ bool execute_and_extract_single_value(THD *thd, const char *query,
   // Copy the string while the Ed_connection is still alive
   value->assign(result->str, result->length);
   return false;  // Success
-}
-
-// ===== Identifier normalization implementations =====
-
-const CHARSET_INFO *get_identifier_charset() {
-  // Use the same logic as MySQL DD's fs_name_collation()
-  if (::lower_case_table_names == 0) {
-    return &my_charset_utf8mb4_bin;  // Case-sensitive
-  }
-  return &my_charset_utf8mb4_0900_ai_ci;  // Case-insensitive
-}
-
-std::string normalize_database_name(const std::string &name) {
-  if (::lower_case_table_names == 0) {
-    return name;  // Case-sensitive, store as-is
-  }
-  // Case-insensitive: normalize to lowercase
-  return casedn(get_identifier_charset(), name);
-}
-
-std::string normalize_table_name(const std::string &name) {
-  if (::lower_case_table_names == 0) {
-    return name;  // Case-sensitive, store as-is
-  }
-  // Case-insensitive: normalize to lowercase
-  return casedn(get_identifier_charset(), name);
-}
-
-std::string normalize_column_name(const std::string &name) {
-  // Column names are always case-insensitive in MySQL
-  return casedn(&my_charset_utf8mb4_0900_ai_ci, name);
-}
-
-std::string normalize_extension_name(const std::string &name) {
-  // Extension names are in system character set.
-  // TODO(villagesql-beta): Check and replace all other hard coded
-  // my_charset_utf8mb4_0900_ai_ci in this file.
-  return casedn(system_charset_info, name);
-}
-
-std::string normalize_type_name(const std::string &name) {
-  // Type names should be case-insensitive (like SQL type names)
-  return casedn(&my_charset_utf8mb4_0900_ai_ci, name);
-}
-
-std::string normalize_index_name(const std::string &name) {
-  // Index names are always case-insensitive in MySQL, regardless of
-  // lower_case_table_names (which only governs table/database identifiers).
-  return casedn(&my_charset_utf8mb4_0900_ai_ci, name);
 }
 
 // ===== Test utilities =====

--- a/villagesql/schema/systable/helpers.h
+++ b/villagesql/schema/systable/helpers.h
@@ -30,30 +30,6 @@ namespace villagesql {
 // For use with asserts.
 const bool VILLAGESQL_NOT_IMPLEMENTED = false;
 
-// ===== Identifier normalization utilities =====
-// Get the appropriate charset for identifier normalization
-// Uses fs_name_collation() logic from MySQL DD
-const CHARSET_INFO *get_identifier_charset();
-
-// Normalize different identifier types according to MySQL rules
-// Database names: Follow lower_case_table_names setting (like MySQL DD)
-std::string normalize_database_name(const std::string &name);
-
-// Table names: Follow lower_case_table_names setting (like MySQL DD)
-std::string normalize_table_name(const std::string &name);
-
-// Column names: Always case-insensitive (per MySQL standard)
-std::string normalize_column_name(const std::string &name);
-
-// Extension names: Always case-insensitive (like plugin names)
-std::string normalize_extension_name(const std::string &name);
-
-// Type names: Always case-insensitive (like SQL type names)
-std::string normalize_type_name(const std::string &name);
-
-// Index names: Follow lower_case_table_names setting (same as table names)
-std::string normalize_index_name(const std::string &name);
-
 // Build a qualified base name string "extension_name.type_name".
 inline std::string make_qualified_base_name(std::string_view extension_name,
                                             std::string_view type_name) {


### PR DESCRIPTION
## Description

This is phase 5, the cleanup phase, of the standardizing encodings work. It removes the old normalization helpers and their tests, which were replaced by the canonicalization library added in #965.

The canonicalization library tests are a superset of the normalization tests and cover more scenarios (accents, sharp-s, all lower_case_table_names settings), so the old tests can be safely discarded.

## Related issue

Part of the changes for #811 

## How was this tested?

Ran all the villagesql MTR suites and unit tests, all green.

