### PR TITLE
Update tests for Release 0.0.7

### DIFF
--- a/mysql-test/suite/sys_vars/r/villagesql_schema_version_basic.result
+++ b/mysql-test/suite/sys_vars/r/villagesql_schema_version_basic.result
@@ -3,10 +3,10 @@
 # Test 1: Check that the variable exists and is readable
 SHOW VARIABLES LIKE 'villagesql_schema_version';
 Variable_name	Value
-villagesql_schema_version	mysql-8.4_0.0.6
+villagesql_schema_version	mysql-8.4_0.0.7
 SELECT @@GLOBAL.villagesql_schema_version AS current_version;
 current_version
-mysql-8.4_0.0.6
+mysql-8.4_0.0.7
 # Test 2: Verify the variable is READ_ONLY
 SET GLOBAL villagesql_schema_version = 999;
 ERROR HY000: Variable 'villagesql_schema_version' is a read only variable

--- a/mysql-test/suite/sys_vars/r/villagesql_server_version_basic.result
+++ b/mysql-test/suite/sys_vars/r/villagesql_server_version_basic.result
@@ -3,10 +3,10 @@
 # Test 1: Check that the variable exists and is readable
 SHOW VARIABLES LIKE 'villagesql_server_version';
 Variable_name	Value
-villagesql_server_version	mysql-8.4_0.0.6
+villagesql_server_version	mysql-8.4_0.0.7
 SELECT @@GLOBAL.villagesql_server_version AS server_version;
 server_version
-mysql-8.4_0.0.6
+mysql-8.4_0.0.7
 # Test 2: Verify the variable is READ_ONLY
 SET GLOBAL villagesql_server_version = '999';
 ERROR HY000: Variable 'villagesql_server_version' is a read only variable

--- a/mysql-test/suite/villagesql/startup/r/upgrade_scenarios.result
+++ b/mysql-test/suite/villagesql/startup/r/upgrade_scenarios.result
@@ -23,7 +23,7 @@ properties_table_exists
 1
 SELECT name, value FROM villagesql.properties WHERE name = 'version';
 name	value
-version	mysql-8.4_0.0.6-dev
+version	mysql-8.4_0.0.7-dev
 # Check that 'created' timestamp is set after fresh installation
 SELECT COUNT(*) AS created_timestamp_exists
 FROM villagesql.properties
@@ -39,7 +39,7 @@ SET SESSION debug='+d,skip_dd_table_access_check';
 # Verify that 'created' timestamp was not updated during normal restart
 SELECT name, value FROM villagesql.properties WHERE name = 'version';
 name	value
-version	mysql-8.4_0.0.6-dev
+version	mysql-8.4_0.0.7-dev
 # Test 3: Current version (should be no-op)
 # Force upgrade on already current installation
 # Add a small delay to ensure timestamp will be different
@@ -52,7 +52,7 @@ No-op Upgrade
 # Verify that 'created' timestamp was not updated during force update no-op
 SELECT name, value FROM villagesql.properties WHERE name = 'version';
 name	value
-version	mysql-8.4_0.0.6-dev
+version	mysql-8.4_0.0.7-dev
 # Test 4: Simulate a partial install
 # Manually delete the version
 DELETE FROM villagesql.properties WHERE name = 'version';
@@ -70,7 +70,7 @@ test_case
 After Simulated Upgrade
 SELECT name, value FROM villagesql.properties WHERE name = 'version';
 name	value
-version	mysql-8.4_0.0.6-dev
+version	mysql-8.4_0.0.7-dev
 # Verify that 'created' timestamp was updated after forced reinstall
 # Test 5: Partial installation recovery
 # Drop properties table and verify it gets recreated
@@ -103,7 +103,7 @@ properties_table_exists
 0
 SELECT name, value FROM villagesql.properties WHERE name = 'version';
 name	value
-version	mysql-8.4_0.0.6-dev
+version	mysql-8.4_0.0.7-dev
 # Verify that 'created' timestamp was updated after forced reinstall
 # Test 6: Check upgrade log for issues
 # Verify no warnings or errors occurred during upgrades

--- a/mysql-test/suite/villagesql/startup/r/upgrade_skip_grant_tables.result
+++ b/mysql-test/suite/villagesql/startup/r/upgrade_skip_grant_tables.result
@@ -16,7 +16,7 @@ properties_table_exists
 1
 SELECT name, value FROM villagesql.properties WHERE name = 'version';
 name	value
-version	mysql-8.4_0.0.6-dev
+version	mysql-8.4_0.0.7-dev
 # Shutdown and cleanup
 # Restart with original datadir
 # Test passed - VillageSQL installed correctly with --skip-grant-tables!


### PR DESCRIPTION
## Description

Fix tests that depend on the values in `VSQL_VERSION`.

## Related Issue

Part of the Release 0.0.6 effort.
