### PR TITLE
Update version checks to 0.0.7

### DIFF
--- a/mysql-test/suite/villagesql/startup/r/init_file_schema_version.result
+++ b/mysql-test/suite/villagesql/startup/r/init_file_schema_version.result
@@ -8,7 +8,7 @@
 # Check the value that was captured during --initialize
 SELECT captured_version AS version_during_initialize FROM test.init_version_check;
 version_during_initialize
-mysql-8.4_0.0.6
+mysql-8.4_0.0.7
 #
 # Test: villagesql_schema_version accessibility with --init-file (without --initialize)
 # Verify that @@GLOBAL.villagesql_schema_version can be queried from init-file during normal startup
@@ -17,7 +17,7 @@ mysql-8.4_0.0.6
 # Check the value that was captured during normal startup with --init-file
 SELECT captured_version AS version_during_startup FROM test.startup_version_check;
 version_during_startup
-mysql-8.4_0.0.6
+mysql-8.4_0.0.7
 #
 # Cleanup
 #

--- a/mysql-test/suite/villagesql/startup/r/upgrade_basic.result
+++ b/mysql-test/suite/villagesql/startup/r/upgrade_basic.result
@@ -14,7 +14,7 @@ properties_table_exists
 1
 SELECT name, value FROM villagesql.properties WHERE name = 'version';
 name	value
-version	mysql-8.4_0.0.6-dev
+version	mysql-8.4_0.0.7-dev
 # Test 2: Version update simulation
 SELECT 'Version Update Test' AS test_case;
 test_case
@@ -30,7 +30,7 @@ version	0
 UPDATE villagesql.properties SET value = @original_version WHERE name = 'version';
 SELECT name, value FROM villagesql.properties WHERE name = 'version';
 name	value
-version	mysql-8.4_0.0.6-dev
+version	mysql-8.4_0.0.7-dev
 # Test 3: Properties completeness
 SELECT 'Properties Completeness' AS test_case;
 test_case


### PR DESCRIPTION
## Description

Adjust the recorded schema version to 0.0.7, since that is what engineering is working on.

## Related Issue

Release 0.0.6