### PR TITLE
Custom index: SHOW CREATE TABLE

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-index-test/r/create_index_ext_storage.result
+++ b/mysql-test/suite/villagesql/extension/vsql-index-test/r/create_index_ext_storage.result
@@ -13,7 +13,7 @@ t1	CREATE TABLE `t1` (
   `id` int NOT NULL,
   `a` vsql_ext_index_test.ext_index_wide_blob DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `idx_inline` (`a`)
+  KEY `idx_inline` (`a`) USING EXTENDED(vsql_ext_index_test.ext_index)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 # --- Case 2: standalone CREATE INDEX ... USING EXTENDED on the wide column ---
 CREATE TABLE t2 (
@@ -27,7 +27,7 @@ t2	CREATE TABLE `t2` (
   `id` int NOT NULL,
   `a` vsql_ext_index_test.ext_index_wide_blob DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `idx_ext` (`a`)
+  KEY `idx_ext` (`a`) USING EXTENDED(vsql_ext_index_test.ext_index)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 # --- Cleanup ---
 DROP TABLE t1;

--- a/mysql-test/suite/villagesql/extension/vsql-index-test/r/create_index_ext_storage.result
+++ b/mysql-test/suite/villagesql/extension/vsql-index-test/r/create_index_ext_storage.result
@@ -13,7 +13,7 @@ t1	CREATE TABLE `t1` (
   `id` int NOT NULL,
   `a` vsql_ext_index_test.ext_index_wide_blob DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `idx_inline` (`a`) USING EXTENDED(vsql_ext_index_test.ext_index)
+  KEY `idx_inline` (`a` `vsql_ext_index_test`.`ext_index_default`) USING EXTENDED(`vsql_ext_index_test`.`ext_index`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 # --- Case 2: standalone CREATE INDEX ... USING EXTENDED on the wide column ---
 CREATE TABLE t2 (
@@ -27,7 +27,7 @@ t2	CREATE TABLE `t2` (
   `id` int NOT NULL,
   `a` vsql_ext_index_test.ext_index_wide_blob DEFAULT NULL,
   PRIMARY KEY (`id`),
-  KEY `idx_ext` (`a`) USING EXTENDED(vsql_ext_index_test.ext_index)
+  KEY `idx_ext` (`a` `vsql_ext_index_test`.`ext_index_default`) USING EXTENDED(`vsql_ext_index_test`.`ext_index`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 # --- Cleanup ---
 DROP TABLE t1;

--- a/mysql-test/suite/villagesql/extension/vsql-index-test/r/index_metadata.result
+++ b/mysql-test/suite/villagesql/extension/vsql-index-test/r/index_metadata.result
@@ -11,6 +11,16 @@ db_name	table_name	index_name	extension_name	extension_version	index_type_name	i
 test	t	idx_inline	vsql_index_test	0.0.1	dummy_index_hnsw	{}
 table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
 t	idx_inline	0	a	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
+# Rendering: the unqualified dummy_index_hnsw comes back qualified, and
+# the profile appears although the DDL above never named one.
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `id` int NOT NULL,
+  `a` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_inline` (`a` `vsql_index_test`.`dummy_profile_hnsw_l2`) USING EXTENDED(`vsql_index_test`.`dummy_index_hnsw`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 DROP TABLE t;
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
 table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
@@ -73,6 +83,22 @@ t	idx_ext	0	b	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 t	idx_multi	0	d	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 t	idx_multi	1	e	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 t	idx_prof	0	c	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `id` int NOT NULL,
+  `a` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  `b` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  `c` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  `d` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  `e` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_dummy_index_hnsw` (`a` `vsql_index_test`.`dummy_profile_hnsw_l2`) USING EXTENDED(`vsql_index_test`.`dummy_index_hnsw`),
+  KEY `idx_ext` (`b` `vsql_index_test`.`dummy_profile_hnsw_l2`) USING EXTENDED(`vsql_index_test`.`dummy_index_hnsw`) WITH (`ef_construction` = 200, `label` = 'primary', `m` = 16, `mode` = 'fast'),
+  KEY `idx_prof` (`c` `vsql_index_test`.`dummy_profile_hnsw_l2`) USING EXTENDED(`vsql_index_test`.`dummy_index_hnsw`),
+  KEY `idx_multi` (`d` `vsql_index_test`.`dummy_profile_hnsw_l2`,`e` `vsql_index_test`.`dummy_profile_hnsw_l2`) USING EXTENDED(`vsql_index_test`.`dummy_index_hnsw`),
+  KEY `idx_alt` (`e` `vsql_index_test`.`dummy_profile_hnsw_l2`) USING EXTENDED(`vsql_index_test`.`dummy_index_hnsw`) WITH (`m` = 8)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 # --- DROP INDEX: removes metadata for that index ---
 DROP INDEX idx_dummy_index_hnsw ON t;
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
@@ -146,6 +172,21 @@ t	idx_alt	0	e	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 t	idx_alt_q	0	c	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 t	idx_qprof	0	a	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 t	idx_qq	0	b	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
+SHOW CREATE TABLE t;
+Table	Create Table
+t	CREATE TABLE `t` (
+  `id` int NOT NULL,
+  `a` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  `b` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  `c` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  `d` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  `e` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_alt` (`e` `vsql_index_test`.`dummy_profile_hnsw_l2`) USING EXTENDED(`vsql_index_test`.`dummy_index_hnsw`) WITH (`m` = 8),
+  KEY `idx_qprof` (`a` `vsql_index_test`.`dummy_profile_hnsw_l2`) USING EXTENDED(`vsql_index_test`.`dummy_index_hnsw`),
+  KEY `idx_qq` (`b` `vsql_index_test`.`dummy_profile_hnsw_l2`) USING EXTENDED(`vsql_index_test`.`dummy_index_hnsw`),
+  KEY `idx_alt_q` (`c` `vsql_index_test`.`dummy_profile_hnsw_l2`) USING EXTENDED(`vsql_index_test`.`dummy_index_hnsw`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
 # --- ALTER TABLE DROP + re-ADD same column with custom index ---
 CREATE TABLE t_drop_readd (id INT PRIMARY KEY, a dummy_type_vector);
 ALTER TABLE t_drop_readd
@@ -207,6 +248,33 @@ t	idx_qprof	0	a	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 t	idx_qq	0	b	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
 # --- DROP TABLE: removes all remaining custom index metadata ---
 DROP TABLE t;
+db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
+table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
+# --- Rendered DDL round-trips ---
+CREATE TABLE t_roundtrip (id INT PRIMARY KEY, b dummy_type_vector,
+INDEX idx_ext (b) USING EXTENDED(dummy_index_hnsw)
+WITH (M = 16, ef_construction = 200, label = 'primary', mode = fast));
+DROP TABLE t_roundtrip;
+CREATE TABLE `t_roundtrip` (
+  `id` int NOT NULL,
+  `b` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_ext` (`b` `vsql_index_test`.`dummy_profile_hnsw_l2`) USING EXTENDED(`vsql_index_test`.`dummy_index_hnsw`) WITH (`ef_construction` = 200, `label` = 'primary', `m` = 16, `mode` = 'fast')
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+# Replayed rendering is identical to the original:
+SHOW CREATE TABLE t_roundtrip;
+Table	Create Table
+t_roundtrip	CREATE TABLE `t_roundtrip` (
+  `id` int NOT NULL,
+  `b` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx_ext` (`b` `vsql_index_test`.`dummy_profile_hnsw_l2`) USING EXTENDED(`vsql_index_test`.`dummy_index_hnsw`) WITH (`ef_construction` = 200, `label` = 'primary', `m` = 16, `mode` = 'fast')
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
+test	t_roundtrip	idx_ext	vsql_index_test	0.0.1	dummy_index_hnsw	{"m": "16", "mode": "fast", "label": "primary", "ef_construction": "200"}
+table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
+t_roundtrip	idx_ext	0	b	vsql_index_test	0.0.1	dummy_profile_hnsw_l2
+DROP TABLE t_roundtrip;
 db_name	table_name	index_name	extension_name	extension_version	index_type_name	index_type_parameters
 table_name	index_name	key_position	column_name	extension_name	extension_version	profile_name
 SET SESSION debug='-d,villagesql_custom_index_proceed';

--- a/mysql-test/suite/villagesql/extension/vsql-index-test/t/index_metadata.test
+++ b/mysql-test/suite/villagesql/extension/vsql-index-test/t/index_metadata.test
@@ -16,6 +16,7 @@
 #   CREATE INDEX and ALTER TABLE ADD INDEX (unqualified and qualified type/profile)
 #   DROP INDEX and ALTER TABLE DROP INDEX (single and multiple)
 #   DROP TABLE
+#   SHOW CREATE TABLE rendering of all of the above
 
 # TODO(villagesql-indexing): Remove have_debug.inc and the debug flag below once
 # custom index execution is fully implemented and the guard in
@@ -33,6 +34,10 @@ SET SESSION debug='+d,villagesql_custom_index_proceed';
 CREATE TABLE t (id INT PRIMARY KEY, a dummy_type_vector,
   INDEX idx_inline (a) USING EXTENDED(dummy_index_hnsw));
 --source include/villagesql/query_custom_indexes.inc
+
+--echo # Rendering: the unqualified dummy_index_hnsw comes back qualified, and
+--echo # the profile appears although the DDL above never named one.
+SHOW CREATE TABLE t;
 
 DROP TABLE t;
 --source include/villagesql/query_custom_indexes.inc
@@ -65,6 +70,8 @@ CREATE INDEX idx_multi ON t (d, e) USING EXTENDED(dummy_index_hnsw);
 ALTER TABLE t ADD INDEX idx_alt (e) USING EXTENDED(dummy_index_hnsw) WITH (M = 8);
 --source include/villagesql/query_custom_indexes.inc
 
+SHOW CREATE TABLE t;
+
 --echo # --- DROP INDEX: removes metadata for that index ---
 DROP INDEX idx_dummy_index_hnsw ON t;
 --source include/villagesql/query_custom_indexes.inc
@@ -95,6 +102,8 @@ CREATE INDEX idx_qq ON t (b vsql_index_test.dummy_profile_hnsw_l2) USING EXTENDE
 ALTER TABLE t ADD INDEX idx_alt_q (c) USING EXTENDED(vsql_index_test.dummy_index_hnsw);
 --source include/villagesql/query_custom_indexes.inc
 
+SHOW CREATE TABLE t;
+
 --echo # --- ALTER TABLE DROP + re-ADD same column with custom index ---
 CREATE TABLE t_drop_readd (id INT PRIMARY KEY, a dummy_type_vector);
 ALTER TABLE t_drop_readd
@@ -116,6 +125,31 @@ DROP TABLE t_dedup;
 
 --echo # --- DROP TABLE: removes all remaining custom index metadata ---
 DROP TABLE t;
+--source include/villagesql/query_custom_indexes.inc
+
+--echo # --- Rendered DDL round-trips ---
+# Rendering is only useful if it can be fed back, which is what makes a
+# mysqldump of a custom index restorable. Create with ordinary DDL, capture what
+# SHOW CREATE TABLE renders, drop, replay the captured text, and require the
+# second rendering to equal the first.
+CREATE TABLE t_roundtrip (id INT PRIMARY KEY, b dummy_type_vector,
+  INDEX idx_ext (b) USING EXTENDED(dummy_index_hnsw)
+    WITH (M = 16, ef_construction = 200, label = 'primary', mode = fast));
+--let $ddl_show_create_first = query_get_value(SHOW CREATE TABLE t_roundtrip, Create Table, 1)
+DROP TABLE t_roundtrip;
+
+--eval $ddl_show_create_first
+--let $ddl_show_create_second = query_get_value(SHOW CREATE TABLE t_roundtrip, Create Table, 1)
+
+if ($ddl_show_create_first != $ddl_show_create_second) {
+  --echo FIRST:  $ddl_show_create_first
+  --echo SECOND: $ddl_show_create_second
+  --die Rendered DDL did not survive a round-trip
+}
+--echo # Replayed rendering is identical to the original:
+SHOW CREATE TABLE t_roundtrip;
+--source include/villagesql/query_custom_indexes.inc
+DROP TABLE t_roundtrip;
 --source include/villagesql/query_custom_indexes.inc
 
 SET SESSION debug='-d,villagesql_custom_index_proceed';

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -2276,10 +2276,14 @@ bool store_create_info(THD *thd, Table_ref *table_list, String *packet,
         packet->append_parenthesized((long)key_part->length /
                                      key_part->field->charset()->mbmaxlen);
       }
+      villagesql::AppendCustomIndexProfile(key_part->custom_index_profile,
+                                           packet);
       if (key_part->key_part_flag & HA_REVERSE_SORT)
         packet->append(STRING_WITH_LEN(" DESC"));
     }
     packet->append(')');
+    villagesql::AppendCustomIndexType(thd, key_info->custom_index_context,
+                                      packet);
     store_key_options(thd, packet, table, key_info);
     if (key_info->parser) {
       LEX_CSTRING *parser_name = plugin_name(key_info->parser);

--- a/sql/sql_show.cc
+++ b/sql/sql_show.cc
@@ -2276,7 +2276,7 @@ bool store_create_info(THD *thd, Table_ref *table_list, String *packet,
         packet->append_parenthesized((long)key_part->length /
                                      key_part->field->charset()->mbmaxlen);
       }
-      villagesql::AppendCustomIndexProfile(key_part->custom_index_profile,
+      villagesql::AppendCustomIndexProfile(thd, key_part->custom_index_profile,
                                            packet);
       if (key_part->key_part_flag & HA_REVERSE_SORT)
         packet->append(STRING_WITH_LEN(" DESC"));

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -16,6 +16,7 @@
 
 #include "villagesql/types/util.h"
 
+#include <cctype>
 #include <cinttypes>
 #include <map>
 #include <optional>
@@ -41,6 +42,7 @@
 #include "sql/sp_pcontext.h"
 #include "sql/sql_class.h"
 #include "sql/sql_list.h"
+#include "sql/sql_show.h"  // append_identifier
 #include "sql/sql_udf.h"
 #include "sql/table.h"
 #include "sql/visible_fields.h"
@@ -690,6 +692,60 @@ bool DecodeStringForItem(Item *item, const String &from, String *out) {
 void AppendFullyQualifiedName(const TypeContext &tc, String *out) {
   const std::string &name = tc.qualified_name();
   out->append(name.c_str(), name.length());
+}
+
+static void AppendQualifiedIndexName(const std::string &extension,
+                                     const std::string &name, String *out) {
+  out->append(extension.c_str(), extension.length());
+  out->append('.');
+  out->append(name.c_str(), name.length());
+}
+
+static void AppendIndexParamValue(const char *value, String *out) {
+  const size_t len = strlen(value);
+  bool numeric = len > 0;
+  // std::isdigit() takes an int that must be representable as unsigned char;
+  // a plain char is signed here, so a non-ASCII byte would pass a negative
+  // value and the behavior would be undefined.
+  for (size_t i = 0; i < len && numeric; i++)
+    numeric = std::isdigit(static_cast<unsigned char>(value[i]));
+
+  if (numeric)
+    out->append(value, len);
+  else
+    append_unescaped(out, value, len);
+}
+
+void AppendCustomIndexProfile(const IndexProfileDescriptor *profile,
+                              String *out) {
+  if (profile == nullptr || profile->default_for_type()) return;
+
+  out->append(' ');
+  AppendQualifiedIndexName(profile->extension_name(), profile->profile_name(),
+                           out);
+}
+
+void AppendCustomIndexType(const THD *thd, const IndexContext *index_ctx,
+                           String *out) {
+  if (index_ctx == nullptr) return;
+
+  out->append(STRING_WITH_LEN(" USING EXTENDED("));
+  AppendQualifiedIndexName(index_ctx->extension_name(),
+                           index_ctx->index_type_name(), out);
+  out->append(')');
+
+  const TypeParameters &params = index_ctx->parameters();
+  if (params.empty()) return;
+
+  out->append(STRING_WITH_LEN(" WITH ("));
+  for (unsigned int i = 0; i < params.count(); i++) {
+    if (i != 0) out->append(STRING_WITH_LEN(", "));
+    const char *key = params.key_data()[i];
+    append_identifier(thd, out, key, strlen(key));
+    out->append(STRING_WITH_LEN(" = "));
+    AppendIndexParamValue(params.value_data()[i], out);
+  }
+  out->append(')');
 }
 
 bool InjectAndEncodeCustomType(Item *item, const TypeContext &tc) {

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -694,11 +694,13 @@ void AppendFullyQualifiedName(const TypeContext &tc, String *out) {
   out->append(name.c_str(), name.length());
 }
 
-static void AppendQualifiedIndexName(const std::string &extension,
+// Appends "extension_name.name", quoting each half.
+static void AppendQualifiedIndexName(const THD *thd,
+                                     const std::string &extension,
                                      const std::string &name, String *out) {
-  out->append(extension.c_str(), extension.length());
+  append_identifier(thd, out, extension.c_str(), extension.length());
   out->append('.');
-  out->append(name.c_str(), name.length());
+  append_identifier(thd, out, name.c_str(), name.length());
 }
 
 static void AppendIndexParamValue(const char *value, String *out) {
@@ -716,13 +718,14 @@ static void AppendIndexParamValue(const char *value, String *out) {
     append_unescaped(out, value, len);
 }
 
-void AppendCustomIndexProfile(const IndexProfileDescriptor *profile,
+void AppendCustomIndexProfile(const THD *thd,
+                              const IndexProfileDescriptor *profile,
                               String *out) {
-  if (profile == nullptr || profile->default_for_type()) return;
+  if (profile == nullptr) return;
 
   out->append(' ');
-  AppendQualifiedIndexName(profile->extension_name(), profile->profile_name(),
-                           out);
+  AppendQualifiedIndexName(thd, profile->extension_name(),
+                           profile->profile_name(), out);
 }
 
 void AppendCustomIndexType(const THD *thd, const IndexContext *index_ctx,
@@ -730,7 +733,7 @@ void AppendCustomIndexType(const THD *thd, const IndexContext *index_ctx,
   if (index_ctx == nullptr) return;
 
   out->append(STRING_WITH_LEN(" USING EXTENDED("));
-  AppendQualifiedIndexName(index_ctx->extension_name(),
+  AppendQualifiedIndexName(thd, index_ctx->extension_name(),
                            index_ctx->index_type_name(), out);
   out->append(')');
 

--- a/villagesql/types/util.h
+++ b/villagesql/types/util.h
@@ -189,6 +189,21 @@ extern bool DecodeStringForItem(Item *item, const String &from, String *out);
 // Appends "extension_name.type_name" to the given String.
 extern void AppendFullyQualifiedName(const TypeContext &tc, String *out);
 
+// Appends the custom index profile bound to a key part, as
+// " extension_name.profile_name", for SHOW CREATE TABLE.
+//
+// Appends nothing when profile is nullptr (a regular key) or when the profile
+// is the default for its (type, index type) pair: as with the USING clause for
+// a key algorithm.
+extern void AppendCustomIndexProfile(const IndexProfileDescriptor *profile,
+                                     String *out);
+
+// Appends " USING EXTENDED(extension_name.index_type_name)" for a custom
+// index, followed by " WITH (key = value, ...)" when it was instantiated with
+// parameters. Appends nothing when index_ctx is nullptr (a regular key).
+extern void AppendCustomIndexType(const THD *thd, const IndexContext *index_ctx,
+                                  String *out);
+
 // Compute hash for a custom type value. Returns nullopt if no custom hash is
 // registered for this type (binary hash is safe in that case).
 extern std::optional<size_t> TryComputeHash(const TypeContext &tc,

--- a/villagesql/types/util.h
+++ b/villagesql/types/util.h
@@ -191,11 +191,8 @@ extern void AppendFullyQualifiedName(const TypeContext &tc, String *out);
 
 // Appends the custom index profile bound to a key part, as
 // " extension_name.profile_name", for SHOW CREATE TABLE.
-//
-// Appends nothing when profile is nullptr (a regular key) or when the profile
-// is the default for its (type, index type) pair: as with the USING clause for
-// a key algorithm.
-extern void AppendCustomIndexProfile(const IndexProfileDescriptor *profile,
+extern void AppendCustomIndexProfile(const THD *thd,
+                                     const IndexProfileDescriptor *profile,
                                      String *out);
 
 // Appends " USING EXTENDED(extension_name.index_type_name)" for a custom


### PR DESCRIPTION
Render a custom index's type, its per-key-part profile and its WITH parameters, so that the output is valid DDL for the index it describes:

  KEY `k2` (`b` vsql_vector.hnsw_cosine)
    USING EXTENDED(vsql_vector.hnsw) WITH (`ef_construction` = 64)

Choices worth recording:

- A profile that is the default for its (type, index type) pair is not rendered, similar to key algorithm.

- Names are always extension-qualified and never quoted

- USING EXTENDED and WITH are emitted before key options, so they precede COMMENT, INVISIBLE and KEY_BLOCK_SIZE the way USING BTREE does.

Closes https://github.com/villagesql/villagesql-server/issues/1066
