### PR TITLE
upgrades: block cross-codebase upgrades

### DIFF
--- a/VSQL_VERSION
+++ b/VSQL_VERSION
@@ -6,6 +6,8 @@
 #   mysql-test/suite/villagesql/startup/r/upgrade_basic.result
 #   mysql-test/suite/villagesql/startup/r/upgrade_scenarios.result
 #   mysql-test/suite/villagesql/startup/r/upgrade_skip_grant_tables.result
+# When changing the codebase, also update:
+#   mysql-test/suite/villagesql/startup/r/upgrade_minimal.result
 # Codebase identifies a named fork that receives VillageSQL changes.
 # Versions with different codebase values should not allow upgrades.
 VSQL_CODE_BASE=mysql-8.4

--- a/mysql-test/suite/villagesql/startup/r/upgrade_code_base_mismatch.result
+++ b/mysql-test/suite/villagesql/startup/r/upgrade_code_base_mismatch.result
@@ -1,0 +1,30 @@
+SET SESSION debug='+d,skip_dd_table_access_check';
+# Shut server down
+# Initialize a fresh datadir
+# Start the server on the fresh datadir, which must succeed
+SET SESSION debug='+d,skip_dd_table_access_check';
+# Rewrite the stored version to name a different code base. The value is
+# a valid version so this exercises the code base check rather than
+# version parsing, and is picked so it always differs from the code base
+# of the running build.
+UPDATE villagesql.properties
+SET value = IF(@@GLOBAL.villagesql_server_version LIKE 'percona-9.7\_%',
+'mysql-8.4_0.0.1',
+'percona-9.7_0.0.1')
+WHERE name = 'version';
+SELECT SUBSTRING_INDEX(value, '_', 1)
+<> SUBSTRING_INDEX(@@GLOBAL.villagesql_server_version, '_', 1)
+AS code_base_differs
+FROM villagesql.properties
+WHERE name = 'version';
+code_base_differs
+1
+# Shut server down
+# Starting on that datadir must fail rather than skip the upgrade.
+Pattern "Cannot upgrade the VillageSQL schema across code bases" found
+# --upgrade=MINIMAL skips the server upgrades but still runs the
+# VillageSQL ones, so it must be rejected too.
+Pattern "Cannot upgrade the VillageSQL schema across code bases" found
+# Cleanup
+# Restart with the original datadir
+# Test completed successfully

--- a/mysql-test/suite/villagesql/startup/r/upgrade_minimal.result
+++ b/mysql-test/suite/villagesql/startup/r/upgrade_minimal.result
@@ -7,7 +7,7 @@ SUBSTRING_INDEX(@@GLOBAL.villagesql_server_version, '_', 1),
 WHERE name = 'version';
 SELECT value FROM villagesql.properties WHERE name = 'version';
 value
-CODE_BASE_0.0.5
+mysql-8.4_0.0.5
 # restart: --upgrade=MINIMAL
 SET SESSION debug='+d,skip_dd_table_access_check';
 villagesql_upgrades_ran	stored_version

--- a/mysql-test/suite/villagesql/startup/r/upgrade_minimal.result
+++ b/mysql-test/suite/villagesql/startup/r/upgrade_minimal.result
@@ -1,11 +1,15 @@
 SET SESSION debug='+d,skip_dd_table_access_check';
 call mtr.add_suppression("Server upgrade is required, but skipped");
-UPDATE villagesql.properties SET value = 'mysql-8.4_0.0.5' WHERE name = 'version';
+UPDATE villagesql.properties
+SET value = CONCAT(
+SUBSTRING_INDEX(@@GLOBAL.villagesql_server_version, '_', 1),
+'_0.0.5')
+WHERE name = 'version';
 SELECT value FROM villagesql.properties WHERE name = 'version';
 value
-mysql-8.4_0.0.5
+CODE_BASE_0.0.5
 # restart: --upgrade=MINIMAL
 SET SESSION debug='+d,skip_dd_table_access_check';
-villagesql_upgrades_ran
-1
+villagesql_upgrades_ran	stored_version
+1	BUILD_VERSION
 # restart

--- a/mysql-test/suite/villagesql/startup/t/upgrade_code_base_mismatch.test
+++ b/mysql-test/suite/villagesql/startup/t/upgrade_code_base_mismatch.test
@@ -1,0 +1,91 @@
+# Verify that a data directory whose stored version names a different code base
+# is rejected at startup.
+#
+# Semver deliberately leaves versions from different code bases unordered, so
+# the numeric upgrade comparison can never see a code base change. Without an
+# explicit check the upgrade is skipped silently, the stored version keeps
+# naming the old code base, and every later restart re-runs the whole server
+# upgrade path.
+
+--source include/villagesql/internal_schema_test.inc
+
+let BASEDIR= `select @@basedir`;
+let DDIR=$MYSQL_TMP_DIR/upgrade_code_base_mismatch_test;
+let INIT_LOG=$MYSQL_TMP_DIR/upgrade_code_base_mismatch_init.log;
+let START_LOG=$MYSQL_TMP_DIR/upgrade_code_base_mismatch_start.log;
+let MINIMAL_LOG=$MYSQL_TMP_DIR/upgrade_code_base_mismatch_minimal.log;
+let SOCKET=$MYSQL_TMP_DIR/upgrade_code_base_mismatch.sock;
+let extra_args=--no-defaults --innodb_dedicated_server=OFF --console --loose-skip-auto_generate_certs --loose-skip-sha256_password_auto_generate_rsa_keys --tls-version= --basedir=$BASEDIR --lc-messages-dir=$MYSQL_SHAREDIR;
+let BOOTSTRAP_SQL=$MYSQL_TMP_DIR/upgrade_code_base_mismatch_bootstrap.sql;
+
+write_file $BOOTSTRAP_SQL;
+CREATE DATABASE test;
+EOF
+
+--echo # Shut server down
+--exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--shutdown_server
+--source include/wait_until_disconnected.inc
+
+--echo # Initialize a fresh datadir
+--exec $MYSQLD $extra_args --initialize-insecure --datadir=$DDIR --init-file=$BOOTSTRAP_SQL --log-error-verbosity=1 > $INIT_LOG 2>&1
+
+--echo # Start the server on the fresh datadir, which must succeed
+--exec echo "restart:--datadir=$DDIR " > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/wait_until_connected_again.inc
+--source include/villagesql/internal_schema_test.inc
+
+--echo # Rewrite the stored version to name a different code base. The value is
+--echo # a valid version so this exercises the code base check rather than
+--echo # version parsing, and is picked so it always differs from the code base
+--echo # of the running build.
+UPDATE villagesql.properties
+   SET value = IF(@@GLOBAL.villagesql_server_version LIKE 'percona-9.7\_%',
+                  'mysql-8.4_0.0.1',
+                  'percona-9.7_0.0.1')
+ WHERE name = 'version';
+
+SELECT SUBSTRING_INDEX(value, '_', 1)
+         <> SUBSTRING_INDEX(@@GLOBAL.villagesql_server_version, '_', 1)
+         AS code_base_differs
+  FROM villagesql.properties
+ WHERE name = 'version';
+
+--echo # Shut server down
+--exec echo "wait" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--shutdown_server
+--source include/wait_until_disconnected.inc
+
+--echo # Starting on that datadir must fail rather than skip the upgrade.
+# mysqld is run directly rather than through the restart mechanism so that a
+# failed start is the expected outcome. Should the check ever regress, the
+# server starts instead of exiting and this exec blocks until the testcase
+# timeout, which still fails the test.
+--error 1
+--exec $MYSQLD $extra_args --datadir=$DDIR --skip-networking --socket=$SOCKET > $START_LOG 2>&1
+
+let SEARCH_FILE= $START_LOG;
+let SEARCH_PATTERN= Cannot upgrade the VillageSQL schema across code bases;
+--source include/search_pattern.inc
+
+--echo # --upgrade=MINIMAL skips the server upgrades but still runs the
+--echo # VillageSQL ones, so it must be rejected too.
+--error 1
+--exec $MYSQLD $extra_args --datadir=$DDIR --skip-networking --socket=$SOCKET --upgrade=MINIMAL > $MINIMAL_LOG 2>&1
+
+let SEARCH_FILE= $MINIMAL_LOG;
+let SEARCH_PATTERN= Cannot upgrade the VillageSQL schema across code bases;
+--source include/search_pattern.inc
+
+--echo # Cleanup
+remove_file $INIT_LOG;
+remove_file $START_LOG;
+remove_file $MINIMAL_LOG;
+remove_file $BOOTSTRAP_SQL;
+--force-rmdir $DDIR
+
+--echo # Restart with the original datadir
+--exec echo "restart" > $MYSQLTEST_VARDIR/tmp/mysqld.1.expect
+--source include/wait_until_connected_again.inc
+
+--echo # Test completed successfully

--- a/mysql-test/suite/villagesql/startup/t/upgrade_minimal.test
+++ b/mysql-test/suite/villagesql/startup/t/upgrade_minimal.test
@@ -25,8 +25,6 @@ UPDATE villagesql.properties
          SUBSTRING_INDEX(@@GLOBAL.villagesql_server_version, '_', 1),
          '_0.0.5')
  WHERE name = 'version';
---let $code_base= `SELECT SUBSTRING_INDEX(@@GLOBAL.villagesql_server_version, '_', 1)`
---replace_result $code_base CODE_BASE
 SELECT value FROM villagesql.properties WHERE name = 'version';
 
 --let $restart_parameters = restart: --upgrade=MINIMAL

--- a/mysql-test/suite/villagesql/startup/t/upgrade_minimal.test
+++ b/mysql-test/suite/villagesql/startup/t/upgrade_minimal.test
@@ -16,8 +16,17 @@ call mtr.add_suppression("Server upgrade is required, but skipped");
 --eval $dd_columns_query
 --enable_query_log
 
-# Pretend the datadir is at schema version 0.0.5.
-UPDATE villagesql.properties SET value = 'mysql-8.4_0.0.5' WHERE name = 'version';
+# Pretend the datadir is at schema version 0.0.5 of this build's code base.
+# The code base is read from the build rather than written as a literal because
+# upgrade_villagesql_schema() refuses to upgrade across code bases: after a code
+# base port a stale literal would stop exercising the upgrade at all.
+UPDATE villagesql.properties
+   SET value = CONCAT(
+         SUBSTRING_INDEX(@@GLOBAL.villagesql_server_version, '_', 1),
+         '_0.0.5')
+ WHERE name = 'version';
+--let $code_base= `SELECT SUBSTRING_INDEX(@@GLOBAL.villagesql_server_version, '_', 1)`
+--replace_result $code_base CODE_BASE
 SELECT value FROM villagesql.properties WHERE name = 'version';
 
 --let $restart_parameters = restart: --upgrade=MINIMAL
@@ -26,7 +35,10 @@ SELECT value FROM villagesql.properties WHERE name = 'version';
 # The stored version is back at the build version iff the upgrades ran.
 --source include/villagesql/internal_schema_test.inc
 --disable_query_log
---eval SELECT value = '$build_version' AS villagesql_upgrades_ran FROM villagesql.properties WHERE name = 'version'
+# The stored version is printed too: a bare 0 cannot distinguish "the upgrades
+# did not run" from "they ran but stamped a different code base".
+--replace_result $build_version BUILD_VERSION
+--eval SELECT value = '$build_version' AS villagesql_upgrades_ran, value AS stored_version FROM villagesql.properties WHERE name = 'version'
 --enable_query_log
 
 --let $restart_parameters = restart

--- a/villagesql/schema/schema_manager.cc
+++ b/villagesql/schema/schema_manager.cc
@@ -714,6 +714,32 @@ bool SchemaManager::upgrade_villagesql_schema(THD *thd) {
   const Semver current_villagesql_version = get_version();
   const Semver target_villagesql_version = GetBuildVersion();
 
+  // A code base change is not a numeric upgrade, so Semver deliberately leaves
+  // versions from different code bases unordered and the comparison below can
+  // never see one. Refuse to start rather than fall through it: otherwise the
+  // version-specific upgrades are skipped, the stored version keeps naming the
+  // old code base, and is_villagesql_upgrade_needed() stays true so every
+  // later restart re-runs the whole server upgrade path.
+  //
+  // An invalid stored version means the schema is missing or incomplete, not
+  // that it came from another code base: an unparsable stored version already
+  // failed startup back in read_villagesql_version(). Installing is the job of
+  // maybe_install_villagesql_schema_on_first_run(), which runs after this, so
+  // there is nothing to check or upgrade here.
+  //
+  // TODO(villagesql-ga): support upgrading a data directory across code bases.
+  if (current_villagesql_version.is_valid() &&
+      current_villagesql_version.code_base() !=
+          target_villagesql_version.code_base()) {
+    LogVSQL(ERROR_LEVEL,
+            "Cannot upgrade the VillageSQL schema across code bases: this data "
+            "directory was created by a %s build, but this server is a %s "
+            "build. Use the original server binary for this data directory.",
+            current_villagesql_version.to_string().c_str(),
+            target_villagesql_version.to_string().c_str());
+    return true;
+  }
+
   if (current_villagesql_version < target_villagesql_version) {
     if (opt_upgrade_mode == UPGRADE_NONE) {
       LogVSQL(ERROR_LEVEL,

--- a/villagesql/schema/schema_manager.h
+++ b/villagesql/schema/schema_manager.h
@@ -113,6 +113,9 @@ class SchemaManager {
    * constant. If an upgrade is needed, it runs version-specific migration
    * functions and updates the stored version.
    *
+   * Fails if the stored version names a different code base than the running
+   * build, since upgrading across code bases is not supported.
+   *
    * @param[in]  thd   Thread handle.
    *
    * @retval false  ON SUCCESS


### PR DESCRIPTION
I realized in doing the 9.7 port that our semver semantics mean that we don't compare across codebase. For now, I think we should just block cross-codebase runs, by checking if the codebase differs and erroring out asap.