### PR TITLE
add is_null() check to PrerunArgs

### DIFF
--- a/mysql-test/suite/villagesql/std_data/state_and_varargs_vdf.cc
+++ b/mysql-test/suite/villagesql/std_data/state_and_varargs_vdf.cc
@@ -62,9 +62,8 @@ void varargs_indexed_prerun(PrerunArgs args, PrerunResult out) {
   }
   for (size_t i = 0; i < args.size(); i++) {
     auto t = args.type_at(i);
-    // Allow CUSTOM (real values) and STRING (so NULL literals — which arrive
-    // typed as STRING — also pass prerun). The body re-checks per-row.
-    if (!t.is_custom() && !t.is_str()) {
+    // Allow CUSTOM (real values) and NULL The body re-checks per-row.
+    if (!t.is_custom() && !t.is_null() && !t.is_str()) {
       out.error("varargs_indexed: argument " + std::to_string(i) +
                 " must be a CUSTOM-typed value");
       return;

--- a/sql/item.h
+++ b/sql/item.h
@@ -4811,7 +4811,7 @@ class Item_null : public Item_basic_constant {
   bool get_time(MYSQL_TIME *) override { return true; }
   bool val_json(Json_wrapper *wr) override;
   bool send(Protocol *protocol, String *str) override;
-  Item_result result_type() const override { return INVALID_RESULT; }
+  Item_result result_type() const override { return STRING_RESULT; }
   Item *clone_item() const override { return new Item_null(item_name); }
   bool is_null() override { return true; }
 

--- a/sql/item.h
+++ b/sql/item.h
@@ -2782,7 +2782,6 @@ class Item : public Parse_tree_node {
   /// A processor to handle the select lex visitor framework.
   virtual bool visitor_processor(uchar *arg);
 
-
   /**
     Item::walk function. Set bit in table->cond_set for all fields of
     all tables that are referred to by the Item.
@@ -4812,7 +4811,7 @@ class Item_null : public Item_basic_constant {
   bool get_time(MYSQL_TIME *) override { return true; }
   bool val_json(Json_wrapper *wr) override;
   bool send(Protocol *protocol, String *str) override;
-  Item_result result_type() const override { return STRING_RESULT; }
+  Item_result result_type() const override { return INVALID_RESULT; }
   Item *clone_item() const override { return new Item_null(item_name); }
   bool is_null() override { return true; }
 

--- a/sql/item.h
+++ b/sql/item.h
@@ -2782,6 +2782,7 @@ class Item : public Parse_tree_node {
   /// A processor to handle the select lex visitor framework.
   virtual bool visitor_processor(uchar *arg);
 
+  
   /**
     Item::walk function. Set bit in table->cond_set for all fields of
     all tables that are referred to by the Item.

--- a/sql/item.h
+++ b/sql/item.h
@@ -2782,7 +2782,7 @@ class Item : public Parse_tree_node {
   /// A processor to handle the select lex visitor framework.
   virtual bool visitor_processor(uchar *arg);
 
-  
+
   /**
     Item::walk function. Set bit in table->cond_set for all fields of
     all tables that are referred to by the Item.

--- a/villagesql/examples/vsql-simple/src/extension.cc
+++ b/villagesql/examples/vsql-simple/src/extension.cc
@@ -155,8 +155,7 @@ void ba_len(IntResult out) { out.set(static_cast<long long>(kBytearrayLen)); }
 // Demonstrates .varargs() on the func builder paired with a prerun that
 // validates argument types and sizes the result buffer.
 //
-// Prerun: validate that all arguments are BYTEARRAY (or NULL literals,
-// which appear as VEF_TYPE_STRING in the prerun arg-type array) and ask
+// Prerun: validate that all arguments are BYTEARRAY or NULL literals and ask
 // the server to allocate arg_count * kBytearrayLen bytes of result buffer.
 void ba_concat_all_prerun(vsql::PrerunArgs args, vsql::PrerunResult out) {
   if (args.size() == 0) {
@@ -165,7 +164,7 @@ void ba_concat_all_prerun(vsql::PrerunArgs args, vsql::PrerunResult out) {
   }
   for (size_t i = 0; i < args.size(); i++) {
     auto t = args.type_at(i);
-    if (!t.is_custom() && !t.is_str()) {
+    if (!t.is_custom() && !t.is_null() && !t.is_str()) {
       out.error("ba_concat_all: argument " + std::to_string(i) +
                 " must be BYTEARRAY");
       return;
@@ -178,10 +177,8 @@ void ba_concat_all(VarArgs args, StringResult out) {
   auto dst = out.buffer();
   size_t off = 0;
   for (auto a : args) {
-    // Prerun accepts VEF_TYPE_STRING so NULL literals (which arrive typed as
-    // STRING) pass type-check, but it cannot distinguish a NULL literal from
-    // a non-NULL string literal like 'abc'. Treat any non-custom argument
-    // here as NULL so we never call as_custom() on a STRING value.
+    // Treat any non-custom argument here as NULL so we never call as_custom()
+    // on a STRING value.
     if (a.is_null() || !a.is_custom()) {
       out.set_null();
       return;

--- a/villagesql/sdk/include/villagesql/abi/types.h
+++ b/villagesql/sdk/include/villagesql/abi/types.h
@@ -278,7 +278,8 @@ typedef enum : int {
   VEF_TYPE_STRING = 0,
   VEF_TYPE_REAL = 1,
   VEF_TYPE_INT = 2,
-  VEF_TYPE_CUSTOM = 3
+  VEF_TYPE_CUSTOM = 3,
+  VEF_TYPE_NULL = 4
 
   // TODO(villagesql-ga): Do we want to support DECIMAL?
 } vef_type_id;

--- a/villagesql/sdk/include/villagesql/vsql/pre_post_run.h
+++ b/villagesql/sdk/include/villagesql/vsql/pre_post_run.h
@@ -68,6 +68,7 @@ class PrerunArgType {
   bool is_real() const { return t_->id == VEF_TYPE_REAL; }
   bool is_str() const { return t_->id == VEF_TYPE_STRING; }
   bool is_custom() const { return t_->id == VEF_TYPE_CUSTOM; }
+  bool is_null() const { return t_->id == VEF_TYPE_NULL; }
 
   // For CUSTOM types: the unqualified type name (no extension prefix).
   // Empty string_view for non-CUSTOM types.

--- a/villagesql/system_views/extension_registration.cc
+++ b/villagesql/system_views/extension_registration.cc
@@ -55,6 +55,8 @@ static const char *type_id_to_str(vef_type_id id) {
       return "INT";
     case VEF_TYPE_CUSTOM:
       return "CUSTOM";
+    case VEF_TYPE_NULL:
+      return "NULL";
   }
   return "UNKNOWN";
 }

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -229,6 +229,8 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
         if (tc != nullptr) {
           arg_types[i].id = VEF_TYPE_CUSTOM;
           arg_types[i].custom_type = tc->type_name().c_str();
+        } else if (m_args[i]->type() == Item::NULL_ITEM) {
+          arg_types[i].id = VEF_TYPE_NULL;
         } else {
           switch (m_args[i]->result_type()) {
             case REAL_RESULT:
@@ -236,9 +238,6 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
               break;
             case INT_RESULT:
               arg_types[i].id = VEF_TYPE_INT;
-              break;
-            case INVALID_RESULT:
-              arg_types[i].id = VEF_TYPE_NULL;
               break;
             default:
               arg_types[i].id = VEF_TYPE_STRING;
@@ -367,6 +366,8 @@ static void marshal_args_typed(const vef_signature_t *sig, uint value_count,
       auto *tc = arg_item->get_type_context();
       if (tc != nullptr) {
         param_type = VEF_TYPE_CUSTOM;
+      } else if (arg_item->type() == Item::NULL_ITEM) {
+        param_type = VEF_TYPE_NULL;
       } else {
         switch (arg_item->result_type()) {
           case REAL_RESULT:
@@ -408,6 +409,11 @@ static void marshal_args_typed(const vef_signature_t *sig, uint value_count,
           invalues[i].str_len = arg_str->length();
         }
         break;
+      }
+      case VEF_TYPE_NULL: {
+        invalues[i].is_null = true;
+        invalues[i].str_value = nullptr;
+        invalues[i].str_len = 0;
       }
       case VEF_TYPE_CUSTOM:
       default: {

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -231,6 +231,7 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
           arg_types[i].custom_type = tc->type_name().c_str();
         } else if (m_args[i]->type() == Item::NULL_ITEM) {
           arg_types[i].id = VEF_TYPE_NULL;
+          arg_types[i].custom_type = nullptr;
         } else {
           switch (m_args[i]->result_type()) {
             case REAL_RESULT:
@@ -414,6 +415,7 @@ static void marshal_args_typed(const vef_signature_t *sig, uint value_count,
         invalues[i].is_null = true;
         invalues[i].str_value = nullptr;
         invalues[i].str_len = 0;
+        break;
       }
       case VEF_TYPE_CUSTOM:
       default: {

--- a/villagesql/vdf/vdf_handler.cc
+++ b/villagesql/vdf/vdf_handler.cc
@@ -237,6 +237,9 @@ bool vdf_handler::fix_fields(THD *thd [[maybe_unused]],
             case INT_RESULT:
               arg_types[i].id = VEF_TYPE_INT;
               break;
+            case INVALID_RESULT:
+              arg_types[i].id = VEF_TYPE_NULL;
+              break;
             default:
               arg_types[i].id = VEF_TYPE_STRING;
               break;


### PR DESCRIPTION
## Description

Adds `is_null()` check for `PrerunArgs`

## Related Issue

Fixes https://github.com/villagesql/villagesql-server/issues/573

## How was this tested?

This was tested by creating an extension that adds two numbers and default to zero if `NULL` is provided as an argument.

### before

```c++

void add_pre_run(PrerunArgs args, PrerunResult res) {
  for (size_t i = 0; i < args.size(); i++) {
    if (!args.type_at(i).is_int() && !args.type_at(i).is_str()) {
      res.error("add: all arguments must be int or string ");
      return;
    }
  }
}

void add(VarArgs args, IntResult out) {
  int a, b;

  if (args[0].is_str()) {
    if (args[0].is_null()) {
      a = 0;
    } else {
      out.set(-1);
      return;
    }
  } else {
    a = args[0].as_int();
  }

  if (args[1].is_str()) {
    if (args[1].is_null()) {
      b = 0;
    } else {
      out.set(-1);
      return;
    }
  } else {
    b = args[1].as_int();
  }

  long long total = a + b;
  out.set(total);
}
```

### after

```c++
void add_pre_run(PrerunArgs args, PrerunResult res) {
  for (size_t i = 0; i < args.size(); i++) {
    if (!args.type_at(i).is_int() && !args.type_at(i).is_null()) {
      res.error("add: all arguments must be int or null");
      return;
    }
  }
}

void add(VarArgs args, IntResult out) {
  int a, b;

  if (args[0].is_null()) {
    a = 0;
  } else {
    a = args[0].as_int();
  }

  if (args[1].is_null()) {
    b = 0;
  } else {
    b = args[1].as_int();
  }

  long long total = a + b;
  out.set(total);
}
```

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
