### PR TITLE
Big Endian: Fix raw byte conversion

### DIFF
--- a/villagesql/include/byteorder.h
+++ b/villagesql/include/byteorder.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef VILLAGESQL_INCLUDE_BYTEORDER_H
+#define VILLAGESQL_INCLUDE_BYTEORDER_H
+
+// VillageSQL: Helper functions for processing raw bytes along the lines of
+// @file include/my_byteorder.h.
+
+#include <string.h>
+
+#include "my_inttypes.h"
+
+// Return unsigned bytes pointed to by ptr in an ulonglong. Endianness
+// agnostic as the byte layout of memory pointed to by ptr should be the
+// same as the byte layout of ulonglong.
+inline ulonglong ulonglongget(const uchar *ptr) {
+  ulonglong val;
+  memcpy(&val, ptr, sizeof(val));
+  return val;
+}
+
+// Return implicitly unsigned bytes pointed to by ptr in an ulonglong.
+inline ulonglong ulonglongget(const char *ptr) {
+  return ulonglongget(
+      static_cast<const uchar *>(static_cast<const void *>(ptr)));
+}
+
+#endif  // VILLAGESQL_INCLUDE_BYTEORDER_H

--- a/villagesql/include/byteorder.h
+++ b/villagesql/include/byteorder.h
@@ -25,17 +25,10 @@
 #include "my_inttypes.h"
 
 // Return a native-endian ulonglong from bytes pointed to by ptr.
-inline ulonglong ulonglongget(const uchar *ptr) {
+inline ulonglong ulonglongget(const char *ptr) {
   ulonglong val;
   memcpy(&val, ptr, sizeof(val));
   return val;
-}
-
-// Return a native-endian ulonglong from bytes pointed to by ptr. The bytes are
-// treated as unsigned.
-inline ulonglong ulonglongget(const char *ptr) {
-  return ulonglongget(
-      static_cast<const uchar *>(static_cast<const void *>(ptr)));
 }
 
 #endif  // VILLAGESQL_INCLUDE_BYTEORDER_H

--- a/villagesql/include/byteorder.h
+++ b/villagesql/include/byteorder.h
@@ -24,16 +24,15 @@
 
 #include "my_inttypes.h"
 
-// Return unsigned bytes pointed to by ptr in an ulonglong. Endianness
-// agnostic as the byte layout of memory pointed to by ptr should be the
-// same as the byte layout of ulonglong.
+// Return a native-endian ulonglong from bytes pointed to by ptr.
 inline ulonglong ulonglongget(const uchar *ptr) {
   ulonglong val;
   memcpy(&val, ptr, sizeof(val));
   return val;
 }
 
-// Return implicitly unsigned bytes pointed to by ptr in an ulonglong.
+// Return a native-endian ulonglong from bytes pointed to by ptr. The bytes are
+// treated as unsigned.
 inline ulonglong ulonglongget(const char *ptr) {
   return ulonglongget(
       static_cast<const uchar *>(static_cast<const void *>(ptr)));

--- a/villagesql/schema/schema_manager.cc
+++ b/villagesql/schema/schema_manager.cc
@@ -47,6 +47,7 @@
 #include "sql/table.h"
 #include "sql/thd_raii.h"
 #include "sql/transaction.h"
+#include "villagesql/include/byteorder.h"
 #include "villagesql/include/error.h"
 #include "villagesql/include/version.h"
 #include "villagesql/schema/systable/helpers.h"
@@ -806,13 +807,17 @@ bool SchemaManagerStatus::read_villagesql_version(THD *thd, Semver *version) {
     return false;  // Success, but exists=false will trigger full initialization
   }
 
-  // The value is not text, it is an integer, so we need to read the raw binary..
+  // The value is not text, it is an integer, so we need to read the raw
+  // binary..
   if (schema_id_str.length() != sizeof(uint64_t)) {
     LogVSQL(ERROR_LEVEL, "Read unexpected sized value");
     return true;
   }
 
-  const uint64_t schema_id = uint8korr(schema_id_str.data());
+  const uint64_t schema_id = ulonglongget(schema_id_str.data());
+
+  LogVSQL(INFORMATION_LEVEL,
+          "VillageSQL schema_id in mysql.schemata: %" PRIu64 "", schema_id);
 
   // Schema exists, check if properties table exists, which should be the last
   // table created in the schema file

--- a/villagesql/schema/schema_manager.cc
+++ b/villagesql/schema/schema_manager.cc
@@ -807,8 +807,7 @@ bool SchemaManagerStatus::read_villagesql_version(THD *thd, Semver *version) {
     return false;  // Success, but exists=false will trigger full initialization
   }
 
-  // The value is not text, it is an integer, so we need to read the raw
-  // binary..
+  // The value is not text, it is an integer, so we need to read the raw binary.
   if (schema_id_str.length() != sizeof(uint64_t)) {
     LogVSQL(ERROR_LEVEL, "Read unexpected sized value");
     return true;


### PR DESCRIPTION
Big Endian: Fix raw byte conversion

Server wouldn't start on big-endian arch with below error logs:
'First time run (or incomplete system tables) detected, applying schema'
'No valid version found after install'
'Failed to install VillageSQL schema on first run'

After villagesql schema is installed, its schema_id is read from
mysql.schemata as raw bytes and converted to uint64_t. The big-endian
variant of uint8korr is not the right function to do that as it assumes
little-endian input.

A key observation is that Ed_connection’s results for schema_id are in
host-endian order and no byte swapping is needed for its conversion to
uint64_t.

Tested: The right value of schema_id outputs to logs and server starts
on linux/s390x.
