### PR TITLE
add `is_null()` check to PrerunArgs

### DIFF
--- a/sql/item.h
+++ b/sql/item.h
@@ -4811,7 +4811,7 @@ class Item_null : public Item_basic_constant {
   bool get_time(MYSQL_TIME *) override { return true; }
   bool val_json(Json_wrapper *wr) override;
   bool send(Protocol *protocol, String *str) override;
-  Item_result result_type() const override { return INVALID_RESULT; }
+  Item_result result_type() const override { return STRING_RESULT; }
   Item *clone_item() const override { return new Item_null(item_name); }
   bool is_null() override { return true; }
 

--- a/sql/item.h
+++ b/sql/item.h
@@ -2782,7 +2782,6 @@ class Item : public Parse_tree_node {
   /// A processor to handle the select lex visitor framework.
   virtual bool visitor_processor(uchar *arg);
 
-
   /**
     Item::walk function. Set bit in table->cond_set for all fields of
     all tables that are referred to by the Item.
@@ -4812,7 +4811,7 @@ class Item_null : public Item_basic_constant {
   bool get_time(MYSQL_TIME *) override { return true; }
   bool val_json(Json_wrapper *wr) override;
   bool send(Protocol *protocol, String *str) override;
-  Item_result result_type() const override { return STRING_RESULT; }
+  Item_result result_type() const override { return INVALID_RESULT; }
   Item *clone_item() const override { return new Item_null(item_name); }
   bool is_null() override { return true; }
 

--- a/villagesql/sdk/include/villagesql/abi/types.h
+++ b/villagesql/sdk/include/villagesql/abi/types.h
@@ -278,7 +278,8 @@ typedef enum : int {
   VEF_TYPE_STRING = 0,
   VEF_TYPE_REAL = 1,
   VEF_TYPE_INT = 2,
-  VEF_TYPE_CUSTOM = 3
+  VEF_TYPE_CUSTOM = 3,
+  VEF_TYPE_NULL = 4
 
   // TODO(villagesql-ga): Do we want to support DECIMAL?
 } vef_type_id;

--- a/villagesql/sdk/include/villagesql/vsql/pre_post_run.h
+++ b/villagesql/sdk/include/villagesql/vsql/pre_post_run.h
@@ -68,6 +68,7 @@ class PrerunArgType {
   bool is_real() const { return t_->id == VEF_TYPE_REAL; }
   bool is_str() const { return t_->id == VEF_TYPE_STRING; }
   bool is_custom() const { return t_->id == VEF_TYPE_CUSTOM; }
+  bool is_null() const { return t_->id == VEF_TYPE_NULL; }
 
   // For CUSTOM types: the unqualified type name (no extension prefix).
   // Empty string_view for non-CUSTOM types.

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -229,6 +229,8 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
         if (tc != nullptr) {
           arg_types[i].id = VEF_TYPE_CUSTOM;
           arg_types[i].custom_type = tc->type_name().c_str();
+        } else if (m_args[i]->type() == Item::NULL_ITEM) {
+          arg_types[i].id = VEF_TYPE_NULL;
         } else {
           switch (m_args[i]->result_type()) {
             case REAL_RESULT:
@@ -236,9 +238,6 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
               break;
             case INT_RESULT:
               arg_types[i].id = VEF_TYPE_INT;
-              break;
-            case INVALID_RESULT:
-              arg_types[i].id = VEF_TYPE_NULL;
               break;
             default:
               arg_types[i].id = VEF_TYPE_STRING;
@@ -367,6 +366,8 @@ static void marshal_args_typed(const vef_signature_t *sig, uint value_count,
       auto *tc = arg_item->get_type_context();
       if (tc != nullptr) {
         param_type = VEF_TYPE_CUSTOM;
+      } else if (arg_item->type() == Item::NULL_ITEM) {
+        param_type = VEF_TYPE_NULL;
       } else {
         switch (arg_item->result_type()) {
           case REAL_RESULT:
@@ -408,6 +409,11 @@ static void marshal_args_typed(const vef_signature_t *sig, uint value_count,
           invalues[i].str_len = arg_str->length();
         }
         break;
+      }
+      case VEF_TYPE_NULL: {
+        invalues[i].is_null = true;
+        invalues[i].str_value = nullptr;
+        invalues[i].str_len = 0;
       }
       case VEF_TYPE_CUSTOM:
       default: {

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -237,6 +237,9 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
             case INT_RESULT:
               arg_types[i].id = VEF_TYPE_INT;
               break;
+            case INVALID_RESULT:
+              arg_types[i].id = VEF_TYPE_NULL;
+              break;
             default:
               arg_types[i].id = VEF_TYPE_STRING;
               break;


### PR DESCRIPTION
## Description

Adds `is_null()` check for `PrerunArgs`

## Related Issue

Fixes https://github.com/villagesql/villagesql-server/issues/573

## How was this tested?

This was tested by creating an extension that adds two numbers and default to zero if `NULL` is provided as an argument.

### before

```c++

void add_pre_run(PrerunArgs args, PrerunResult res) {
  for (size_t i = 0; i < args.size(); i++) {
    if (!args.type_at(i).is_int() && !args.type_at(i).is_str()) {
      res.error("add: all arguments must be int or string ");
      return;
    }
  }
}

void add(VarArgs args, IntResult out) {
  int a, b;

  if (args[0].is_str()) {
    if (args[0].is_null()) {
      a = 0;
    } else {
      out.set(-1);
      return;
    }
  } else {
    a = args[0].as_int();
  }

  if (args[1].is_str()) {
    if (args[1].is_null()) {
      b = 0;
    } else {
      out.set(-1);
      return;
    }
  } else {
    b = args[1].as_int();
  }

  long long total = a + b;
  out.set(total);
}
```

### after

```c++
void add_pre_run(PrerunArgs args, PrerunResult res) {
  for (size_t i = 0; i < args.size(); i++) {
    if (!args.type_at(i).is_int() && !args.type_at(i).is_null()) {
      res.error("add: all arguments must be int or null");
      return;
    }
  }
}

void add(VarArgs args, IntResult out) {
  int a, b;

  if (args[0].is_null()) {
    a = 0;
  } else {
    a = args[0].as_int();
  }

  if (args[1].is_null()) {
    b = 0;
  } else {
    b = args[1].as_int();
  }

  long long total = a + b;
  out.set(total);
}
```

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
