### PR TITLE
build: add bundle=dev channel, GAR push

### DIFF
--- a/.github/workflows/build-docker-branch.yml
+++ b/.github/workflows/build-docker-branch.yml
@@ -33,10 +33,15 @@ on:
         required: true
         type: string
       repo:
-        description: 'Image repository to push to.'
+        description: 'Image repository to push to. Ignored when registry is "gar", which composes the path from the GAR_* repository variables.'
         required: false
         type: string
         default: 'villagesql/server'
+      registry:
+        description: 'Registry to push to: "dockerhub" or "gar". GAR carries the pre-release images.'
+        required: false
+        type: string
+        default: 'dockerhub'
       pre_release_version:
         description: 'Pre-release suffix for the version. Empty (the default) is a release build; set e.g. dev or rc1 otherwise.'
         required: false
@@ -72,10 +77,18 @@ on:
         type: string
         default: '"ubuntu-latest"'
       repo:
-        description: 'Image repository to push to.'
+        description: 'Image repository to push to. Ignored when registry is "gar".'
         required: false
         type: string
         default: 'villagesql/server'
+      registry:
+        description: 'Registry to push to. GAR carries the pre-release images.'
+        required: true
+        type: choice
+        options:
+          - dockerhub
+          - gar
+        default: dockerhub
       pre_release_version:
         description: 'Pre-release suffix for the version. Empty (the default) is a release build; set e.g. dev or rc1 otherwise.'
         required: false
@@ -92,6 +105,9 @@ on:
 
 permissions:
   contents: read
+  # Workload Identity Federation mints a short-lived GAR credential from this
+  # token, so no service-account key is stored. Harmless for Docker Hub pushes.
+  id-token: write
 
 jobs:
 
@@ -108,6 +124,7 @@ jobs:
           echo "Image Tag: ${{ inputs.tag }}"
           echo "Platform: ${{ inputs.platform }}"
           echo "Runner: ${{ inputs.runner }}"
+          echo "Registry: ${{ inputs.registry }}"
           echo "Repository: ${{ inputs.repo }}"
           echo "Pre-release Version: '${{ inputs.pre_release_version }}'"
           echo "Dev ABI: ${{ inputs.dev_abi }}"
@@ -124,18 +141,66 @@ jobs:
           echo "Git SHA1: $(git -C source rev-parse ${{ inputs.ref }})"
           echo "Git Commit: $(git -C source log -n1 --oneline)"
 
+      # The repository path is composed once, here, so that every later step
+      # and publish_image.sh itself agree on it. For GAR that path is assembled
+      # from the GAR_* repository variables; resolve_repo fails loudly when one
+      # is unset, rather than pushing to a half-formed path and reporting it as
+      # a permission error.
+      - name: Resolve image repository
+        env:
+          GAR_LOCATION: ${{ vars.GAR_LOCATION }}
+          GAR_PROJECT: ${{ vars.GAR_PROJECT }}
+          GAR_REPOSITORY: ${{ vars.GAR_REPOSITORY }}
+          GAR_IMAGE: ${{ vars.GAR_IMAGE }}
+        run: |
+          # shellcheck source=/dev/null
+          source source/docker/server/docker_release_lib.sh
+          REPO="$(resolve_repo '${{ inputs.registry }}' '${{ inputs.repo }}')"
+          echo "IMAGE_REPO=$REPO" >> "$GITHUB_ENV"
+          echo "Pushing to $REPO"
+          if [ '${{ inputs.registry }}' = 'gar' ]; then
+            echo "GAR_HOST=$(gar_host)" >> "$GITHUB_ENV"
+          fi
+
       - name: Log in to Docker Hub
+        if: inputs.registry == 'dockerhub'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Direct Workload Identity Federation: the GitHub-signed OIDC token is
+      # exchanged for a Google token tied to the pool that performed the
+      # exchange, and IAM addresses that pool directly. No service account is
+      # impersonated and no key is stored. The villagesql-server-dev repository
+      # grants roles/artifactregistry.writer to this repo's numeric ID within
+      # the pool, so only this repo's workflows can push. Both are declared in
+      # vcloud-cell/dev-cluster (artifact-registry.tf, wif.tf).
+      #
+      # auth_token is that federated token, which is what direct WIF yields;
+      # access_token would require impersonating a service account, and there
+      # is none in this path.
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        if: inputs.registry == 'gar'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.GAR_WIF_PROVIDER || 'projects/161966695365/locations/global/workloadIdentityPools/github/providers/github-workflow' }}
+
+      - name: Log in to Artifact Registry
+        if: inputs.registry == 'gar'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.GAR_HOST }}
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.auth_token }}
 
       # Drop any local copy of the exact tag we are about to build.
       - name: Clean prior image for this tag
         run: |
           # shellcheck source=/dev/null
           source source/docker/server/docker_release_lib.sh
-          IMAGE="$(arch_tag '${{ inputs.repo }}' '${{ inputs.tag }}' '${{ inputs.platform }}')"
+          IMAGE="$(arch_tag "$IMAGE_REPO" '${{ inputs.tag }}' '${{ inputs.platform }}')"
           echo "Removing $IMAGE if present"
           docker image rm -f "$IMAGE" || true
 
@@ -154,5 +219,5 @@ jobs:
           source/docker/server/publish_image.sh \
             --tag "${{ inputs.tag }}" \
             --platform "${{ inputs.platform }}" \
-            --repo "${{ inputs.repo }}" \
+            --repo "$IMAGE_REPO" \
             --push

--- a/.github/workflows/build-server-branch.yml
+++ b/.github/workflows/build-server-branch.yml
@@ -138,6 +138,11 @@ jobs:
       # this env var; leave it unset and they fall back to VSQL_VERSION file's
       # 'dev' suffix regardless of release_build.
       VSQL_PRE_RELEASE_VERSION: ${{ !inputs.release_build && 'dev' || '' }}
+      # Resolved here for the same reason: the clone, build and package stages
+      # must agree on which extensions they are handling, or packaging fails on
+      # a VEB the build stage was never asked to produce. Pre-release builds
+      # carry the bundle=dev extensions; release builds do not.
+      BUNDLE_CHANNEL: ${{ !inputs.release_build && 'dev' || 'release' }}
 
     steps:
       - name: Report Parameters
@@ -150,6 +155,7 @@ jobs:
           echo "Run Unit Tests: $RUN_UNIT_TESTS (${{ inputs.run_unit_tests }})"
           echo "Run Integration Tests: $RUN_INTEGRATION_TESTS (${{ inputs.run_integration_tests }})"
           echo "Bundle Extension: $BUILD_BUNDLED_EXTENSIONS (${{ inputs.bundled_extensions }})"
+          echo "Bundle Channel: $BUNDLE_CHANNEL"
           echo "Upload SDK: $UPLOAD_SDK (${{ inputs.upload_sdk }})"
 
       - name: Checkout
@@ -177,7 +183,7 @@ jobs:
           rm -rf "$EXTS_ROOT"
           mkdir -p "$EXTS_ROOT/sources"
           source/villagesql/bld_tools/checkout_bundled_extensions.sh \
-            "$EXTS_ROOT/sources"
+            "$EXTS_ROOT/sources" "" "$BUNDLE_CHANNEL"
 
       # Bundled-extension build deps. Slated for separate revision; preserved
       # as inline steps so BUILD_BUNDLED_EXTENSIONS builds keep working.
@@ -214,7 +220,8 @@ jobs:
         run: |
           SDK_STAGING_DIR="$(source/villagesql/bld_tools/get_sdk.sh "$BUILD_DIR")"
           source/villagesql/bld_tools/build_bundled_extensions.sh \
-            "$EXTS_ROOT/sources" "${SDK_STAGING_DIR}" "${BUILD_DIR}/veb_output_directory"
+            "$EXTS_ROOT/sources" "${SDK_STAGING_DIR}" "${BUILD_DIR}/veb_output_directory" \
+            "" "$BUNDLE_CHANNEL"
 
       - name: Test bundled extensions
         if: env.BUILD_BUNDLED_EXTENSIONS == '1'
@@ -230,6 +237,7 @@ jobs:
           BUILD_DIR="$BUILD_DIR" \
           OUTPUT_DIR="$OUTPUT_DIR" \
           BUILD_BUNDLED_EXTENSIONS="${BUILD_BUNDLED_EXTENSIONS:-0}" \
+          BUNDLE_CHANNEL="$BUNDLE_CHANNEL" \
             source/villagesql/bld_tools/package_dev_server.sh
 
       - name: Run integration tests

--- a/.github/workflows/release-docker-branch.yml
+++ b/.github/workflows/release-docker-branch.yml
@@ -23,10 +23,15 @@ on:
         type: string
         default: ''
       repo:
-        description: 'Image repository to push to.'
+        description: 'Image repository to push to. Ignored when registry is "gar", which composes the path from the GAR_* repository variables.'
         required: false
         type: string
         default: 'villagesql/server'
+      registry:
+        description: 'Registry to publish to: "dockerhub" or "gar". GAR carries the pre-release images.'
+        required: false
+        type: string
+        default: 'dockerhub'
       pre_release_version:
         description: 'Pre-release suffix for the version. Empty (the default) is a release build; set e.g. dev or rc1 otherwise.'
         required: false
@@ -55,10 +60,18 @@ on:
         type: string
         default: ''
       repo:
-        description: 'Image repository to push to.'
+        description: 'Image repository to push to. Ignored when registry is "gar".'
         required: false
         type: string
         default: 'villagesql/server'
+      registry:
+        description: 'Registry to publish to. GAR carries the pre-release images.'
+        required: true
+        type: choice
+        options:
+          - dockerhub
+          - gar
+        default: dockerhub
       pre_release_version:
         description: 'Pre-release suffix for the version. Leave blank for a release build; set e.g. dev or rc1 otherwise.'
         required: false
@@ -80,6 +93,9 @@ on:
 
 permissions:
   contents: read
+  # Needed by the Workload Identity Federation exchange in the GAR path, both
+  # here and in the build-docker-branch jobs this workflow calls.
+  id-token: write
 
 jobs:
   # Reports what is being built and reads the image table. The report describes
@@ -106,6 +122,7 @@ jobs:
           echo "Git SHA1: $(git rev-parse HEAD)"
           echo "Git Commit: $(git log -n1 --oneline)"
           echo "Image Tag: ${{ inputs.tag || inputs.ref }}"
+          echo "Registry: ${{ inputs.registry }}"
           echo "Repository: ${{ inputs.repo }}"
           echo "Pre-release Version: '${{ inputs.pre_release_version }}'"
           echo "Dev ABI: ${{ inputs.dev_abi }}"
@@ -151,6 +168,7 @@ jobs:
       platform: ${{ matrix.docker_platform }}
       runner: ${{ toJSON(matrix.runner) }}
       repo: ${{ inputs.repo }}
+      registry: ${{ inputs.registry }}
       pre_release_version: ${{ inputs.pre_release_version }}
       dev_abi: ${{ inputs.dev_abi }}
 
@@ -171,11 +189,47 @@ jobs:
           sparse-checkout: docker/server/
           ref: ${{ inputs.ref }}
 
+      # The same resolution build-docker-branch did, repeated here because the
+      # manifest job needs the identical path to find the arch tags it stitches.
+      - name: Resolve image repository
+        env:
+          GAR_LOCATION: ${{ vars.GAR_LOCATION }}
+          GAR_PROJECT: ${{ vars.GAR_PROJECT }}
+          GAR_REPOSITORY: ${{ vars.GAR_REPOSITORY }}
+          GAR_IMAGE: ${{ vars.GAR_IMAGE }}
+        run: |
+          # shellcheck source=/dev/null
+          source docker/server/docker_release_lib.sh
+          REPO="$(resolve_repo '${{ inputs.registry }}' '${{ inputs.repo }}')"
+          echo "IMAGE_REPO=$REPO" >> "$GITHUB_ENV"
+          echo "Publishing manifest for $REPO"
+          if [ '${{ inputs.registry }}' = 'gar' ]; then
+            echo "GAR_HOST=$(gar_host)" >> "$GITHUB_ENV"
+          fi
+
       - name: Log in to Docker Hub
+        if: inputs.registry == 'dockerhub'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Direct Workload Identity Federation, as in build-docker-branch: no
+      # service account, and auth_token is the federated token IAM addresses.
+      - name: Authenticate to Google Cloud
+        id: gcp-auth
+        if: inputs.registry == 'gar'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+        with:
+          workload_identity_provider: ${{ vars.GAR_WIF_PROVIDER || 'projects/161966695365/locations/global/workloadIdentityPools/github/providers/github-workflow' }}
+
+      - name: Log in to Artifact Registry
+        if: inputs.registry == 'gar'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ${{ env.GAR_HOST }}
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.auth_token }}
 
       # The shared tags move to this manifest. A test push clears them, so
       # that a 'docker pull villagesql/server' cannot see the result.
@@ -183,6 +237,6 @@ jobs:
         run: |
           docker/server/publish_manifest.sh \
             --tag "${{ inputs.tag || inputs.ref }}" \
-            --repo "${{ inputs.repo }}" \
+            --repo "$IMAGE_REPO" \
             --platforms "${{ needs.report-parameters.outputs.platforms }}" \
             --shared-tags "${{ inputs.shared_tags }}"

--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -67,7 +67,14 @@ RUN VSQL_DEV_ABI=ON build-bundled-extension.sh vsql-complex
 # and have additional dependencies
 COPY scripts/setup_linux_ext_deps.sh /tmp/
 RUN /tmp/setup_linux_ext_deps.sh && rm -rf /var/lib/apt/lists/*
-RUN VSQL_DEV_ABI=$VSQL_DEV_ABI build-bundled-extensions.sh
+
+# Which extensions ship in the image. Left empty it follows the build type: a
+# pre-release image gets the bundle=dev extensions, a release image does not.
+# Set it explicitly to override that pairing.
+ARG BUNDLE_CHANNEL=
+RUN CHANNEL="${BUNDLE_CHANNEL:-$([ -n "$VSQL_PRE_RELEASE_VERSION" ] \
+        && echo dev || echo release)}" \
+    && VSQL_DEV_ABI=$VSQL_DEV_ABI build-bundled-extensions.sh "$CHANNEL"
 
 # ---------------------------------------------------------------------------
 # Stage 2: Runtime image

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -11,7 +11,9 @@ docker build -f docker/server/Dockerfile -t villagesql/server:latest .
 The build compiles VillageSQL from source and bundles several extensions:
 - `vsql_complex` (in-tree example)
 Plus the bundled extensions defined by
-`villagesql/dev_server/bundled_extensions.txt`
+`villagesql/dev_server/bundled_extensions.txt`. Which of those the image
+actually ships depends on the build channel — see `BUNDLE_CHANNEL` under
+[Release Build Args](#release-build-args).
 
 The first build takes ~25 minutes (server compilation). Subsequent builds are fast
 (~35 seconds) as long as source files outside `docker/` haven't changed.
@@ -97,9 +99,52 @@ Images are tagged `REPO:TAG-ARCH` per platform (e.g. `villagesql/server:0.0.5-ar
 and the manifest list is published under `TAG` plus each shared tag (`latest` and
 `stable` by default).
 
+### Registries
+
+Both scripts take `--registry`, which decides where the image goes:
+
+| Registry | Carries | Repository |
+| --- | --- | --- |
+| `dockerhub` (default) | Released images | `--repo`, default `villagesql/server` |
+| `gar` | Pre-release images | Composed from the `GAR_*` variables below |
+
+Google Artifact Registry holds the pre-release images, so an unreleased build
+never lands on a public registry. The defaults name the `villagesql-server-dev`
+repository declared in the `vcloud-cell/dev-cluster` Terraform, so
+`--registry gar` needs no configuration to push to the usual place:
+
+| Variable | Meaning | Default |
+| --- | --- | --- |
+| `GAR_LOCATION` | GAR region | `us-central1` |
+| `GAR_PROJECT` | GCP project id | `villagesql-vcloud-pelican-dev` |
+| `GAR_REPOSITORY` | Artifact Registry repository | `villagesql-server-dev` |
+| `GAR_IMAGE` | Image name within it | `server` |
+
+Together those form
+`$GAR_LOCATION-docker.pkg.dev/$GAR_PROJECT/$GAR_REPOSITORY/$GAR_IMAGE`, i.e.
+`us-central1-docker.pkg.dev/villagesql-vcloud-pelican-dev/villagesql-server-dev/server`.
+Setting one empty is an error rather than a half-formed path, which GAR would
+otherwise report as an opaque permission denial.
+
+```bash
+VSQL_PRE_RELEASE_VERSION=dev \
+    docker/server/publish_image.sh \
+        --registry gar --tag 0.0.6-dev --platform linux/amd64 --push
+```
+
+Locally that needs `gcloud auth configure-docker us-central1-docker.pkg.dev`
+once. In CI nothing is configured by hand: the workflows use direct Workload
+Identity Federation, exchanging the job's OIDC token for a Google token tied to
+the pool that performed the exchange. No service account is impersonated and no
+key is stored — the repository's IAM policy grants
+`roles/artifactregistry.writer` to this GitHub repo's numeric ID within the
+pool, so only this repo's workflows can push. The pool, provider and policy are
+declared in `vcloud-cell/dev-cluster` (`wif.tf`, `artifact-registry.tf`); the
+`GAR_WIF_PROVIDER` repository variable overrides the provider if it ever moves.
+
 ## Release Build Args
 
-Both build args are read from the environment and forwarded to `docker build`:
+The build args are read from the environment and forwarded to `docker build`:
 
 ```bash
 VSQL_PRE_RELEASE_VERSION="" VSQL_DEV_ABI=OFF \
@@ -107,6 +152,11 @@ VSQL_PRE_RELEASE_VERSION="" VSQL_DEV_ABI=OFF \
 ```
 
 Defaults are an empty `VSQL_PRE_RELEASE_VERSION` (a release build) and `VSQL_DEV_ABI=ON`.
+
+`BUNDLE_CHANNEL` picks which extensions the image ships. Left unset it follows
+the build type — a pre-release image gets the `bundle=dev` extensions from the
+manifest, a release image does not — so it is worth setting only to break that
+pairing deliberately.
 
 ## Building Additional Extensions
 

--- a/docker/server/build-bundled-extension.sh
+++ b/docker/server/build-bundled-extension.sh
@@ -22,8 +22,9 @@
 # The extension name should be like "vsql-complex", "vsql-uuid", etc.
 #
 # For in-tree extensions (vsql-complex), the source is taken from
-# /source/villagesql/examples/<name>. For external extensions, the
-# repo is cloned from github.com/villagesql/<name>.
+# /source/villagesql/examples/<name>. For external extensions, the repo is
+# cloned from EXT_URL at EXT_BRANCH when build-bundled-extensions.sh supplies
+# them from the manifest, and from github.com/villagesql/<name> otherwise.
 
 set -eo pipefail
 
@@ -57,11 +58,13 @@ if [ -d "$IN_TREE_DIR" ]; then
     echo "==> Building in-tree extension: ${EXT_NAME}"
 else
     EXT_SRC="/ext-src-${EXT_NAME}"
-    echo "==> Cloning extension: ${EXT_NAME}"
+    CLONE_URL="${EXT_URL:-https://github.com/villagesql/${EXT_NAME}.git}"
+    echo "==> Cloning extension: ${EXT_NAME} (${CLONE_URL}${EXT_BRANCH:+ @ ${EXT_BRANCH}})"
     if [ ! -f /etc/ssl/certs/ca-certificates.crt ]; then
         apt-get update -qq && apt-get install -y -qq ca-certificates >/dev/null
     fi
-    git clone "https://github.com/villagesql/${EXT_NAME}.git" "$EXT_SRC"
+    git clone --depth=1 ${EXT_BRANCH:+--branch "$EXT_BRANCH"} \
+        "$CLONE_URL" "$EXT_SRC"
 fi
 
 EXT_BUILD="/ext-build-${EXT_NAME}"

--- a/docker/server/build-bundled-extensions.sh
+++ b/docker/server/build-bundled-extensions.sh
@@ -1,46 +1,56 @@
 #!/bin/bash
 # Copyright (c) 2026 VillageSQL Contributors
-# Build VEB files for bundled VillageSQL extensions.
+# Build every bundled VillageSQL extension during a Docker image build.
 #
-# Usage: include_bundled_extensions.sh <dst_dir> <veb_src_dir>
+# Usage: build-bundled-extensions.sh [channel]
 #
-# <veb_src_dir>: Directory where built .veb files were placed.
+# [channel]: Build channel to build for: release (default) or dev. "dev" adds
+#            the bundle=dev extensions, which ship only in pre-release images.
+#            Taken from BUNDLE_CHANNEL when the argument is omitted.
 #
-# The extension list is read from villagesql/dev_server/bundled_extensions.txt,
-# located relative to this script's source tree.
+# The extensions themselves are still defined by the manifest,
+# villagesql/dev_server/bundled_extensions.txt. This script no longer parses it
+# directly: villagesql/bld_matrix/json_bundle_extensions.sh does, so the image
+# and CI agree on what a manifest entry means. That matters for bundle=dev,
+# which the parser this replaced would have shipped in release images.
+#
+# Inputs (environment variables, all optional):
+#   SOURCE_DIR      — the source tree holding the scripts and the manifest
+#                     (default: /source, where the Dockerfile copies it)
+#   EXTENSIONS_FILE — a manifest somewhere other than the one in SOURCE_DIR.
+#                     Read by json_extensions.sh; passed straight through.
+#
+# jq comes from setup_linux_build_env.sh, run earlier in the builder stage.
+#
+# Each extension is handed to build-bundled-extension.sh, which does the clone
+# and the cmake build. The url and branch travel with it so a manifest entry
+# pointing at a fork or a pinned tag is honoured here, not just in CI.
 
 set -euo pipefail
 
-EXTENSIONS_LIST="source/villagesql/dev_server/bundled_extensions.txt"
+SOURCE_DIR="${SOURCE_DIR:-/source}"
+BUNDLE_CHANNEL="${1:-${BUNDLE_CHANNEL:-release}}"
 
-function log_info() { echo "$*"; }
+SELECT="$SOURCE_DIR/villagesql/bld_matrix/json_bundle_extensions.sh"
+[[ -x "$SELECT" ]] || { echo "error: not found: $SELECT" >&2; exit 1; }
 
-if [[ ! -f "$EXTENSIONS_LIST" ]]; then
-    log_info "Extensions list not found: $EXTENSIONS_LIST"
-    exit 1
-fi
+echo "==> Bundled extensions: $BUNDLE_CHANNEL channel"
 
-# Read and parse the list of extensions
-while IFS= read -r line; do
-    [[ "$line" =~ ^[[:space:]]*# ]] && continue
-    [[ -z "${line// }" ]] && continue
+# Collected up front, rather than piped into the loop, so a manifest error
+# stops the script before anything is built.
+ENTRIES="$("$SELECT" "$BUNDLE_CHANNEL" \
+    | jq -r '.[] | [.extension, .url, .branch, .build] | @tsv')"
 
-    # Parse "url [branch-or-tag] [key=value ...]" — all fields after url are optional
-    read -ra FIELDS <<< "$line"
-    SOURCE="${FIELDS[0]%/}"
-    BRANCH="${FIELDS[1]:-}"
-    REPO_NAME="${SOURCE##*/}"
+while IFS=$'\t' read -r EXTENSION URL BRANCH BUILD_TOOL; do
+    [[ -z "$EXTENSION" ]] && continue
 
-    # Confirm the extension is bundled
-    BUNDLE=true
-    for FIELD in "${FIELDS[@]:2}"; do
-        [[ "$FIELD" == "bundle=false" || "$FIELD" == "bundle=no" ]] && BUNDLE=false
-    done
-    if [[ "$BUNDLE" == "false" ]]; then
-        log_info "Skipping $REPO_NAME (bundle=false)"
+    # This image builds with cmake. Skip entries that use another build tool
+    # such as cargo, matching villagesql/bld_tools/build_bundled_extensions.sh.
+    # TODO(villagesql-rust): support cargo extensions in the image too.
+    if [[ "$BUILD_TOOL" != "cmake" ]]; then
+        echo "Skipping $EXTENSION (build=$BUILD_TOOL not supported here)"
         continue
     fi
 
-    build-bundled-extension.sh "$REPO_NAME"
-
-done < "$EXTENSIONS_LIST"
+    EXT_URL="$URL" EXT_BRANCH="$BRANCH" build-bundled-extension.sh "$EXTENSION"
+done <<< "$ENTRIES"

--- a/docker/server/docker_release_lib.sh
+++ b/docker/server/docker_release_lib.sh
@@ -24,6 +24,20 @@ DOCKER_REPO="villagesql/server"
 DOCKER_SHARED_TAGS="latest,stable"
 DEFAULT_PLATFORMS="linux/amd64,linux/arm64"
 
+# Google Artifact Registry. Only the pre-release images go here: Docker Hub
+# carries the releases, and an unreleased build has no business on a public
+# registry.
+#
+# These defaults name the villagesql-server-dev repository declared in the
+# vcloud-cell/dev-cluster Terraform (artifact-registry.tf), which also grants
+# this GitHub repo push access. Override them to publish somewhere else; empty
+# is an error rather than a half-formed path, which GAR would otherwise report
+# as an opaque permission denial.
+GAR_LOCATION="${GAR_LOCATION:-us-central1}"
+GAR_PROJECT="${GAR_PROJECT:-villagesql-vcloud-pelican-dev}"
+GAR_REPOSITORY="${GAR_REPOSITORY:-villagesql-server-dev}"
+GAR_IMAGE="${GAR_IMAGE:-server}"
+
 # Build args forwarded to docker build. Override via the environment, e.g.
 #   VSQL_PRE_RELEASE_VERSION="" VSQL_DEV_ABI=OFF publish_image.sh ...
 # Default to a release build (empty pre-release suffix).
@@ -47,6 +61,33 @@ run() {
 
 require_docker() {
     command -v docker >/dev/null 2>&1 || die "docker not found on PATH"
+}
+
+# The GAR host that docker pushes to and gcloud configures credentials for.
+gar_host() {
+    [ -n "$GAR_LOCATION" ] || die "GAR_LOCATION is not set"
+    echo "${GAR_LOCATION}-docker.pkg.dev"
+}
+
+# The full GAR repository path, which is what --repo wants. GAR nests an image
+# inside a named repository inside a project, so this is one segment longer
+# than a Docker Hub repo: us-central1-docker.pkg.dev/proj/villagesql-server-dev/server
+gar_repo() {
+    [ -n "$GAR_PROJECT" ] || die "GAR_PROJECT is not set"
+    [ -n "$GAR_REPOSITORY" ] || die "GAR_REPOSITORY is not set"
+    [ -n "$GAR_IMAGE" ] || die "GAR_IMAGE is not set"
+    echo "$(gar_host)/${GAR_PROJECT}/${GAR_REPOSITORY}/${GAR_IMAGE}"
+}
+
+# Resolve --repo for a registry: "dockerhub" keeps whatever the caller passed,
+# "gar" composes the path from the GAR_* variables above.
+resolve_repo() {
+    local registry="$1" fallback="$2"
+    case "$registry" in
+        gar)       gar_repo ;;
+        dockerhub) echo "$fallback" ;;
+        *)         die "Unknown registry: $registry (expected dockerhub or gar)" ;;
+    esac
 }
 
 # Map a docker platform to the arch suffix we tag with: linux/amd64 -> amd64,

--- a/docker/server/publish_image.sh
+++ b/docker/server/publish_image.sh
@@ -38,6 +38,7 @@ DOCKERFILE="$SCRIPT_DIR/Dockerfile"
 
 TAG=""
 REPO="$DOCKER_REPO"
+REGISTRY="dockerhub"
 PLATFORM=""
 PUSH=0
 
@@ -51,7 +52,12 @@ Usage:
 Options:
   -t, --tag TAG          Tag to build, e.g. a version (required)
   -p, --platform PLAT    Single docker platform, e.g. linux/arm64 (required)
-  -r, --repo REPO        Image repository (default: $DOCKER_REPO)
+  -r, --repo REPO        Image repository (default: $DOCKER_REPO). Ignored
+                         when --registry is gar.
+      --registry NAME    Where to push: dockerhub (default) or gar. "gar"
+                         composes the repository from GAR_LOCATION,
+                         GAR_PROJECT, GAR_REPOSITORY and GAR_IMAGE, and is
+                         where the pre-release images go.
       --push             Publish the image to the registry. Without this the
                          image is only built, and loaded locally for testing.
   -n, --dry-run          Print the commands without running them
@@ -64,6 +70,9 @@ arch tags into the shared multi-arch tags.
 Build args are taken from the environment:
   VSQL_PRE_RELEASE_VERSION  pre-release suffix (default: empty, a release)
   VSQL_DEV_ABI              expose the development ABI (default: ON)
+  BUNDLE_CHANNEL            which extensions ship (default: empty, which
+                            follows VSQL_PRE_RELEASE_VERSION — dev for a
+                            pre-release image, release otherwise)
 
 Examples:
   # Build the native arch and smoke test it before publishing anything
@@ -72,6 +81,11 @@ Examples:
 
   # Build and publish one arch
   publish_image.sh --tag 0.0.5 --platform linux/arm64 --push
+
+  # Publish a pre-release image to Artifact Registry
+  GAR_LOCATION=us-central1 GAR_PROJECT=my-project \\
+  VSQL_PRE_RELEASE_VERSION=dev \\
+    publish_image.sh --registry gar --tag 0.0.6-dev --platform linux/amd64 --push
 EOF
 }
 
@@ -81,6 +95,7 @@ main() {
             -t|--tag)      TAG="$2"; shift 2 ;;
             -p|--platform) PLATFORM="$2"; shift 2 ;;
             -r|--repo)     REPO="$2"; shift 2 ;;
+            --registry)    REGISTRY="$2"; shift 2 ;;
             --push)        PUSH=1; shift ;;
             -n|--dry-run)  DRY_RUN=1; shift ;;
             -h|--help)     usage; exit 0 ;;
@@ -94,6 +109,7 @@ main() {
         *,*) echo "error: --platform takes a single platform; run once per arch" >&2; exit 2 ;;
     esac
     require_docker
+    REPO="$(resolve_repo "$REGISTRY" "$REPO")"
 
     local image_tag output
     image_tag="$(arch_tag "$REPO" "$TAG" "$PLATFORM")"
@@ -104,7 +120,8 @@ main() {
     fi
 
     echo "--- Building $PLATFORM -> $image_tag ($output) ---"
-    echo "Build args : VSQL_PRE_RELEASE_VERSION='$VSQL_PRE_RELEASE_VERSION' VSQL_DEV_ABI=$VSQL_DEV_ABI"
+    echo "Build args : VSQL_PRE_RELEASE_VERSION='$VSQL_PRE_RELEASE_VERSION'" \
+         "VSQL_DEV_ABI=$VSQL_DEV_ABI BUNDLE_CHANNEL='${BUNDLE_CHANNEL:-}'"
     [ "$DRY_RUN" -eq 1 ] && echo "(dry run: commands will be printed, not executed)"
 
     run docker buildx build \
@@ -112,6 +129,7 @@ main() {
         -f "$DOCKERFILE" \
         --build-arg "VSQL_PRE_RELEASE_VERSION=$VSQL_PRE_RELEASE_VERSION" \
         --build-arg "VSQL_DEV_ABI=$VSQL_DEV_ABI" \
+        --build-arg "BUNDLE_CHANNEL=${BUNDLE_CHANNEL:-}" \
         -t "$image_tag" \
         "$output" \
         "$REPO_ROOT"

--- a/docker/server/publish_manifest.sh
+++ b/docker/server/publish_manifest.sh
@@ -32,6 +32,7 @@ source "$SCRIPT_DIR/docker_release_lib.sh"
 
 TAG=""
 REPO="$DOCKER_REPO"
+REGISTRY="dockerhub"
 PLATFORMS="$DEFAULT_PLATFORMS"
 SHARED_TAGS="$DOCKER_SHARED_TAGS"
 
@@ -46,7 +47,11 @@ Usage:
 
 Options:
   -t, --tag TAG          Primary tag to publish, e.g. a version (required)
-  -r, --repo REPO        Image repository (default: $DOCKER_REPO)
+  -r, --repo REPO        Image repository (default: $DOCKER_REPO). Ignored
+                         when --registry is gar.
+      --registry NAME    Where the arch images live: dockerhub (default) or
+                         gar. "gar" composes the repository from GAR_LOCATION,
+                         GAR_PROJECT, GAR_REPOSITORY and GAR_IMAGE.
   -p, --platforms LIST   Comma-separated platforms whose arch images make up
                          the manifest (default: $DEFAULT_PLATFORMS)
   -s, --shared-tags LIST       Comma-separated shared tags applied in addition to
@@ -109,6 +114,7 @@ main() {
         case "$1" in
             -t|--tag)          TAG="$2"; shift 2 ;;
             -r|--repo)      REPO="$2"; shift 2 ;;
+            --registry)     REGISTRY="$2"; shift 2 ;;
             -p|--platforms) PLATFORMS="$2"; shift 2 ;;
             -s|--shared-tags)      SHARED_TAGS="$2"; shift 2 ;;
             -n|--dry-run)   DRY_RUN=1; shift ;;
@@ -119,6 +125,7 @@ main() {
 
     [ -n "$TAG" ] || { echo "error: --tag is required" >&2; usage >&2; exit 2; }
     require_docker
+    REPO="$(resolve_repo "$REGISTRY" "$REPO")"
 
     local platform
     ARCH_TAGS=()

--- a/villagesql/bld_matrix/README.md
+++ b/villagesql/bld_matrix/README.md
@@ -15,6 +15,7 @@ span lines. Pipe through `jq .` to read it.
 | `json_docker.sh`     | The Docker images published, as an array of objects.           |
 | `json_build_matrix.sh` | The build-server matrix, one row per platform.                |
 | `json_test_extensions.sh` | The extension tests, one row per (platform, extension, abi). |
+| `json_bundle_extensions.sh` | The extensions one build channel ships.                      |
 
 Each script's header comment documents its arguments and environment
 variables, and is the source of truth for them.
@@ -28,6 +29,11 @@ and each prints its whole set.
 The rest select and combine. They call the tables they need and take filters
 as positional arguments; pass "" for a filter to keep everything.
 
+`json_bundle_extensions.sh` is the one to reach for when the question is "which
+extensions does this build ship?" — the answer depends on a build channel
+(release, dev, all), not on the manifest alone, and every consumer that copies
+that logic by hand is a chance for the image and the tarball to disagree.
+
 A `_matrix` suffix means the output is a GitHub Actions strategy matrix —
 `{"include": [...]}`, ready for `matrix: ${{ fromJson(...) }}`. Everything
 else prints a bare array, which a caller can wrap with `jq '{include: .}'`.
@@ -39,8 +45,16 @@ MATRIX="$PWD/villagesql/bld_matrix"
 
 "$MATRIX/json_extensions.sh" | jq .
 
-# The extensions shipped in the dev-server tarball.
-"$MATRIX/json_extensions.sh" | jq -r '.[] | select(.bundle) | .extension'
+# The extensions shipped in a release tarball, and in a pre-release one.
+"$MATRIX/json_bundle_extensions.sh" release | jq -r '.[].extension'
+"$MATRIX/json_bundle_extensions.sh" dev | jq -r '.[].extension'
+
+# Everything the sanitizer and compat suites build, bundle=false included.
+"$MATRIX/json_bundle_extensions.sh" all | jq -r '.[].extension'
+
+# What a channel adds over the release set.
+diff <("$MATRIX/json_bundle_extensions.sh" release | jq -r '.[].extension') \
+     <("$MATRIX/json_bundle_extensions.sh" dev | jq -r '.[].extension')
 
 # A manifest from somewhere else.
 EXTENSIONS_FILE=/tmp/exts.txt "$MATRIX/json_extensions.sh"

--- a/villagesql/bld_matrix/json_bundle_extensions.sh
+++ b/villagesql/bld_matrix/json_bundle_extensions.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Copyright (c) 2026 VillageSQL Contributors
+#
+# Print the extensions that belong in one build channel, as a compact JSON
+# array. This selects from json_extensions.sh; it is not itself a data table.
+#
+# Usage: json_bundle_extensions.sh [channel] [extension]
+#
+# [channel]:   Which build channel to select for. Default "release".
+#                release — bundle=true only. What a release artifact ships.
+#                dev     — bundle=true and bundle=dev. What a pre-release
+#                          artifact ships: the -dev tarball, the dev image.
+#                all     — every entry, bundle=false included. What the
+#                          sanitizer and compat suites build, since they test
+#                          extensions that no artifact ships.
+#              For compatibility with the include_unbundled argument these
+#              scripts used to take, "" and 0/no mean release, and 1/yes means
+#              all.
+# [extension]: Optional extension name to select just that one. Pass "" to
+#              keep every extension the channel allows.
+#
+# A channel is a widening sequence: release ⊂ dev ⊂ all. Nothing selects
+# bundle=dev without also selecting bundle=true, because an extension held
+# back from release still depends on the ones that are not.
+#
+# Inputs (environment variables, all optional):
+#   EXTENSIONS_FILE — passed through to json_extensions.sh
+#
+# Testable locally:
+#   villagesql/bld_matrix/json_bundle_extensions.sh dev | jq .
+#   villagesql/bld_matrix/json_bundle_extensions.sh all vsql-ai | jq .
+
+set -euo pipefail
+
+MATRIX_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_DIR="$(cd "$MATRIX_DIR/../.." && pwd)"
+source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
+
+CHANNEL="${1:-release}"
+EXTENSION_FILTER="${2:-}"
+
+case "$CHANNEL" in
+    release|0|no|"") CHANNEL=release ;;
+    dev)             CHANNEL=dev ;;
+    all|1|yes)       CHANNEL=all ;;
+    *) die "Invalid channel: $CHANNEL (expected release, dev, or all)" ;;
+esac
+
+"$MATRIX_DIR/json_extensions.sh" | jq -c \
+    --arg channel "$CHANNEL" \
+    --arg filter "$EXTENSION_FILTER" '
+      [ { release: ["release"],
+          dev:     ["release", "dev"],
+          all:     ["release", "dev", "none"] }[$channel] ] as $keep
+      | map(select((.bundle | IN($keep[][]))
+                   and ($filter == "" or .extension == $filter)))'

--- a/villagesql/bld_matrix/json_extensions.sh
+++ b/villagesql/bld_matrix/json_extensions.sh
@@ -13,7 +13,12 @@
 #   path       — subdirectory holding the extension, "" for the repo root
 #   extension  — last segment of path, or of url when path is ""
 #   abis       — ["stable","dev"] unless the entry pins one with abi=
-#   bundle     — false only for bundle=false or bundle=no, otherwise true
+#   bundle     — the narrowest build channel that ships the extension:
+#                "release" (bundle=true, the default), "dev" (bundle=dev), or
+#                "none" (bundle=false). A "dev" extension ships in pre-release
+#                artifacts only — the -dev tarball and the dev Docker image —
+#                and is held back from release builds. Any other bundle= value
+#                is an error, so a typo cannot silently ship or withhold one.
 #
 # There is no default branch. An entry that names none — whether it stops at
 # the url or goes straight to a key=value option — is an error. Unrecognized
@@ -58,7 +63,7 @@ jq -Rcn '
           as $path
       | ($opts | map(select(startswith("abi=")) | ltrimstr("abi=")) | .[0]) as $abi
       | ($opts | map(select(startswith("bundle=")) | ltrimstr("bundle=")) | .[0] //
-        "true") as $bundle
+        "true" | ascii_downcase) as $bundle
       | {
           url:       ($f[0] | rtrimstr("/")),
           branch:    $f[1],
@@ -67,6 +72,10 @@ jq -Rcn '
           extension: (if $path != "" then ($path | split("/") | last)
                       else ($f[0] | rtrimstr("/") | split("/") | last) end),
           abis:      (if $abi then [$abi] else ["stable","dev"] end),
-          bundle:    ($bundle | ascii_downcase | (. != "false" and . != "no"))
+          bundle:    (if   $bundle == "true"  or $bundle == "yes" then "release"
+                      elif $bundle == "dev"                       then "dev"
+                      elif $bundle == "false" or $bundle == "no"  then "none"
+                      else error("unknown bundle=\($bundle) in entry: \(.)")
+                      end)
         }
     ]' "$EXTENSIONS_FILE"

--- a/villagesql/bld_tools/README.md
+++ b/villagesql/bld_tools/README.md
@@ -20,7 +20,12 @@ without producing a package.
   `build_bundled_extensions.sh` builds each into a `.veb`, and
   `test_extension_vebs.sh` runs the MTR suite that each extension repo carries.
   All three are driven by the manifest at
-  [../dev_server/bundled_extensions.txt](../dev_server/bundled_extensions.txt).
+  [../dev_server/bundled_extensions.txt](../dev_server/bundled_extensions.txt),
+  and all three take a **build channel** saying how much of it to act on:
+  `release` (the `bundle=true` extensions), `dev` (those plus `bundle=dev`), or
+  `all` (plus `bundle=false`, which no artifact ships but the sanitizer and
+  compat suites still build). Which entries a channel selects is decided in one
+  place, [../bld_matrix/json_bundle_extensions.sh](../bld_matrix/json_bundle_extensions.sh).
 - **Test.** `test_ci.sh` runs the VillageSQL unit tests and the MTR
   integration suites.
 - **Package.** `package_dev_server.sh` produces the dev-server tarball.
@@ -33,6 +38,14 @@ Two ordering constraints are not evident from the script names:
 - `package_dev_server.sh` **packages, it does not build.** It runs `cpack`
   against a finished `BUILD_DIR`, and with `BUILD_BUNDLED_EXTENSIONS=1` it
   expects the VEBs to already be in `$BUILD_DIR/veb_output_directory`.
+
+A third constraint follows from the channel: **the clone, build and package
+stages must all be given the same one.** Packaging copies rather than builds, so
+a channel wider than the build stage's fails on a `.veb` that was never
+produced. `package_dev_server.sh` defaults its channel to `dev` when
+`VSQL_PRE_RELEASE_VERSION` is set and `release` otherwise, which is why CI
+resolves `BUNDLE_CHANNEL` once at job scope and passes the same value to each
+stage.
 
 ## The scripts
 
@@ -98,6 +111,21 @@ mkdir -p "$EXTS_DIR"
     "$BUILD_DIR/veb_output_directory"
 
 BUILD_BUNDLED_EXTENSIONS=1 "$TOOLS/package_dev_server.sh"
+```
+
+For a pre-release tarball that also carries the `bundle=dev` extensions, pass
+the `dev` channel to every stage. The extension filter is the argument before
+it, so pass `""` to keep them all:
+
+```bash
+"$TOOLS/checkout_bundled_extensions.sh" "$EXTS_DIR" "" dev
+"$TOOLS/build_bundled_extensions.sh" \
+    "$EXTS_DIR" \
+    "$("$TOOLS/get_sdk.sh" "$BUILD_DIR")" \
+    "$BUILD_DIR/veb_output_directory" \
+    "" dev
+
+BUILD_BUNDLED_EXTENSIONS=1 BUNDLE_CHANNEL=dev "$TOOLS/package_dev_server.sh"
 ```
 
 Extensions have their own build dependencies, installed by

--- a/villagesql/bld_tools/build_bundled_extensions.sh
+++ b/villagesql/bld_tools/build_bundled_extensions.sh
@@ -3,43 +3,41 @@
 # Build VEB files for bundled VillageSQL extensions.
 #
 # Usage: build_bundled_extensions.sh <ext_dir> <sdk_dir> <veb_output_dir>
-#            [extension] [include_unbundled]
+#            [extension] [channel]
 # <ext_dir>:        Path to a directory of extension git clones.
 # <sdk_dir>:        Path to an extracted villagesql-extension-sdk-* directory.
 #                   After 'make', this is $BUILD_DIR/villagesql-extension-sdk-<version>.
 # <veb_output_dir>: Directory where built .veb files are placed.
 # [extension]:      Optional extension name to build only one extension (e.g.
 #                   vsql-ai). Omit to build every extension in the manifest.
-# [include_unbundled]: 0/no (default) to skip bundle=false extensions, 1/yes to
-#                   build them too. They ship with no dev server, but are still
-#                   built and tested (e.g. by the sanitizer workflow).
+# [channel]:        Build channel to build for: release (default), dev, or all.
+#                   "dev" adds the bundle=dev extensions, which ship only in
+#                   pre-release artifacts; "all" adds bundle=false too, which
+#                   ship nowhere but are still built and tested (e.g. by the
+#                   sanitizer workflow). 0/no and 1/yes are accepted as the
+#                   old include_unbundled spellings of release and all.
 #
-# The manifest is parsed by villagesql/bld_matrix/json_extensions.sh, which
-# reads villagesql/dev_server/bundled_extensions.txt from this script's own
-# source tree.
+# Which entries a channel selects is decided by
+# villagesql/bld_matrix/json_bundle_extensions.sh, which reads the manifest at
+# villagesql/dev_server/bundled_extensions.txt from this script's own source
+# tree.
 #
 # Env vars:
 #   CMAKE_EXTRA_FLAGS  - additional per-extension cmake flags appended verbatim
 
 set -euo pipefail
 
-USAGE="Usage: $0 <ext_dir> <sdk_dir> <veb_output_dir> [extension] [include_unbundled]"
+USAGE="Usage: $0 <ext_dir> <sdk_dir> <veb_output_dir> [extension] [channel]"
 EXTENSION_CLONES_DIR="${1:?$USAGE}"
 SDK_DIR="${2:?$USAGE}"
 VEB_OUTPUT_DIR="${3:?$USAGE}"
 EXTENSION_FILTER="${4:-}"
-INCLUDE_UNBUNDLED="${5:-no}"
+BUNDLE_CHANNEL="${5:-release}"
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
 
 source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
-
-case "$INCLUDE_UNBUNDLED" in
-    1|yes) INCLUDE_UNBUNDLED=yes ;;
-    0|no|"") INCLUDE_UNBUNDLED=no ;;
-    *) die "Invalid include_unbundled: $INCLUDE_UNBUNDLED (expected 0/no or 1/yes)" ;;
-esac
 
 if [[ ! -d "$SDK_DIR" ]]; then
     die "SDK directory not found: $SDK_DIR"
@@ -71,16 +69,14 @@ NCORES=$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo "4")
 BUILT=0
 FAILED=0
 
-# One tab-separated row per manifest entry the filter keeps. Collected up front,
-# rather than piped into the loop, so a manifest error stops the script here.
-ENTRIES="$("$SOURCE_DIR/villagesql/bld_matrix/json_extensions.sh" \
-    | jq -r --arg f "$EXTENSION_FILTER" '
-        .[]
-        | select($f == "" or .extension == $f)
-        | [.extension, .url, .branch, .build, (.bundle | tostring), .path]
-        | @tsv')"
+# One tab-separated row per manifest entry the channel and filter keep.
+# Collected up front, rather than piped into the loop, so a manifest error
+# stops the script here.
+ENTRIES="$("$SOURCE_DIR/villagesql/bld_matrix/json_bundle_extensions.sh" \
+    "$BUNDLE_CHANNEL" "$EXTENSION_FILTER" \
+    | jq -r '.[] | [.extension, .url, .branch, .build, .path] | @tsv')"
 
-while IFS=$'\t' read -r EXTENSION SOURCE BRANCH BUILD_TOOL BUNDLE EXT_PATH; do
+while IFS=$'\t' read -r EXTENSION SOURCE BRANCH BUILD_TOOL EXT_PATH; do
     [[ -z "$EXTENSION" ]] && continue
 
     # This script builds with cmake. Skip entries that use another build tool
@@ -90,11 +86,6 @@ while IFS=$'\t' read -r EXTENSION SOURCE BRANCH BUILD_TOOL BUNDLE EXT_PATH; do
     # skip non-cmake extensions.
     if [[ "$BUILD_TOOL" != "cmake" ]]; then
         log_info "Skipping $EXTENSION (build=$BUILD_TOOL not supported here)"
-        continue
-    fi
-
-    if [[ "$INCLUDE_UNBUNDLED" == "no" && "$BUNDLE" == "false" ]]; then
-        log_info "Skipping $EXTENSION (bundle=false)"
         continue
     fi
 

--- a/villagesql/bld_tools/checkout_bundled_extensions.sh
+++ b/villagesql/bld_tools/checkout_bundled_extensions.sh
@@ -2,53 +2,49 @@
 # Copyright (c) 2026 VillageSQL Contributors
 # Checkout the sources for bundled VillageSQL extensions.
 #
-# Usage: checkout_bundled_extensions.sh <ext_dir> [extension] [include_unbundled]
+# Usage: checkout_bundled_extensions.sh <ext_dir> [extension] [channel]
 #
 # <ext_dir>:        Path for checked out extensions.  Should exist before calling.
 # [extension]:      Optional extension name to clone only one extension (e.g.
 #                   vsql-ai). Omit to clone every extension in the manifest.
-# [include_unbundled]: 0/no (default) to skip bundle=false extensions, 1/yes to
-#                   clone them too. They ship with no dev server, but are still
-#                   built and tested (e.g. by the sanitizer workflow).
+# [channel]:        Build channel to clone for: release (default), dev, or all.
+#                   "dev" adds the bundle=dev extensions, which ship only in
+#                   pre-release artifacts; "all" adds bundle=false too, which
+#                   ship nowhere but are still built and tested (e.g. by the
+#                   sanitizer workflow). 0/no and 1/yes are accepted as the
+#                   old include_unbundled spellings of release and all.
 #
-# The manifest is parsed by villagesql/bld_matrix/json_extensions.sh, which
-# reads villagesql/dev_server/bundled_extensions.txt from this script's own
-# source tree.
+# Which entries a channel selects is decided by
+# villagesql/bld_matrix/json_bundle_extensions.sh, which reads the manifest at
+# villagesql/dev_server/bundled_extensions.txt from this script's own source
+# tree.
 
 set -euo pipefail
 
-EXTENSION_CLONES_DIR="${1:?Usage: $0 <ext_dir> [<ext_filter>] [include_unbundled]}"
+EXTENSION_CLONES_DIR="${1:?Usage: $0 <ext_dir> [<ext_filter>] [channel]}"
 EXTENSION_FILTER="${2:-}"
-INCLUDE_UNBUNDLED="${3:-no}"
+BUNDLE_CHANNEL="${3:-release}"
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
 
 source "$SOURCE_DIR/villagesql/scripts/vsql_script_utils.sh"
 
-case "$INCLUDE_UNBUNDLED" in
-    1|yes) INCLUDE_UNBUNDLED=yes ;;
-    0|no|"") INCLUDE_UNBUNDLED=no ;;
-    *) die "Invalid include_unbundled: $INCLUDE_UNBUNDLED (expected 0/no or 1/yes)" ;;
-esac
-
 if [[ ! -d "$EXTENSION_CLONES_DIR" ]]; then
     die "Extension directory not found: $EXTENSION_CLONES_DIR (mkdir first)"
 fi
 
-# One tab-separated row per manifest entry the filter keeps. Collected up front,
-# rather than piped into the loop, so a manifest error stops the script here.
-ENTRIES="$("$SOURCE_DIR/villagesql/bld_matrix/json_extensions.sh" \
-    | jq -r --arg f "$EXTENSION_FILTER" '
-        .[]
-        | select($f == "" or .extension == $f)
-        | [.extension, .url, .branch, .build, (.bundle | tostring)]
-        | @tsv')"
+# One tab-separated row per manifest entry the channel and filter keep.
+# Collected up front, rather than piped into the loop, so a manifest error
+# stops the script here.
+ENTRIES="$("$SOURCE_DIR/villagesql/bld_matrix/json_bundle_extensions.sh" \
+    "$BUNDLE_CHANNEL" "$EXTENSION_FILTER" \
+    | jq -r '.[] | [.extension, .url, .branch, .build] | @tsv')"
 
 CLONED=0
 FAILED=0
 
-while IFS=$'\t' read -r EXTENSION SOURCE BRANCH BUILD_TOOL BUNDLE; do
+while IFS=$'\t' read -r EXTENSION SOURCE BRANCH BUILD_TOOL; do
     [[ -z "$EXTENSION" ]] && continue
 
     # This script builds with cmake. Skip entries that use another build tool
@@ -59,11 +55,6 @@ while IFS=$'\t' read -r EXTENSION SOURCE BRANCH BUILD_TOOL BUNDLE; do
     # skip non-cmake extensions.
     if [[ "$BUILD_TOOL" != "cmake" ]]; then
         log_info "Skipping $EXTENSION (build=$BUILD_TOOL not supported here)"
-        continue
-    fi
-
-    if [[ "$INCLUDE_UNBUNDLED" == "no" && "$BUNDLE" == "false" ]]; then
-        log_info "Skipping $EXTENSION (bundle=false)"
         continue
     fi
 

--- a/villagesql/bld_tools/include_bundled_extensions.sh
+++ b/villagesql/bld_tools/include_bundled_extensions.sh
@@ -2,17 +2,28 @@
 # Copyright (c) 2026 VillageSQL Contributors
 # Copy the bundled VillageSQL extension VEB files into a package tree.
 #
-# Usage: include_bundled_extensions.sh <dst_dir> <veb_src_dir>
+# Usage: include_bundled_extensions.sh <dst_dir> <veb_src_dir> [channel]
 #
+# <dst_dir>:     Directory in the package tree to copy the .veb files into.
 # <veb_src_dir>: Directory where built .veb files were placed.
+# [channel]:     Build channel to package for: release (default) or dev.
+#                "dev" also copies the bundle=dev extensions, which ship only
+#                in pre-release artifacts.
 #
-# The manifest is parsed by villagesql/bld_matrix/json_extensions.sh, which
-# reads villagesql/dev_server/bundled_extensions.txt from this script's own
-# source tree.
+# The channel must match the one build_bundled_extensions.sh was given: this
+# script copies, it does not build, and a .veb the build stage was never asked
+# for is a hard error rather than a silently thinner package.
+#
+# Which entries a channel selects is decided by
+# villagesql/bld_matrix/json_bundle_extensions.sh, which reads the manifest at
+# villagesql/dev_server/bundled_extensions.txt from this script's own source
+# tree.
 
 set -euo pipefail
-DST_DIR="${1:?Usage: $0 <dst_dir> <veb_src_dir>}"
-VEB_SRC_DIR="${2:?Usage: $0 <dst_dir> <veb_src_dir>}"
+USAGE="Usage: $0 <dst_dir> <veb_src_dir> [channel]"
+DST_DIR="${1:?$USAGE}"
+VEB_SRC_DIR="${2:?$USAGE}"
+BUNDLE_CHANNEL="${3:-release}"
 
 TOOLS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SOURCE_DIR="$(cd "$TOOLS_DIR/../.." && pwd)"
@@ -23,18 +34,13 @@ if [[ ! -d "$VEB_SRC_DIR" ]]; then
     die "Missing extension source directory: $VEB_SRC_DIR"
 fi
 
-# One tab-separated row per manifest entry. Collected up front, rather than
-# piped into the loop, so a manifest error stops the script here.
-ENTRIES="$("$SOURCE_DIR/villagesql/bld_matrix/json_extensions.sh" \
-    | jq -r '.[] | [.extension, (.bundle | tostring)] | @tsv')"
+# One extension per line, those the channel ships. Collected up front, rather
+# than piped into the loop, so a manifest error stops the script here.
+ENTRIES="$("$SOURCE_DIR/villagesql/bld_matrix/json_bundle_extensions.sh" \
+    "$BUNDLE_CHANNEL" | jq -r '.[].extension')"
 
-while IFS=$'\t' read -r EXTENSION BUNDLE; do
+while IFS= read -r EXTENSION; do
     [[ -z "$EXTENSION" ]] && continue
-
-    if [[ "$BUNDLE" == "false" ]]; then
-        log_info "Skipping $EXTENSION (bundle=false)"
-        continue
-    fi
 
     # Convert all dashes to underscores
     EXT_FILE="${EXTENSION//-/_}.veb"

--- a/villagesql/bld_tools/package_dev_server.sh
+++ b/villagesql/bld_tools/package_dev_server.sh
@@ -14,6 +14,13 @@
 #   OUTPUT_DIR  Where the final tarball is written (default: $PWD)
 #   BUILD_BUNDLED_EXTENSIONS
 #               "1" to fold bundled extension VEBs into the package
+#   BUNDLE_CHANNEL
+#               Which extensions to fold in: "release" or "dev". Defaults to
+#               dev for a pre-release build (VSQL_PRE_RELEASE_VERSION set) and
+#               release otherwise, so a -dev tarball carries the bundle=dev
+#               extensions and a release tarball never does. Must match the
+#               channel build_bundled_extensions.sh was given, which is why CI
+#               resolves it once at job scope and passes it to both.
 
 set -e
 
@@ -40,6 +47,10 @@ source "$SOURCE_DIR/villagesql/bld_tools/build_info.sh"
 vsql_parse_version "$SOURCE_DIR"
 vsql_platform_info
 
+# A pre-release tarball ships the bundle=dev extensions; a release one does not.
+BUNDLE_CHANNEL="${BUNDLE_CHANNEL:-$([[ -n "${VSQL_PRE_RELEASE_VERSION:-}" ]] \
+    && echo dev || echo release)}"
+
 PACKAGE_NAME="villagesql-dev-server-${VSQL_CODE_BASE}_${VSQL_VERSION}-${PLATFORM}-${ARCH}"
 TARBALL_NAME="${PACKAGE_NAME}.tar.gz"
 
@@ -51,7 +62,7 @@ log_info "Package includes:"
 log_info "  - Server and client binaries"
 log_info "  - Example VEB files (vsql_simple, vsql_complex)"
 if [[ "${BUILD_BUNDLED_EXTENSIONS:-0}" == "1" ]]; then
-    log_info "  - Bundled extensions (from villagesql/dev_server/bundled_extensions.txt)"
+    log_info "  - Bundled extensions ($BUNDLE_CHANNEL channel, from villagesql/dev_server/bundled_extensions.txt)"
 fi
 log_info "  - mysql-test framework (binaries only, no test/result files)"
 log_info "  - Support files and SQL scripts"
@@ -137,7 +148,8 @@ if [[ "${BUILD_BUNDLED_EXTENSIONS:-0}" == "1" ]]; then
 
     "$SOURCE_DIR/villagesql/bld_tools/include_bundled_extensions.sh" \
             "lib/veb" \
-            "$BUILD_DIR/veb_output_directory"
+            "$BUILD_DIR/veb_output_directory" \
+            "$BUNDLE_CHANNEL"
 
     log_info "Bundled extensions added to release"
 

--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -9,8 +9,15 @@
 #   branch-or-tag: Branch to clone.
 #   abi=<abi>:     Optional. ABI to test against: "stable" or "dev".
 #                  Omit to test against both.
-#   bundle=false:  Optional. Omit (or bundle=true) to include in dev server.
-#                  Set bundle=false to run compat tests only — not shipped.
+#   bundle=<when>: Optional. Which artifacts ship the extension.
+#                  true (the default) — every artifact, release included.
+#                  dev  — pre-release artifacts only: the -dev tarball and the
+#                         dev Docker image. Held back from release builds, so
+#                         an extension can be shipped to early users before it
+#                         is ready to carry a release compatibility promise.
+#                  false — no artifact ships it; it is still cloned, built and
+#                         compat-tested. Use for work in progress.
+#                  Any other value is an error rather than a silent default.
 #   build=<tool>:  Optional. Build system: "cmake" or "cargo". Default "cmake".
 #   path=<subdir>: Optional. Extension lives in this subdir of the repo.
 #                  Default: repo root. Also used to derive the extension name


### PR DESCRIPTION
## Description

Extensions in `bundled_extensions.txt` were binary: shipped everywhere, or shipped nowhere. This adds a third state, **`bundle=dev`**, for extensions that go to pre-release artifacts (the `-dev` tarball, the dev Docker image) but are held back from release builds — so an extension can reach early users before it carries a release compatibility promise.

| In the manifest | Ships in |
| --- | --- |
| *(omitted)* or `bundle=true` | release + dev |
| `bundle=dev` | dev only |
| `bundle=false` | nothing (still cloned, built, compat-tested) |

Selection now runs through a **build channel** (`release` / `dev` / `all`) resolved in one place, `bld_matrix/json_bundle_extensions.sh`, so the tarball and the image cannot drift apart on what a manifest entry means. The clone, build and package stages must be given the same channel — packaging copies rather than builds, so a wider channel fails loudly on a missing `.veb` rather than silently shipping a thinner package. CI resolves `BUNDLE_CHANNEL` once at job scope and passes it to all three.

Two fixes fell out of this:

- **The Docker path had its own copy of the manifest parser** that treated any `bundle=` value other than `false` as bundled — so `bundle=dev` would have shipped in *release* images. It now uses the same selector. That also means an entry's `url` and `branch` are honoured there; it previously cloned `github.com/villagesql/<name>` at the default branch regardless of what the manifest said.
- **`bundle=` typos no longer default silently.** `bundle=maybe` is now a parse error. (`bundle=Dev` is still accepted — case is normalised, as it always was for `bundle=FALSE`.)

Second half: **pre-release images now publish to Google Artifact Registry** (`villagesql-server-dev`), keeping unreleased builds off Docker Hub. `--registry dockerhub|gar` on `publish_image.sh` / `publish_manifest.sh`, and a `registry` input on both docker workflows. Auth is **direct Workload Identity Federation**, matching the `vcloud-control-plane` precedent: no service account is impersonated and no key is stored, because the repository's IAM policy grants `artifactregistry.writer` to this repo's numeric ID within the `github` pool. Pool, provider and policy are already declared in `vcloud-cell/dev-cluster` (`wif.tf`, `artifact-registry.tf`), so no new infrastructure is needed.

**Nothing shipped changes yet.** No extension is marked `bundle=dev`, so `release` and `dev` currently select the same 11 extensions. This PR adds the mechanism; classifying extensions is a follow-up decision.

## Related Issue

<!-- none filed -->

## How was this tested?

Manifest and channel logic, against a fixture manifest covering every state (not the live manifest, so assertions don't drift):

```bash
# release ships only bundle=true; dev adds bundle=dev; all adds bundle=false
villagesql/bld_matrix/json_bundle_extensions.sh release
villagesql/bld_matrix/json_bundle_extensions.sh dev
villagesql/bld_matrix/json_bundle_extensions.sh all
```

Verified explicitly:

- `bundle=` absent → `release`; `bundle=dev` → `dev`; `bundle=false` → `none`
- legacy `include_unbundled` spellings still resolve: `""`/`0`/`no` → release, `1`/`yes` → all, so **`sanitizer.yml` needs no change**
- `bundle=maybe` and a missing branch are hard parse errors (exit 5); an unknown channel exits 1
- a mistyped *key* (`bundled=dev`) is ignored and the extension stays in release
- packaging: release picks up only `bundle=true` VEBs, dev picks up both, `bundle=false` never packaged
- channel mismatch (packaging `dev` when the build produced only release VEBs) exits 1 rather than shipping thin
- GAR path composition, including that an empty `GAR_PROJECT` and an unknown registry are both fatal
- `publish_image.sh --registry gar --dry-run` produces
  `us-central1-docker.pkg.dev/villagesql-vcloud-pelican-dev/villagesql-server-dev/server:0.0.6-dev-amd64`
- fork URL + pinned tag (`https://github.com/example/vsql-fork v2.1`) survives into the build step — regression cover for the hardcoded-URL bug above
- `bash -n` on all 11 changed scripts; YAML parse on all 4 changed workflows; no trailing whitespace, no missing final newlines

**Not yet exercised:** a real Docker image build (~75 min) and a live GAR push. The WIF exchange is unverified end-to-end — worth a throwaway push of a small image to `villagesql-server-dev` before relying on this. `villint.sh` was not run locally (needs clang-format 22.1, not installed here); no C/C++ files are touched, so CI's run should be the first meaningful one.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4

> Test checkbox left unticked deliberately: the verification above was run as an ad-hoc script, not committed. There is no test harness under `villagesql/bld_matrix/` today; happy to add the suite as a follow-up commit if reviewers want it in-tree.
