### PR TITLE
Exclude sdk_version.h.in from Extension

### DIFF
--- a/villagesql/CMakeLists.txt
+++ b/villagesql/CMakeLists.txt
@@ -111,6 +111,14 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E copy_directory
     "${CMAKE_CURRENT_SOURCE_DIR}/sdk/include/villagesql"
     "${SDK_STAGING_DIR}/include-dev/villagesql"
+  # copy_directory above sweeps in sdk_version.h.in (the configure_file()
+  # template, unsubstituted "@VSQL_MAJOR_VERSION@" tokens and all) along
+  # with the real headers, since it lives in the same source directory.
+  # Remove it: the real, substituted header is placed explicitly right
+  # below. The raw template is not usable as a C++ header outside the
+  # build (its @VSQL_MAJOR_VERSION@-style tokens are never substituted).
+  COMMAND ${CMAKE_COMMAND} -E remove -f
+    "${SDK_STAGING_DIR}/include-dev/villagesql/sdk_version.h.in"
   COMMAND ${CMAKE_COMMAND} -E copy
     "${CMAKE_BINARY_DIR}/sdk/include/villagesql/sdk_version.h"
     "${SDK_STAGING_DIR}/include-dev/villagesql/"


### PR DESCRIPTION
## Description

Exclude sdk_version.h.in from the installed Extension SDK

## Problem

The SDK-staging copy_directory sweeps the whole sdk/include/villagesql source dir into staging, so sdk_version.h.in (the configure_file() template, marked "do not edit directly") gets copied alongside the real headers and installed with them, unsubstituted @VSQL_MAJOR_VERSION@ tokens and all. Not usable as a header.

Caught while attempting an rpmbuild of the codebase on OL10, but that's just how it surfaced: it shouldn't ship regardless of packaging system.

Fix: remove it from staging right after copy_directory, before the real generated sdk_version.h is placed in the same spot.

## How was this tested?

While trying to build a villagesql rpm, rpmbuild reported a failure due to unpackaged files which should not have been installed into any directory to put into an rpm in the first place.

## Criticality

Low. This doesn't affect you now but rpmbuild verification of "unexpected files" would catch this. This should not be affected there as the "installed file" should not be present in the first place.  Fix is tiny.

## Checklist

- [X] I have signed the CLA
- [X] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests as appropriate
- [X] My changes maintain compatibility with upstream MySQL 8.4

## Disclosure

- This patch and testing was done with the help of AI.