### PR TITLE
custom index table with data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ TAGS_sorted_by_file
 .vscode/
 
 build/
-build-debug/
+build-*/
 # Exception: libarchive needs its build/ directory for version and cmake modules
 !extra/libarchive/libarchive-3.8.1/build/
 datatool/

--- a/mysql-test/suite/villagesql/extension/vsql-index-test/r/create_index_populated.result
+++ b/mysql-test/suite/villagesql/extension/vsql-index-test/r/create_index_populated.result
@@ -1,0 +1,57 @@
+SET PERSIST vsql_allow_preview_extensions = ON;
+INSTALL EXTENSION vsql_index_test;
+# --- Empty table: standalone CREATE INDEX succeeds ---
+CREATE TABLE t_empty (id INT PRIMARY KEY, a dummy_type_vector);
+CREATE INDEX idx ON t_empty (a) USING EXTENDED(dummy_index_hnsw);
+SHOW CREATE TABLE t_empty;
+Table	Create Table
+t_empty	CREATE TABLE `t_empty` (
+  `id` int NOT NULL,
+  `a` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx` (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t_empty;
+# --- Populated table: CREATE INDEX builds over existing rows ---
+CREATE TABLE t_full (id INT PRIMARY KEY, a dummy_type_vector);
+INSERT INTO t_full VALUES (1, '[1,2,3,4]'), (2, '[5,6,7,8]'), (3, '[9,1,2,3]');
+CREATE INDEX idx ON t_full (a) USING EXTENDED(dummy_index_hnsw);
+SHOW CREATE TABLE t_full;
+Table	Create Table
+t_full	CREATE TABLE `t_full` (
+  `id` int NOT NULL,
+  `a` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx` (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+# --- Rows are intact and a plain scan still works after the build ---
+SELECT COUNT(*) FROM t_full;
+COUNT(*)
+3
+# --- Rows inserted AFTER the populated build also index (incremental) ---
+INSERT INTO t_full VALUES (4, '[4,4,4,4]');
+SELECT COUNT(*) FROM t_full;
+COUNT(*)
+4
+DROP TABLE t_full;
+# --- ALTER TABLE ADD INDEX on populated data takes the same build path ---
+CREATE TABLE t_alter (id INT PRIMARY KEY, a dummy_type_vector);
+INSERT INTO t_alter VALUES (1, '[1,2,3,4]'), (2, '[5,6,7,8]');
+ALTER TABLE t_alter ADD INDEX idx (a) USING EXTENDED(dummy_index_hnsw);
+SHOW CREATE TABLE t_alter;
+Table	Create Table
+t_alter	CREATE TABLE `t_alter` (
+  `id` int NOT NULL,
+  `a` vsql_index_test.dummy_type_vector DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `idx` (`a`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
+DROP TABLE t_alter;
+# --- Index-at-CREATE-TABLE then load still works (incremental build) ---
+CREATE TABLE t_ok (id INT PRIMARY KEY, a dummy_type_vector,
+INDEX idx (a) USING EXTENDED(dummy_index_hnsw));
+INSERT INTO t_ok VALUES (1, '[1,2,3,4]'), (2, '[5,6,7,8]');
+DROP TABLE t_ok;
+UNINSTALL EXTENSION vsql_index_test;
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/mysql-test/suite/villagesql/extension/vsql-index-test/t/create_index_populated.test
+++ b/mysql-test/suite/villagesql/extension/vsql-index-test/t/create_index_populated.test
@@ -1,0 +1,64 @@
+# CREATE INDEX ... USING EXTENDED on a table that already contains rows.
+#
+# A custom index cannot be built by the sort-merge path (a graph is not a
+# sortable key stream); like an RTree it is built row-by-row during the
+# clustered-index scan, inserting each existing row into the extension's index.
+# The build resolves each row's externally-stored column from the source table's
+# column store (fetch_for_bulk_ddl) and calls the extension insert. The scan may
+# run on multiple threads, so the inserts reach the extension index
+# concurrently, as concurrent DML inserts do at run time.
+#
+# Covers:
+#   Empty table: standalone CREATE INDEX ... USING EXTENDED succeeds.
+#   Populated table: the same CREATE INDEX succeeds, building over existing rows.
+#   The server is alive and the rows are intact afterwards.
+#
+# The debug flag lets the custom-index DDL path run in this build.
+--source include/have_debug.inc
+
+SET PERSIST vsql_allow_preview_extensions = ON;
+INSTALL EXTENSION vsql_index_test;
+--disable_query_log
+SET SESSION debug='+d,villagesql_custom_index_proceed';
+--enable_query_log
+
+--echo # --- Empty table: standalone CREATE INDEX succeeds ---
+CREATE TABLE t_empty (id INT PRIMARY KEY, a dummy_type_vector);
+CREATE INDEX idx ON t_empty (a) USING EXTENDED(dummy_index_hnsw);
+SHOW CREATE TABLE t_empty;
+DROP TABLE t_empty;
+
+--echo # --- Populated table: CREATE INDEX builds over existing rows ---
+CREATE TABLE t_full (id INT PRIMARY KEY, a dummy_type_vector);
+# Codec stubs store a fixed [0,0,0,0], so any value populates the column.
+INSERT INTO t_full VALUES (1, '[1,2,3,4]'), (2, '[5,6,7,8]'), (3, '[9,1,2,3]');
+CREATE INDEX idx ON t_full (a) USING EXTENDED(dummy_index_hnsw);
+SHOW CREATE TABLE t_full;
+
+--echo # --- Rows are intact and a plain scan still works after the build ---
+SELECT COUNT(*) FROM t_full;
+
+--echo # --- Rows inserted AFTER the populated build also index (incremental) ---
+INSERT INTO t_full VALUES (4, '[4,4,4,4]');
+SELECT COUNT(*) FROM t_full;
+DROP TABLE t_full;
+
+--echo # --- ALTER TABLE ADD INDEX on populated data takes the same build path ---
+CREATE TABLE t_alter (id INT PRIMARY KEY, a dummy_type_vector);
+INSERT INTO t_alter VALUES (1, '[1,2,3,4]'), (2, '[5,6,7,8]');
+ALTER TABLE t_alter ADD INDEX idx (a) USING EXTENDED(dummy_index_hnsw);
+SHOW CREATE TABLE t_alter;
+DROP TABLE t_alter;
+
+--echo # --- Index-at-CREATE-TABLE then load still works (incremental build) ---
+CREATE TABLE t_ok (id INT PRIMARY KEY, a dummy_type_vector,
+  INDEX idx (a) USING EXTENDED(dummy_index_hnsw));
+INSERT INTO t_ok VALUES (1, '[1,2,3,4]'), (2, '[5,6,7,8]');
+DROP TABLE t_ok;
+
+--disable_query_log
+SET SESSION debug='-d,villagesql_custom_index_proceed';
+--enable_query_log
+UNINSTALL EXTENSION vsql_index_test;
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/storage/innobase/ddl/ddl0builder.cc
+++ b/storage/innobase/ddl/ddl0builder.cc
@@ -1042,8 +1042,16 @@ dberr_t Builder::copy_row(Copy_ctx &ctx, size_t &mv_rows_added) noexcept {
 
   doc_id_t write_doc_id{};
 
+  /* VillageSQL: fetch_for_bulk_ddl resolves an extended column's stored ref to
+  its value by reading the source table's column store, so it needs the source
+  clustered index. For a clustered build that is the old table's first index;
+  for a custom (USING EXTENDED) secondary build over existing rows, the source
+  is the table being scanned -- also the old table's clustered index -- so the
+  stored col_refs in each scanned row resolve to their values. */
   const dict_index_t *old_index =
-      m_index->is_clustered() ? m_ctx.m_old_table->first_index() : nullptr;
+      (m_index->is_clustered() || m_index->custom_index != nullptr)
+          ? m_ctx.m_old_table->first_index()
+          : nullptr;
 
   for (;;) {
     // clang-format off
@@ -1353,6 +1361,54 @@ dberr_t Builder::batch_add_row(Row &row, size_t thread_id) noexcept {
   return DB_SUCCESS;
 }
 
+/* VillageSQL: a custom (USING EXTENDED) index is built by inserting each
+scanned row through the extension's insert, one row at a time -- not by the
+sort-merge path, and, unlike a spatial index, not batched. copy_row builds the
+index entry, resolving any externally stored column to its value
+(fetch_for_bulk_ddl), into the per-thread key buffer; that entry is handed to
+the extension's insert and dropped -- nothing goes to merge. The scan may run on
+multiple threads (each with its own key buffer), so the inserts reach the
+extension index concurrently, as concurrent DML inserts do at run time. Whether
+the resolution step runs is decided per field by is_extended() inside copy_row,
+so a field held in the row itself is passed through without a fetch.
+TODO(villagesql-indexing): the extension ABI offers only a single-row insert, so
+rows are inserted one at a time; a batch/bulk-insert hook (like the RTree batch
+inserter) would let an extension amortize its per-call storage overhead.
+TODO(villagesql-indexing): the ABI has no way for a custom index to declare that
+its keys are sortable, so the sort-merge path is never used here; use it for
+indexes that declare sortable keys once the ABI can express that. */
+dberr_t Builder::custom_add_row(Row &row, size_t thread_id) noexcept {
+  ut_a(is_custom_index());
+
+  auto key_buffer = m_thread_ctxs[thread_id]->m_key_buffer;
+  size_t mv_rows_added{};
+
+  Copy_ctx ctx{row, m_ctx.m_eval_table, thread_id};
+  auto err = copy_row(ctx, mv_rows_added);
+
+  if (err == DB_SUCCESS && ctx.m_n_rows_added > 0) {
+    const uint16_t n_fields =
+        static_cast<uint16_t>(dict_index_get_n_fields(m_index));
+    dfield_t *fields = key_buffer->back();
+    dtuple_t *entry = dtuple_create(key_buffer->heap(), n_fields);
+    for (uint16_t i = 0; i < n_fields; ++i) {
+      entry->fields[i] = fields[i];
+    }
+    dtuple_set_n_fields_cmp(entry, n_fields);
+    err = villagesql::innodb::Custom_index::insert(
+        m_index, m_ctx.m_trx->id, entry, /*dup_chk_only=*/false);
+    key_buffer->clear();
+  }
+
+  /* copy_row may allocate a virtual column into m_v_heap; reclaim it per row.
+  (Spatial's batch_add_row reads row.m_ptr directly and so has nothing to
+  clear.) The entry copied above points into that heap, so clear only after the
+  insert above has consumed it. */
+  clear_virtual_heap();
+
+  return err;
+}
+
 dberr_t Builder::enqueue_parsing(const dtuple_t &row) noexcept {
   ut_a(is_fts_index());
   const auto n_fields = dict_index_get_n_fields(m_index);
@@ -1615,6 +1671,10 @@ dberr_t Builder::add_row(Cursor &cursor, Row &row, size_t thread_id,
   } else if (is_spatial_index()) {
     if (!cursor.eof()) {
       err = batch_add_row(row, thread_id);
+    }
+  } else if (is_custom_index()) {
+    if (!cursor.eof()) {
+      err = custom_add_row(row, thread_id);
     }
   } else {
     err = bulk_add_row(cursor, row, thread_id, std::move(latch_release));

--- a/storage/innobase/ddl/ddl0loader.cc
+++ b/storage/innobase/ddl/ddl0loader.cc
@@ -301,8 +301,10 @@ dberr_t Loader::load() noexcept {
 
   for (auto builder : m_builders) {
     ut_a(builder->get_state() == Builder::State::ADD);
-    /* RTrees are built during the scan phase, using row by row insert. */
-    if (!builder->is_spatial_index()) {
+    /* RTrees, and VillageSQL custom (USING EXTENDED) indexes, are built during
+    the scan phase using row-by-row insert, not the sort-merge path, so they get
+    no merge task. */
+    if (!builder->is_spatial_index() && !builder->is_custom_index()) {
       builder->set_next_state();
       add_task(Task{builder});
     }

--- a/storage/innobase/handler/ha_innodb.cc
+++ b/storage/innobase/handler/ha_innodb.cc
@@ -6649,6 +6649,16 @@ ulong ha_innobase::index_flags(uint key, uint, bool) const {
     return (0);
   }
 
+  /* Report no access flags for a custom (USING EXTENDED) index, so the
+  optimizer does not build a range, ref, ordered-scan, or index-only access path
+  over it.
+  TODO(villagesql-indexing): the ABI has no way for a custom index to declare
+  which of these operations it supports, so we report none; return the
+  operations the index actually supports once the ABI can express them. */
+  if (table_share->key_info[key].custom_index_context != nullptr) {
+    return (0);
+  }
+
   ulong flags = HA_READ_NEXT | HA_READ_PREV | HA_READ_ORDER | HA_READ_RANGE |
                 HA_KEYREAD_ONLY | HA_DO_INDEX_COND_PUSHDOWN;
 

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -1303,6 +1303,23 @@ enum_alter_inplace_result ha_innobase::check_if_supported_inplace_alter(
     online = false;
   }
 
+  /* VillageSQL: a custom (USING EXTENDED) index is built with the table locked,
+  not online. Building it online would allocate a modification log and leave the
+  index in ONLINE_INDEX_CREATION; nothing replays that log into a custom index,
+  so its status would never advance to ONLINE_INDEX_COMPLETE and the commit
+  would assert. Keyed on the index itself, not on the column's storage: a custom
+  index can be built over an ordinary in-row column.
+  TODO(villagesql-indexing): allow online builds once a custom index can consume
+  a replayed DML row-log, exposed as a declared per-index capability. */
+  for (uint i = 0; i < ha_alter_info->index_add_count; i++) {
+    const KEY *key =
+        &ha_alter_info->key_info_buffer[ha_alter_info->index_add_buffer[i]];
+    if (key->custom_index_context != nullptr) {
+      online = false;
+      break;
+    }
+  }
+
   // Extended custom column storage holds DML operations during table rebuild.
   // TODO(villagesql): Enable online row logging for column storage.
   if (m_prebuilt->table->has_extended_storage) {

--- a/storage/innobase/include/ddl0impl-builder.h
+++ b/storage/innobase/include/ddl0impl-builder.h
@@ -316,6 +316,13 @@ struct Builder {
   @return DB_SUCCESS or error code. */
   [[nodiscard]] dberr_t batch_add_row(Row &row, size_t thread_id) noexcept;
 
+  /** Insert a scanned row into a custom (USING EXTENDED) index. Built row by
+  row through the extension's insert, not by the sort-merge path.
+  @param[in,out] row            Row to add.
+  @param[in] thread_id          ID of current thread.
+  @return DB_SUCCESS or error code. */
+  [[nodiscard]] dberr_t custom_add_row(Row &row, size_t thread_id) noexcept;
+
   /** Add a row to the merge buffer.
   @param[in,out]        cursor        Current scan cursor.
   @param[in,out] row            Row to add.

--- a/storage/innobase/villagesql/custom_column.cc
+++ b/storage/innobase/villagesql/custom_column.cc
@@ -1043,12 +1043,18 @@ dberr_t Custom_column::fetch_for_bulk_ddl(const dict_index_t *new_index,
     return DB_SUCCESS;
   };
 
-  // No col_map: old and new tables are the same. Position i is valid in both
-  // old and new index; fetch each extended field at its current position.
+  // No col_map: old and new tables are the same. fields belongs to new_index,
+  // so field i's column is new_index->get_field(i)->col -- not old_index's,
+  // whose field order differs (e.g. a secondary index built over an existing
+  // clustered index puts its key column at position 0 while the clustered
+  // index has the primary key there). Using the wrong index's column resolves
+  // fields[i] against a different column, so an extended value is fetched from
+  // the wrong column store or (when that column is not extended) left as its
+  // bare reference.
   if (col_map == nullptr) {
     for (uint32_t i = 0; i < n_fields; i++) {
       if (!fields[i].is_extended()) continue;
-      auto err = fetch_at(i, old_index->get_field(i)->col);
+      auto err = fetch_at(i, new_index->get_field(i)->col);
       if (err != DB_SUCCESS) return err;
     }
     return DB_SUCCESS;


### PR DESCRIPTION
create table with data in the table

limits to online=false

also includes one fix so that optimizer does not choose a custom index for the simple select count(*) path