### PR TITLE
sdk: fix sys_var capability example

### DIFF
--- a/villagesql/sdk/include/villagesql/preview/sys_var.h
+++ b/villagesql/sdk/include/villagesql/preview/sys_var.h
@@ -163,9 +163,9 @@ struct SysVarDescriptor {
 //   namespace sv = vsql::preview_sys_var;
 //
 //   static auto g_sys_vars = sv::make_capability({
-//       {sv::BOOL, "enabled",      "Enable feature",  &g_enabled,   true},
-//       {sv::INT,  "threshold_ms", "Threshold in ms", &g_threshold, 1000, 0,
-//       3600000}});
+//       sv::make_bool("enabled", "Enable feature", &g_enabled, true),
+//       sv::make_int("threshold_ms", "Threshold in ms", &g_threshold, 1000, 0,
+//                    3600000)});
 //
 //   VEF_GENERATE_ENTRY_POINTS(
 //       make_extension()


### PR DESCRIPTION
## Description
Applies the fix from #1021 to a 2nd location in the same file.

## Related Issue
#1021 

## How was this tested?
Two translation units differing only in the descriptor list, each built against an SDK install alone, no `-I` into a source or build tree.


## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate — comment-only, no test surface
- [x] My changes maintain compatibility with upstream MySQL 8.4

AI=CLAUDE