### PR TITLE
Fix inet_ntop() buffer-length mismatch in gcs_xcom_networking.cc

### DIFF
--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/gcs_xcom_networking.cc
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/gcs_xcom_networking.cc
@@ -422,7 +422,6 @@ static bool sock_descriptor_to_sockaddr(int fd, struct sockaddr_storage *sa) {
   */
 static bool sock_descriptor_to_string(int fd, std::string &out) {
   struct sockaddr_storage sa;
-  socklen_t addr_size = static_cast<socklen_t>(sizeof(struct sockaddr_storage));
   char saddr[INET6_ADDRSTRLEN];
 
   // get the sockaddr struct
@@ -431,7 +430,7 @@ static bool sock_descriptor_to_string(int fd, std::string &out) {
   // try IPv4
   if (sa.ss_family == AF_INET) {
     if (inet_ntop(AF_INET, &(((struct sockaddr_in *)&sa)->sin_addr), saddr,
-                  addr_size)) {
+                  sizeof(saddr))) {
       out = saddr;
       return false;
     }
@@ -440,7 +439,7 @@ static bool sock_descriptor_to_string(int fd, std::string &out) {
   // try IPv6
   if (sa.ss_family == AF_INET6) {
     if (inet_ntop(AF_INET6, &(((struct sockaddr_in6 *)&sa)->sin6_addr), saddr,
-                  addr_size)) {
+                  sizeof(saddr))) {
       out = saddr;
       return false;
     }


### PR DESCRIPTION
## Description

Fix inet_ntop() buffer-length mismatch in gcs_xcom_networking.cc

## Detailed description

sock_descriptor_to_string() declared a 46-byte destination buffer (char saddr[INET6_ADDRSTRLEN]) but told inet_ntop() the buffer was sizeof(struct sockaddr_storage) (128 bytes) via a leftover addr_size variable computed for an unrelated getpeername() call earlier in the file. inet_ntop() never actually writes that many bytes for a real IPv4/IPv6 address, so this has no observed runtime impact, but it is a genuine buffer-length/description mismatch: telling a C string function its destination is bigger than it really is defeats the purpose of passing a length at all.

Pass sizeof(saddr) at both inet_ntop() call sites instead, and drop the now-unused addr_size local.

Caught by GCC 14 + glibc's _FORTIFY_SOURCE=3 (__glibc_fortify) at -O2, which can prove the mismatch after inlining and reports it as "inet_ntop called with bigger length than size of destination buffer" (-Wattribute-warning). Not visible in an unoptimized/non-LTO build, or in any build that doesn't promote this warning to an error.

Found building this tag through packaging/rpm-oel/mysql.spec.in's
release %build on Oracle Linux 10, where RPM's hardened build flags
(redhat-hardened-cc1) inject -D_FORTIFY_SOURCE=3 and this repo's own
VILLAGESQL_WERROR turns the resulting warning fatal.

Two reasons this hasn't surfaced before:

- villagesql-server's CI (.github/workflows/*.yml) builds on different
  runners (including  Ubuntu) and never goes through this RPM spec at all, so
  _FORTIFY_SOURCE=3 is most likely never in effect there.
- Vanilla Oracle MySQL, unmodified, wouldn't fail here either even
  when built through this same spec on the same OL10 toolchain:
  MYSQL_MAINTAINER_MODE (which adds -Werror) defaults on only for
  Debug builds, never for the RelWithDebInfo config that actually
  ships mysqld, so Oracle's own release build only ever sees this as
  a silent warning.

## Details

###  Full compiler invocation (local build paths munged)

This compiler invocation was triggered using a modified packaging/rpm-oel/mysql.spec.in file based on the upstream source, intended to build villagesql-* rpm packages. This is WIP, so final layouts may change.

```
g++ -DHAVE_SYSTEM_TIRPC -DHAVE_TLSv13 -DLZ4_DISABLE_DEPRECATE_WARNINGS \
    -DMYSQL_DYNAMIC_PLUGIN [... other -D/-I flags elided ...] \
    -std=c++20 -O2 -flto=auto -ffat-lto-objects \
    -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS \
    -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 \
    -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1 \
    -Wall -Wextra -Wformat-security -Wvla -Wundef -Wmissing-format-attribute \
    -Woverloaded-virtual -Wcast-qual -Wimplicit-fallthrough=5 \
    -Wstringop-truncation -Wsuggest-override -Wmissing-include-dirs \
    -Wextra-semi -Wlogical-op -Werror \
    -std=gnu++20 -fPIC \
    -c gcs_xcom_networking.cc -o gcs_xcom_networking.cc.o
```

### Error reported

```
In file included from /usr/include/features.h:503,
                 from /usr/include/errno.h:25,
                 from <SRC>/plugin/group_replication/libmysqlgcs/src/bindings/xcom/gcs_xcom_networking.cc:24:
In function 'inet_ntop',
    inlined from 'sock_descriptor_to_string(int, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&)' at <SRC>/plugin/group_replication/libmysql
gcs/src/bindings/xcom/gcs_xcom_networking.cc:433:18,
    inlined from 'Gcs_ip_allowlist::shall_block(int, site_def const*)' at <SRC>/plugin/group_replication/libmysqlgcs/src/bindings/xcom/gcs_xcom_networking.cc:977:30:
/usr/include/bits/inet-fortified.h:32:10: error: call to '*__inet_ntop_chk' declared with attribute warning: inet_ntop called with bigger length than size of destination buff
er [-Werror=attribute-warning]
   32 |   return __glibc_fortify (inet_ntop, __dst_size, sizeof (char),
      |          ^~~~~~~~~~~~~~~
```

Load-bearing: `-O2 -flto=auto` (lets GCC inline
`sock_descriptor_to_string()` far enough to prove the buffer size),
`-Wp,-D_FORTIFY_SOURCE=3` (activates glibc's fortified `inet_ntop`
wrapper), `-Werror` (promotes the resulting warning to a hard error).

## Context

My experimentation with building villagesql rpms for RHEL compatible distributions brought this up. It's not a problem you see now.  When I complete that work I'll probably offer a patch to allow such builds to work. Related to work I've dong here: https://github.com/sjmudd/mysql-rpm-builder/ where in the past having reproducible RPM builds of MySQL have failed. I'm looking to extend this to cover building RPMS for VillageSQL for personal reasons.

## Checklist

- [X] I have signed the CLA
- [X] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests as appropriate
- [X] My changes maintain compatibility with upstream MySQL 9.7 LTS and MySQL 26.7.0. (8.4 LTS missing the change)

## Disclosure

- This patch and testing was done with the help of AI.
-  The same bug will not trigger at the moment upstream for the reasons explained. I will file a bug with them
