### PR TITLE
Adapt manifest push to multiple codebases

### DIFF
--- a/.github/workflows/release-docker-branch.yml
+++ b/.github/workflows/release-docker-branch.yml
@@ -18,10 +18,9 @@ on:
         required: true
         type: string
       tag:
-        description: 'Image tag to publish, e.g. 0.0.5. Defaults to "ref". Use a distinguishable value (e.g. 0.0.5-test) for test pushes.'
-        required: false
+        description: 'Image tag to publish, e.g. mysql-8.4_0.0.6. Use a distinguishable value (e.g. mysql-8.4_0.0.6-test) for test pushes.'
+        required: true
         type: string
-        default: ''
       repo:
         description: 'Image repository to push to.'
         required: false
@@ -37,23 +36,22 @@ on:
         required: false
         type: string
         default: 'ON'
-      shared_tags:
-        description: 'Comma-separated tags the manifest is published under in addition to "tag". Empty publishes only "tag", which is what a test push wants.'
+      version_labels:
+        description: 'Comma-separated labels to add to tag as a version suffix. Empty publishes only "tag".'
         required: false
         type: string
-        default: 'latest,stable'
+        default: ''
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Git tag, branch, or SHA to build from (e.g. 0.0.5 or main).'
+        description: 'Git tag, branch, or SHA to build from (e.g. publish/mysql-8.4_0.0.6 or main).'
         required: true
         type: string
         default: 'main'
       tag:
-        description: 'Image tag to publish. Leave blank to use "ref". Use a distinguishable value (e.g. 0.0.5-test) for test pushes — the shared tags (latest, stable) move to whatever is published here.'
-        required: false
+        description: 'Image tag to publish, e.g. mysql-8.4_0.0.6. Use a distinguishable value (e.g. mysql-8.4_0.0.6-test) for test pushes.'
+        required: true
         type: string
-        default: ''
       repo:
         description: 'Image repository to push to.'
         required: false
@@ -72,11 +70,11 @@ on:
           - 'ON'
           - 'OFF'
         default: 'ON'
-      shared_tags:
-        description: 'Comma-separated tags the manifest is published under in addition to "tag". Clear this for a test push, so latest and stable do not move.'
+      version_labels:
+        description: 'Comma-separated labels to add to tag as version suffix. Clear this to publish only "tag".'
         required: false
         type: string
-        default: 'latest,stable'
+        default: ''
 
 permissions:
   contents: read
@@ -105,11 +103,11 @@ jobs:
           echo "Git Rev: ${{ inputs.ref }}"
           echo "Git SHA1: $(git rev-parse HEAD)"
           echo "Git Commit: $(git log -n1 --oneline)"
-          echo "Image Tag: ${{ inputs.tag || inputs.ref }}"
+          echo "Image Tag: ${{ inputs.tag }}"
           echo "Repository: ${{ inputs.repo }}"
           echo "Pre-release Version: '${{ inputs.pre_release_version }}'"
           echo "Dev ABI: ${{ inputs.dev_abi }}"
-          echo "Shared Tags: '${{ inputs.shared_tags }}'"
+          echo "Version Labels: '${{ inputs.version_labels }}'"
 
       # Matrix logic lives in villagesql/bld_matrix, so it can be run locally
       # exactly as it runs here:
@@ -147,7 +145,7 @@ jobs:
     secrets: inherit
     with:
       ref: ${{ inputs.ref }}
-      tag: ${{ inputs.tag || inputs.ref }}
+      tag: ${{ inputs.tag }}
       platform: ${{ matrix.docker_platform }}
       runner: ${{ toJSON(matrix.runner) }}
       repo: ${{ inputs.repo }}
@@ -177,12 +175,10 @@ jobs:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # The shared tags move to this manifest. A test push clears them, so
-      # that a 'docker pull villagesql/server' cannot see the result.
       - name: Publish manifest
         run: |
           docker/server/publish_manifest.sh \
-            --tag "${{ inputs.tag || inputs.ref }}" \
+            --tag "${{ inputs.tag }}" \
             --repo "${{ inputs.repo }}" \
             --platforms "${{ needs.report-parameters.outputs.platforms }}" \
-            --shared-tags "${{ inputs.shared_tags }}"
+            --version-labels "${{ inputs.version_labels }}"

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -2,7 +2,8 @@
 
 ## Building
 
-From the repository root:
+Build a Docker image for the VillageSQL server locally, tagging it as
+dev-server:
 
 ```bash
 docker build -f docker/server/Dockerfile -t villagesql/server:dev-server .

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -5,7 +5,7 @@
 From the repository root:
 
 ```bash
-docker build -f docker/server/Dockerfile -t villagesql/server:latest .
+docker build -f docker/server/Dockerfile -t villagesql/server:dev-server .
 ```
 
 The build compiles VillageSQL from source and bundles several extensions:
@@ -23,13 +23,13 @@ The first build takes ~25 minutes (server compilation). Subsequent builds are fa
   support the stable ABI.
 
 ```bash
-docker build -f docker/server/Dockerfile --build-arg VSQL_DEV_ABI=OFF -t villagesql/server:latest .
+docker build -f docker/server/Dockerfile --build-arg VSQL_DEV_ABI=OFF -t villagesql/server:dev-server .
 ```
 
 ## Running
 
 ```bash
-docker run -d --name vsql -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -p 3306:3306 villagesql/server:latest
+docker run -d --name vsql -e MYSQL_ALLOW_EMPTY_PASSWORD=1 -p 3306:3306 villagesql/server:dev-server
 ```
 
 ### Environment Variables
@@ -77,7 +77,7 @@ INSTALL EXTENSION vsql_crypto;
 Smoke test an image to verify the server starts and all extensions install correctly:
 
 ```bash
-docker/server/test-image.sh villagesql/server:latest
+docker/server/test-image.sh villagesql/server:dev-server
 ```
 
 This starts a container, installs each extension, runs a basic CRUD test with the
@@ -91,11 +91,16 @@ The option `--dry-run` prints the docker commands without running them.
 | Script | Does |
 | --- | --- |
 | `publish_image.sh` | Builds one platform into one arch-specific tag. Local only unless given `--push`. |
-| `publish_manifest.sh` | Stitches the arch images already in the registry into the shared multi-arch tags. |
+| `publish_manifest.sh` | Stitches the arch images already in the registry into the multi-arch tags. |
 
-Images are tagged `REPO:TAG-ARCH` per platform (e.g. `villagesql/server:0.0.5-arm64`),
-and the manifest list is published under `TAG` plus each shared tag (`latest` and
-`stable` by default).
+A release is identified by `CODEBASE_VERSION` (e.g. `mysql-8.4_0.0.6`), and that
+is the `TAG` both scripts take. Per platform, images are tagged `REPO:TAG-ARCH`
+(e.g. `villagesql/server:mysql-8.4_0.0.6-arm64`).
+
+The manifest list is published under `TAG`, plus one tag per `--version-labels`
+label, with the version replaced by the label. So `--version-labels latest,stable`
+on `mysql-8.4_0.0.6` also publishes `mysql-8.4_latest` and `mysql-8.4_stable`.
+An empty list publishes `TAG` alone.
 
 ## Release Build Args
 
@@ -103,7 +108,7 @@ Both build args are read from the environment and forwarded to `docker build`:
 
 ```bash
 VSQL_PRE_RELEASE_VERSION="" VSQL_DEV_ABI=OFF \
-    docker/server/publish_image.sh --tag 0.0.5 --platform linux/arm64 --push
+    docker/server/publish_image.sh --tag mysql-8.4_0.0.6 --platform linux/arm64 --push
 ```
 
 Defaults are an empty `VSQL_PRE_RELEASE_VERSION` (a release build) and `VSQL_DEV_ABI=ON`.

--- a/docker/server/README.md
+++ b/docker/server/README.md
@@ -103,6 +103,10 @@ label, with the version replaced by the label. So `--version-labels latest,stabl
 on `mysql-8.4_0.0.6` also publishes `mysql-8.4_latest` and `mysql-8.4_stable`.
 An empty list publishes `TAG` alone.
 
+`--define-tags` adds tags that are published as given, with no codebase prefix,
+so `--define-tags latest,edge` publishes `REPO:latest` and `REPO:edge`. It is
+optional and defaults to none.
+
 ## Release Build Args
 
 Both build args are read from the environment and forwarded to `docker build`:

--- a/docker/server/docker_release_lib.sh
+++ b/docker/server/docker_release_lib.sh
@@ -21,7 +21,6 @@
 # a use which shellcheck cannot see.
 # shellcheck disable=SC2034
 DOCKER_REPO="villagesql/server"
-DOCKER_SHARED_TAGS="latest,stable"
 DEFAULT_PLATFORMS="linux/amd64,linux/arm64"
 
 # Build args forwarded to docker build. Override via the environment, e.g.

--- a/docker/server/publish_image.sh
+++ b/docker/server/publish_image.sh
@@ -71,8 +71,8 @@ Examples:
   ./publish_image.sh --tag mysql-8.4_0.0.6 --platform linux/arm64
   ./test-image.sh villagesql/server:mysql-8.4_0.0.6-arm64
 
-  # Build and publish one arch
-  ./publish_image.sh --tag mysql-8.4_0.0.6 --platform linux/arm64 --push
+  # Build and publish a different codebase and arch
+  ./publish_image.sh --tag percona-8.4_0.0.6 --platform linux/amd64 --push
 EOF
 }
 

--- a/docker/server/publish_image.sh
+++ b/docker/server/publish_image.sh
@@ -15,8 +15,8 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 # Build one platform-specific VillageSQL Server image under its arch-specific
-# tag (e.g. villagesql/server:0.0.5-arm64), and optionally publish it to a
-# registry (Docker Hub by default).
+# tag (e.g. villagesql/server:mysql-8.4_0.0.6-arm64), and optionally publish
+# it to a registry (Docker Hub by default).
 #
 # By default the image is built and loaded into the local docker image store,
 # where test-image.sh can smoke test it before anything is published. Pass
@@ -49,7 +49,8 @@ Usage:
   publish_image.sh --tag TAG --platform PLATFORM [options]
 
 Options:
-  -t, --tag TAG          Tag to build, e.g. a version (required)
+  -t, --tag TAG          Tag to build.  For releases, use the full release
+                         identifier with codebase and version (required)
   -p, --platform PLAT    Single docker platform, e.g. linux/arm64 (required)
   -r, --repo REPO        Image repository (default: $DOCKER_REPO)
       --push             Publish the image to the registry. Without this the
@@ -59,7 +60,7 @@ Options:
 
 The image is tagged REPO:TAG-ARCH, where ARCH is derived from the
 platform (linux/amd64 -> amd64). publish_manifest.sh stitches those
-arch tags into the shared multi-arch tags.
+arch tags into the multi-arch tags.
 
 Build args are taken from the environment:
   VSQL_PRE_RELEASE_VERSION  pre-release suffix (default: empty, a release)
@@ -67,11 +68,11 @@ Build args are taken from the environment:
 
 Examples:
   # Build the native arch and smoke test it before publishing anything
-  publish_image.sh --tag 0.0.5 --platform linux/arm64
-  ./test-image.sh villagesql/server:0.0.5-arm64
+  ./publish_image.sh --tag mysql-8.4_0.0.6 --platform linux/arm64
+  ./test-image.sh villagesql/server:mysql-8.4_0.0.6-arm64
 
   # Build and publish one arch
-  publish_image.sh --tag 0.0.5 --platform linux/arm64 --push
+  ./publish_image.sh --tag mysql-8.4_0.0.6 --platform linux/arm64 --push
 EOF
 }
 

--- a/docker/server/publish_manifest.sh
+++ b/docker/server/publish_manifest.sh
@@ -15,12 +15,12 @@
 # along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 # Stitch the per-arch VillageSQL Server images already in the registry into
-# one multi-arch manifest list, published under the primary tag plus every
-# shared tag (e.g. latest, stable), then verify the result.
+# one multi-arch manifest list, published under the primary tag plus tags
+# for any version suffix (e.g. latest) that are provided.
 #
 # Use --dry-run to see what would be published.
 # The arch images it references are verified before anything is written, which
-# catches an arch that was never pushed before the shared tags move.
+# catches an arch that was never pushed.
 #
 # Run publish_image.sh --push once per platform first.
 
@@ -33,7 +33,7 @@ source "$SCRIPT_DIR/docker_release_lib.sh"
 TAG=""
 REPO="$DOCKER_REPO"
 PLATFORMS="$DEFAULT_PLATFORMS"
-SHARED_TAGS="$DOCKER_SHARED_TAGS"
+VERSION_LABELS=""
 
 usage() {
     cat <<EOF
@@ -45,12 +45,14 @@ Usage:
   publish_manifest.sh --tag TAG [options]
 
 Options:
-  -t, --tag TAG          Primary tag to publish, e.g. a version (required)
+  -t, --tag TAG          Primary tag to publish.  For releases, use the full release
+                         identifier with codebase and version (required)
   -r, --repo REPO        Image repository (default: $DOCKER_REPO)
   -p, --platforms LIST   Comma-separated platforms whose arch images make up
                          the manifest (default: $DEFAULT_PLATFORMS)
-  -s, --shared-tags LIST       Comma-separated shared tags applied in addition to
-                         the primary tag (default: $DOCKER_SHARED_TAGS)
+  -v, --version-labels LIST
+                         Comma-separated version labels for version suffix tags
+                         in addition to the primary tag. Leave empty for none.
   -n, --dry-run          Print the commands without running them. The arch
                          images are still checked, and a missing one is a
                          warning rather than an error.
@@ -86,13 +88,15 @@ verify_arch_images() {
 }
 
 publish_manifest() {
-    local manifest_args=() shared_tag
+    local manifest_args=() version_label base_tag
     manifest_args+=(-t "$REPO:$TAG")
     # Guarded by the count: bash 3.2, and so macOS, treats "${arr[@]}" on an
     # empty array as an unbound variable under set -u.
-    if [ "${#SHARED_TAG_LIST[@]}" -gt 0 ]; then
-        for shared_tag in "${SHARED_TAG_LIST[@]}"; do
-            manifest_args+=(-t "$REPO:$shared_tag")
+    if [ "${#VERSION_LABELS_LIST[@]}" -gt 0 ]; then
+        # Strip the version to leave the codebase, or use as is for tests
+        base_tag=${TAG%_*}
+        for version_label in "${VERSION_LABELS_LIST[@]}"; do
+            manifest_args+=(-t "$REPO:${base_tag}_${version_label}")
         done
     fi
 
@@ -110,7 +114,7 @@ main() {
             -t|--tag)          TAG="$2"; shift 2 ;;
             -r|--repo)      REPO="$2"; shift 2 ;;
             -p|--platforms) PLATFORMS="$2"; shift 2 ;;
-            -s|--shared-tags)      SHARED_TAGS="$2"; shift 2 ;;
+            -v|--version-labels)      VERSION_LABELS="$2"; shift 2 ;;
             -n|--dry-run)   DRY_RUN=1; shift ;;
             -h|--help)      usage; exit 0 ;;
             *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
@@ -128,12 +132,13 @@ main() {
         ARCH_TAGS+=("$(arch_tag "$REPO" "$TAG" "$platform")")
     done
 
-    split_list "$SHARED_TAGS"
-    SHARED_TAG_LIST=("${SPLIT_RESULT[@]+"${SPLIT_RESULT[@]}"}")
+    split_list "$VERSION_LABELS"
+    VERSION_LABELS_LIST=("${SPLIT_RESULT[@]+"${SPLIT_RESULT[@]}"}")
 
-    echo "Repository  : $REPO"
-    echo "Arch images : ${ARCH_TAGS[*]}"
-    echo "Manifest as : $TAG ${SHARED_TAG_LIST[*]+${SHARED_TAG_LIST[*]}}"
+    echo "Repository     : $REPO"
+    echo "Arch images    : ${ARCH_TAGS[*]}"
+    echo "Image tag      : $TAG"
+    echo "Version labels : ${VERSION_LABELS_LIST[*]+${VERSION_LABELS_LIST[*]}}"
     [ "$DRY_RUN" -eq 1 ] && echo "(dry run: commands will be printed, not executed)"
     echo ""
 

--- a/docker/server/publish_manifest.sh
+++ b/docker/server/publish_manifest.sh
@@ -34,6 +34,7 @@ TAG=""
 REPO="$DOCKER_REPO"
 PLATFORMS="$DEFAULT_PLATFORMS"
 VERSION_LABELS=""
+DEFINE_TAGS=""
 
 usage() {
     cat <<EOF
@@ -53,6 +54,9 @@ Options:
   -v, --version-labels LIST
                          Comma-separated version labels for version suffix tags
                          in addition to the primary tag. Leave empty for none.
+  -d, --define-tags LIST
+                         Comma-separated tags to publish as well, each used as
+                         given rather than combined with the codebase. Optional.
   -n, --dry-run          Print the commands without running them. The arch
                          images are still checked, and a missing one is a
                          warning rather than an error.
@@ -88,7 +92,7 @@ verify_arch_images() {
 }
 
 publish_manifest() {
-    local manifest_args=() version_label base_tag
+    local manifest_args=() version_label base_tag define_tag
     manifest_args+=(-t "$REPO:$TAG")
     # Guarded by the count: bash 3.2, and so macOS, treats "${arr[@]}" on an
     # empty array as an unbound variable under set -u.
@@ -97,6 +101,11 @@ publish_manifest() {
         base_tag=${TAG%_*}
         for version_label in "${VERSION_LABELS_LIST[@]}"; do
             manifest_args+=(-t "$REPO:${base_tag}_${version_label}")
+        done
+    fi
+    if [ "${#DEFINE_TAGS_LIST[@]}" -gt 0 ]; then
+        for define_tag in "${DEFINE_TAGS_LIST[@]}"; do
+            manifest_args+=(-t "$REPO:${define_tag}")
         done
     fi
 
@@ -115,6 +124,7 @@ main() {
             -r|--repo)      REPO="$2"; shift 2 ;;
             -p|--platforms) PLATFORMS="$2"; shift 2 ;;
             -v|--version-labels)      VERSION_LABELS="$2"; shift 2 ;;
+            -d|--define-tags)      DEFINE_TAGS="$2"; shift 2 ;;
             -n|--dry-run)   DRY_RUN=1; shift ;;
             -h|--help)      usage; exit 0 ;;
             *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
@@ -135,10 +145,14 @@ main() {
     split_list "$VERSION_LABELS"
     VERSION_LABELS_LIST=("${SPLIT_RESULT[@]+"${SPLIT_RESULT[@]}"}")
 
+    split_list "$DEFINE_TAGS"
+    DEFINE_TAGS_LIST=("${SPLIT_RESULT[@]+"${SPLIT_RESULT[@]}"}")
+
     echo "Repository     : $REPO"
     echo "Arch images    : ${ARCH_TAGS[*]}"
     echo "Image tag      : $TAG"
     echo "Version labels : ${VERSION_LABELS_LIST[*]+${VERSION_LABELS_LIST[*]}}"
+    echo "Defined tags   : ${DEFINE_TAGS_LIST[*]+${DEFINE_TAGS_LIST[*]}}"
     [ "$DRY_RUN" -eq 1 ] && echo "(dry run: commands will be printed, not executed)"
     echo ""
 


### PR DESCRIPTION
## Description

Revise the publish manifest workflows and scripts to push and tag manifests in an effective scheme for multiple codebases.  This supports a reasonable notion of `latest` and the exploits the natural Docker Hub ability to extract the correct platform image from a mulit-platform manifest.

## Related Issue

Part of the [Server]: Overhaul CI #819 effort.

## How was this tested?

Experimental run of the workflow on this branch yielded the expected images, manifests, and tags on Docker Hub.  Those experimental artifacts have been manually deleted.

```yaml
Image Tag: leeca-trial_0.0.7
Repository: villagesql/server
Pre-release Version: ''
Dev ABI: OFF
Version Labels: 'latest,stable,dolphin'
```
