### PR TITLE
Use nightly-dispatch for sanitizer

### DIFF
--- a/.github/workflows/nightly-dispatch.yml
+++ b/.github/workflows/nightly-dispatch.yml
@@ -216,3 +216,28 @@ jobs:
             -f ref="$REF" \
             -f slack_notify=true
           echo "Started extension-compat on $REF" >> "$GITHUB_STEP_SUMMARY"
+
+  start-sanitizer:
+    if: always()
+    name: Start sanitizer tests (ASan+UBSan)
+    needs: collect-info
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write  # Required to start a workflow run
+    steps:
+      - name: Start sanitizer
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          REF: ${{ needs.collect-info.outputs.ref }}
+          WORKFLOW_BRANCH: ${{ needs.collect-info.outputs.workflow-branch }}
+        run: |
+          set -euo pipefail
+
+          # no -f extension= value so sanitizer runs all extensions
+          gh workflow run sanitizer.yml \
+            --ref "$WORKFLOW_BRANCH" \
+            -f ref="$REF" \
+            -f slack_notify=true
+          echo "Started sanitizer tests on $REF" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -22,17 +22,9 @@ name: Sanitizer Tests (ASan+UBSan)
 # Results are posted to Slack; see the notify job at the bottom.
 #
 # Trigger via: Actions tab -> Run workflow, or `gh workflow run sanitizer.yml`.
+# nightly-dispatch.yml starts one run this way after every nightly build.
 
 on:
-  # Runs after every Nightly run, as an independent workflow, alongside the
-  # other nightly listeners (full-test-suite.yml, extension-compat.yml).
-  # Deliberately ungated on the nightly's conclusion: the nightly runs the same
-  # village suite this job runs under the sanitizers, so a red nightly still
-  # results in having sanitizer output that could be used to explain the failure.
-  workflow_run:
-    workflows: ['Nightly Build and Test']
-    types: [completed]
-    branches: [main]
   workflow_dispatch:
     inputs:
       ref:
@@ -47,7 +39,7 @@ on:
         description: 'Send Slack notification with results'
         required: false
         type: boolean
-        default: true
+        default: false
 
 concurrency:
   group: sanitizer-${{ github.ref }}
@@ -75,9 +67,7 @@ jobs:
       SOURCE_DIR: ${{ github.workspace }}/source
       BUILD_DIR: ${{ github.workspace }}/build
       EXTS_ROOT: ${{ github.workspace }}/exts
-      # workflow_run supplies no inputs, so fall back to the commit the nightly
-      # run built rather than whatever main has moved to since.
-      REQUEST_REF: ${{ inputs.ref || github.event.workflow_run.head_sha || github.ref }}
+      REQUEST_REF: ${{ inputs.ref || github.ref }}
       EXTENSION_FILTER: ${{ inputs.extension }}
       # MTR overwrites *SAN_OPTIONS for the server processes it spawns, so these
       # values govern the ctest unit tests (which inherit the job environment)
@@ -95,7 +85,6 @@ jobs:
     steps:
     - name: Report Parameters
       run: |
-        echo "Trigger: $GITHUB_EVENT_NAME"
         echo "Requested ref: $REQUEST_REF"
         echo "Extension filter: ${EXTENSION_FILTER:-<all>}"
         echo "Source Directory: $SOURCE_DIR"
@@ -229,14 +218,12 @@ jobs:
         fi
         echo "All sanitizer test phases passed."
 
-  # Posts a per-phase summary after the run (nightly / dispatch).
+  # Posts a per-phase summary after the run.
   notify:
     name: Slack Notification
     needs: build-and-test
-    # Nightly runs always report — a silent night is otherwise
-    # indistinguishable from one where the workflow never fired. Manual runs
-    # honor the checkbox so iterating on this file doesn't spam the channel.
-    if: always() && (github.event_name != 'workflow_dispatch' || inputs.slack_notify)
+    # Even if build-and-test fails, but only if slack notify requested.
+    if: always() && inputs.slack_notify
     runs-on: ubuntu-latest
     # Posts to a webhook; needs no repo access.
     permissions: {}


### PR DESCRIPTION
## Description

Converts the sanitizer workflow to use nightly-dispatch workflow, not the unparameterized on.workflow_run trigger.

## Related Issue

Part of the [Server]: Overhaul CI #819 effort.
