### PR TITLE
No codebase in SDK version

### DIFF
--- a/villagesql/CMakeLists.txt
+++ b/villagesql/CMakeLists.txt
@@ -26,7 +26,7 @@
 # CMAKE_PREFIX_PATH points to the extracted SDK directory.
 # The SDK name should not include the code base.
 
-set(SDK_VERSION "${VSQL_VERSION_STRING}")
+set(SDK_VERSION "${VSQL_ABBR_VERSION}")
 set(SDK_NAME "villagesql-extension-sdk-${VSQL_ABBR_VERSION}")
 set(SDK_STAGING_DIR "${CMAKE_BINARY_DIR}/${SDK_NAME}")
 


### PR DESCRIPTION
## Description

Removes the codebase from the SDK's notion of version.

## Related Issue

Part of the Release 0.0.6 effort.
Part of the effort to Cleanup release-dev-server #595

## How was this tested?

```bash
$ ./villagesql/bld_tools/build_ci.sh
$ ./villagesql/bld_tools/test_ci.sh
$ ./mysql-test/mysql-test-run --suite=villagesql/extension
```
