### PR TITLE
Use nightly-dispatch for extension-compat

### DIFF
--- a/.github/workflows/extension-compat-suite.yml
+++ b/.github/workflows/extension-compat-suite.yml
@@ -2,7 +2,7 @@ name: Extension SDK Compatibility (Reusable)
 
 # Reusable workflow that builds bundled extensions against the SDK built from a
 # given ref and runs their MTR suites. Called by:
-#   - extension-compat.yml (nightly workflow_run + manual workflow_dispatch)
+#   - extension-compat.yml (nightly dispatch + manual workflow_dispatch)
 #   - slash-commands.yml    (/testextensions on a PR)
 #
 # The SDK is compiled fresh from `ref` in build-server, and each extension is

--- a/.github/workflows/extension-compat.yml
+++ b/.github/workflows/extension-compat.yml
@@ -4,7 +4,7 @@ name: Extension SDK Compatibility
 # Delegates the actual build/test matrix to the reusable
 # extension-compat-suite.yml. Tests bundled extensions against the SDK at HEAD.
 #
-#   - Runs automatically after a successful nightly build (workflow_run).
+#   - nightly-dispatch.yml starts a run after each successful nightly build.
 #   - Can be triggered manually to test a single platform, extension, or ABI.
 #
 # For on-demand testing against a PR's commit, see /testextensions in
@@ -19,10 +19,6 @@ name: Extension SDK Compatibility
 # breaks nightly CI across all of them. See cpp/action.yml in extension-actions.
 
 on:
-  workflow_run:
-    workflows: ["Nightly Build and Test"]
-    types: [completed]
-    branches: [main]
   workflow_dispatch:
     inputs:
       platform:
@@ -45,7 +41,7 @@ on:
         description: 'Send Slack notification with results'
         required: false
         type: boolean
-        default: true
+        default: false
 
 permissions:
   contents: read
@@ -53,14 +49,12 @@ permissions:
 jobs:
   run:
     name: Extension compatibility
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
     uses: ./.github/workflows/extension-compat-suite.yml
     with:
       ref: ${{ inputs.ref || github.ref }}
       platform_filter: ${{ inputs.platform }}
       extension_filter: ${{ inputs.extension }}
       abi_filter: ${{ inputs.abi }}
-      # format() coerces the boolean to a non-empty string so a dispatch
-      # 'slack_notify: false' is preserved; workflow_run has no inputs => 'true'.
-      slack_notify: ${{ github.event_name == 'workflow_dispatch' && format('{0}', inputs.slack_notify) || 'true' }}
+      # The suite takes slack_notify as a string; format() coerces the boolean.
+      slack_notify: ${{ format('{0}', inputs.slack_notify) }}
     secrets: inherit

--- a/.github/workflows/nightly-dispatch.yml
+++ b/.github/workflows/nightly-dispatch.yml
@@ -189,3 +189,30 @@ jobs:
             -f platform=macos-arm64 \
             -f artifact-prefix=nightly-full-macos-debug
           echo "Started full-test-suite (macOS, debug) on $REF" >> "$GITHUB_STEP_SUMMARY"
+
+  # Unlike the suites above, this one is gated on the nightly having passed.
+  # extension-actions in every extension repo resolves the latest successful
+  # extension-compat run to fetch its devserver-*/sdk-* artifacts, so there is
+  # little value in producing a set off a red nightly.
+  start-extension-compat:
+    if: always() && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success')
+    name: Start extension SDK compatibility
+    needs: collect-info
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write  # Required to start a workflow run
+    steps:
+      - name: Start extension-compat
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          REF: ${{ needs.collect-info.outputs.ref }}
+          WORKFLOW_BRANCH: ${{ needs.collect-info.outputs.workflow-branch }}
+        run: |
+          set -euo pipefail
+          gh workflow run extension-compat.yml \
+            --ref "$WORKFLOW_BRANCH" \
+            -f ref="$REF" \
+            -f slack_notify=true
+          echo "Started extension-compat on $REF" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Description

Converts the extension compat workflow to use the nightly-dispatch workflow scheduling, not the unparameterized on.workflow_run trigger.

## Related Issue

Part of the [Server]: Overhaul CI #819 effort.
