### PR TITLE
build: compile build info into mysqld instead of sql_main

### DIFF
--- a/mysql-test/suite/sys_vars/r/villagesql_build_info_basic.result
+++ b/mysql-test/suite/sys_vars/r/villagesql_build_info_basic.result
@@ -7,6 +7,11 @@ villagesql_build_info	{"git_sha":"SHA","is_dirty":DIRTY,"files_added":N,"files_d
 SELECT @@GLOBAL.villagesql_build_info AS build_info;
 build_info
 {"git_sha":"SHA","is_dirty":DIRTY,"files_added":N,"files_deleted":N,"files_modified":N,"build_timestamp":"TS","build_host":"HOST","build_os":"OS","build_arch":"ARCH"}
+# Test 1b: Verify the metadata was actually generated into the binary
+SELECT @@GLOBAL.villagesql_build_info
+REGEXP '"build_os":"[^"]+","build_arch":"[^"]+"' AS is_generated;
+is_generated
+1
 # Test 2: Verify the variable is READ_ONLY
 SET GLOBAL villagesql_build_info = '999';
 ERROR HY000: Variable 'villagesql_build_info' is a read only variable

--- a/mysql-test/suite/sys_vars/t/villagesql_build_info_basic.test
+++ b/mysql-test/suite/sys_vars/t/villagesql_build_info_basic.test
@@ -6,12 +6,23 @@
 --echo # Test 1: Check that the variable exists and is readable
 # The value is build/machine specific (git SHA, file counts, timestamp, host,
 # OS, arch), so redact every field to a placeholder and assert only the JSON
-# structure and keys.
---replace_regex /"git_sha":"[^"]*"/"git_sha":"SHA"/ /"is_dirty":(true|false)/"is_dirty":DIRTY/ /"files_added":[0-9]+/"files_added":N/ /"files_deleted":[0-9]+/"files_deleted":N/ /"files_modified":[0-9]+/"files_modified":N/ /"build_timestamp":"[^"]*"/"build_timestamp":"TS"/ /"build_host":"[^"]*"/"build_host":"HOST"/ /"build_os":"[^"]*"/"build_os":"OS"/ /"build_arch":"[^"]*"/"build_arch":"ARCH"/
+# structure and keys. git_sha is redacted only when it is a full 40-char SHA or
+# the documented no-git fallback, so a garbage value shows up as a diff rather
+# than being silently masked.
+--replace_regex /"git_sha":"([0-9a-f]{40}|unknown)"/"git_sha":"SHA"/ /"is_dirty":(true|false)/"is_dirty":DIRTY/ /"files_added":[0-9]+/"files_added":N/ /"files_deleted":[0-9]+/"files_deleted":N/ /"files_modified":[0-9]+/"files_modified":N/ /"build_timestamp":"[^"]*"/"build_timestamp":"TS"/ /"build_host":"[^"]*"/"build_host":"HOST"/ /"build_os":"[^"]*"/"build_os":"OS"/ /"build_arch":"[^"]*"/"build_arch":"ARCH"/
 SHOW VARIABLES LIKE 'villagesql_build_info';
 
---replace_regex /"git_sha":"[^"]*"/"git_sha":"SHA"/ /"is_dirty":(true|false)/"is_dirty":DIRTY/ /"files_added":[0-9]+/"files_added":N/ /"files_deleted":[0-9]+/"files_deleted":N/ /"files_modified":[0-9]+/"files_modified":N/ /"build_timestamp":"[^"]*"/"build_timestamp":"TS"/ /"build_host":"[^"]*"/"build_host":"HOST"/ /"build_os":"[^"]*"/"build_os":"OS"/ /"build_arch":"[^"]*"/"build_arch":"ARCH"/
+--replace_regex /"git_sha":"([0-9a-f]{40}|unknown)"/"git_sha":"SHA"/ /"is_dirty":(true|false)/"is_dirty":DIRTY/ /"files_added":[0-9]+/"files_added":N/ /"files_deleted":[0-9]+/"files_deleted":N/ /"files_modified":[0-9]+/"files_modified":N/ /"build_timestamp":"[^"]*"/"build_timestamp":"TS"/ /"build_host":"[^"]*"/"build_host":"HOST"/ /"build_os":"[^"]*"/"build_os":"OS"/ /"build_arch":"[^"]*"/"build_arch":"ARCH"/
 SELECT @@GLOBAL.villagesql_build_info AS build_info;
+
+--echo # Test 1b: Verify the metadata was actually generated into the binary
+# Redacting every field above means a server built without the generator step
+# would still pass Test 1, so assert generation directly. build_os and
+# build_arch come from CMake and are always populated; unlike git_sha they do
+# not depend on git being available, and unlike build_timestamp/build_host they
+# are not blanked for production builds, so this holds in every configuration.
+SELECT @@GLOBAL.villagesql_build_info
+       REGEXP '"build_os":"[^"]+","build_arch":"[^"]+"' AS is_generated;
 
 --echo # Test 2: Verify the variable is READ_ONLY
 --error ER_INCORRECT_GLOBAL_LOCAL_VAR

--- a/sql/CMakeLists.txt
+++ b/sql/CMakeLists.txt
@@ -1126,9 +1126,20 @@ ELSE()
   SET(MYSQLD_SOURCE main.cc)
 ENDIF()
 
+# VillageSQL build metadata is compiled into mysqld rather than sql_main, so
+# that regenerating it on every build relinks mysqld instead of every target
+# that links sql_main. See villagesql/cmake/build_info.cmake.
+INCLUDE(${CMAKE_SOURCE_DIR}/villagesql/cmake/build_info.cmake)
+VSQL_BUILD_INFO_SOURCES(VSQL_BUILD_INFO_SOURCES)
+LIST(APPEND MYSQLD_SOURCE ${VSQL_BUILD_INFO_SOURCES})
+
 MYSQL_ADD_EXECUTABLE(mysqld
   ${MYSQLD_SOURCE} DESTINATION ${INSTALL_SBINDIR} COMPONENT Server
   )
+ADD_DEPENDENCIES(mysqld villagesql_build_info_gen)
+# Plain signature to match the existing TARGET_LINK_LIBRARIES(mysqld ...)
+# calls in this file; mixing keyword and plain forms on one target is an error.
+TARGET_LINK_LIBRARIES(mysqld extra::rapidjson)
 
 # With Ninja, link huge executables one-by-one.
 IF(WIN32)

--- a/villagesql/cmake/build_info.cmake
+++ b/villagesql/cmake/build_info.cmake
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 VillageSQL Contributors
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+# Sources carrying VillageSQL build metadata (git SHA, work-tree file counts,
+# build timestamp, host).
+#
+# These compile directly into the mysqld executable rather than into sql_main,
+# because the generated source changes on every build (the timestamp is always
+# fresh). In sql_main it would drag every one of the ~75 targets that link
+# sql_main into a relink; in mysqld it costs mysqld's own link plus, on macOS,
+# the plugins that name mysqld via -bundle_loader. Measured on a warm debug
+# tree: 21.9s versus 13.4s, against an 8.4s do-nothing floor.
+#
+# The sysvar that reads the metadata moves with the data, so that nothing in
+# sql_main references GetBuildInfo(). Otherwise sql_main would carry an
+# undefined symbol and every binary linking it would fail to link --
+# server_unittest_library is a shared library, so it must resolve everything.
+#
+# Sets ${out_var} to the sources to add to the mysqld executable, and defines
+# the villagesql_build_info_gen target they depend on.
+MACRO(VSQL_BUILD_INFO_SOURCES out_var)
+  SET(_vsql_build_info_cc ${CMAKE_BINARY_DIR}/villagesql/common/build_info.cc)
+
+  # Production releases (no pre-release suffix) blank the volatile,
+  # non-reproducible fields (build timestamp and host) so release binaries are
+  # reproducible; dev builds keep them. The single template is shared by both.
+  IF(VSQL_HAS_PRE_RELEASE)
+    SET(_vsql_build_info_production OFF)
+  ELSE()
+    SET(_vsql_build_info_production ON)
+  ENDIF()
+
+  # The generator target has no dependencies, so it is always out of date and
+  # every build refreshes the timestamp. Callers include the stable, committed
+  # build_info.h, so only the generated source recompiles.
+  ADD_CUSTOM_TARGET(villagesql_build_info_gen
+    BYPRODUCTS ${_vsql_build_info_cc}
+    COMMAND ${CMAKE_COMMAND}
+      -DSRC_DIR=${CMAKE_SOURCE_DIR}
+      -DIN_FILE=${CMAKE_SOURCE_DIR}/villagesql/common/build_info.cc.in
+      -DOUT_FILE=${_vsql_build_info_cc}
+      -DBUILD_OS=${CMAKE_HOST_SYSTEM}
+      -DBUILD_ARCH=${CMAKE_HOST_SYSTEM_PROCESSOR}
+      -DPRODUCTION_BUILD=${_vsql_build_info_production}
+      -P ${CMAKE_SOURCE_DIR}/villagesql/cmake/gen_build_info.cmake
+    COMMENT "Generating VillageSQL build info"
+    VERBATIM)
+
+  SET_SOURCE_FILES_PROPERTIES(${_vsql_build_info_cc} PROPERTIES GENERATED TRUE)
+
+  SET(${out_var}
+    ${_vsql_build_info_cc}
+    ${CMAKE_SOURCE_DIR}/villagesql/sql/build_info_sysvar.cc)
+ENDMACRO()

--- a/villagesql/common/CMakeLists.txt
+++ b/villagesql/common/CMakeLists.txt
@@ -17,38 +17,8 @@ SET(VILLAGESQL_COMMON_SOURCES
   semver.cc
 )
 
-# Generated build metadata (git SHA, work-tree file counts, build timestamp,
-# host). The generator target is always considered out of date, so every build
-# refreshes the timestamp. Only the generated build_info.cc recompiles: callers
-# include the stable, committed build_info.h, so they are unaffected.
-SET(VILLAGESQL_BUILD_INFO_CC ${CMAKE_CURRENT_BINARY_DIR}/build_info.cc)
-
-# Production releases (no pre-release suffix) blank the volatile,
-# non-reproducible fields (build timestamp and host) so release binaries are
-# reproducible; dev builds keep them. The single template is shared by both.
-if(VSQL_HAS_PRE_RELEASE)
-  set(VSQL_BUILD_INFO_PRODUCTION OFF)
-else()
-  set(VSQL_BUILD_INFO_PRODUCTION ON)
-endif()
-
-ADD_CUSTOM_TARGET(villagesql_build_info_gen
-  BYPRODUCTS ${VILLAGESQL_BUILD_INFO_CC}
-  COMMAND ${CMAKE_COMMAND}
-    -DSRC_DIR=${CMAKE_SOURCE_DIR}
-    -DIN_FILE=${CMAKE_CURRENT_SOURCE_DIR}/build_info.cc.in
-    -DOUT_FILE=${VILLAGESQL_BUILD_INFO_CC}
-    -DBUILD_OS=${CMAKE_HOST_SYSTEM}
-    -DBUILD_ARCH=${CMAKE_HOST_SYSTEM_PROCESSOR}
-    -DPRODUCTION_BUILD=${VSQL_BUILD_INFO_PRODUCTION}
-    -P ${CMAKE_SOURCE_DIR}/villagesql/cmake/gen_build_info.cmake
-  COMMENT "Generating VillageSQL build info"
-  VERBATIM)
-
-SET_SOURCE_FILES_PROPERTIES(${VILLAGESQL_BUILD_INFO_CC} PROPERTIES GENERATED TRUE)
-
-# Generated version header. Like the build info above, the generator target is
-# always considered out of date, so every build regenerates version.h from the
+# Generated version header. The generator target is always considered out of
+# date, so every build regenerates version.h from the
 # current VSQL_VERSION in the source tree. configure_file() only rewrites the
 # header when its content changes, so the files that include it (see
 # villagesql_version_gen dependents) recompile only when the version changes.
@@ -71,10 +41,7 @@ ADD_CUSTOM_TARGET(villagesql_version_gen
 
 # Object library for compilation into sql_main (avoids circular dependencies)
 ADD_LIBRARY(villagesql_common OBJECT
-  ${VILLAGESQL_COMMON_SOURCES}
-  ${VILLAGESQL_BUILD_INFO_CC})
-
-ADD_DEPENDENCIES(villagesql_common villagesql_build_info_gen)
+  ${VILLAGESQL_COMMON_SOURCES})
 
 TARGET_LINK_LIBRARIES(villagesql_common PRIVATE extra::rapidjson)
 

--- a/villagesql/sql/build_info_sysvar.cc
+++ b/villagesql/sql/build_info_sysvar.cc
@@ -1,0 +1,92 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+// The @@villagesql_build_info sysvar. This lives here, compiled straight into
+// the mysqld executable, rather than alongside the other VillageSQL sysvars in
+// initialize.cc, because it is the only reader of GetBuildInfo(). The build
+// metadata it reads is regenerated on every build, so keeping both out of
+// sql_main means refreshing it relinks mysqld instead of the ~75 targets that
+// link sql_main. See villagesql/cmake/build_info.cmake.
+//
+// Registration still works from an executable source: sysvars register through
+// static initialization of a file-scope object, and an object compiled
+// directly into the executable is always linked in (unlike an archive member,
+// which is pulled in only when something references it).
+
+#include "my_rapidjson_size_t.h"  // IWYU pragma: keep
+
+#include <rapidjson/stringbuffer.h>
+#include <rapidjson/writer.h>
+
+#include <algorithm>
+#include <string_view>
+
+#include "sql/sql_class.h"
+#include "sql/sys_vars.h"
+#include "villagesql/include/build_info.h"
+#include "villagesql/include/error.h"
+
+namespace villagesql {
+
+class Sys_var_villagesql_build_info : public Sys_var_charptr_func {
+ public:
+  Sys_var_villagesql_build_info(const char *name_arg, const char *comment_arg)
+      : Sys_var_charptr_func(name_arg, comment_arg, GLOBAL) {}
+  const uchar *global_value_ptr(THD *thd, std::string_view) override;
+};
+
+const uchar *Sys_var_villagesql_build_info::global_value_ptr(THD *thd,
+                                                             std::string_view) {
+  const BuildInfo &info = villagesql::GetBuildInfo();
+
+  rapidjson::StringBuffer sb;
+  rapidjson::Writer<rapidjson::StringBuffer> w(sb);
+  w.StartObject();
+  w.Key("git_sha");
+  w.String(info.git_sha);
+  w.Key("is_dirty");
+  w.Bool(info.is_dirty());
+  w.Key("files_added");
+  w.Int(info.files_added);
+  w.Key("files_deleted");
+  w.Int(info.files_deleted);
+  w.Key("files_modified");
+  w.Int(info.files_modified);
+  w.Key("build_timestamp");
+  w.String(info.build_timestamp);
+  w.Key("build_host");
+  w.String(info.build_host);
+  w.Key("build_os");
+  w.String(info.build_os);
+  w.Key("build_arch");
+  w.String(info.build_arch);
+  w.EndObject();
+
+  size_t buf_size = sb.GetSize() + 1;
+  char *buf = (char *)thd->alloc(buf_size);
+  if (should_assert_if_null(buf))
+    my_error(ER_OUTOFMEMORY, MYF(ME_FATALERROR), buf_size);
+  else
+    std::copy(sb.GetString(), sb.GetString() + sb.GetSize() + 1, buf);
+  return (uchar *)buf;
+}
+
+static Sys_var_villagesql_build_info Sys_villagesql_build_info(
+    "villagesql_build_info",
+    "VillageSQL build metadata (JSON: git SHA, work-tree file counts, build "
+    "timestamp/host/OS/arch).");
+
+}  // namespace villagesql

--- a/villagesql/sql/initialize.cc
+++ b/villagesql/sql/initialize.cc
@@ -33,7 +33,6 @@
 #include "sql/thd_raii.h"
 #include "sql/transaction.h"
 #include "string_with_len.h"
-#include "villagesql/include/build_info.h"
 #include "villagesql/include/error.h"
 #include "villagesql/include/version.h"
 #include "villagesql/schema/schema_manager.h"
@@ -94,54 +93,6 @@ const uchar *Sys_var_villagesql_server_version::global_value_ptr(
 
 static Sys_var_villagesql_server_version Sys_villagesql_server_version(
     "villagesql_server_version", "VillageSQL server version.");
-
-class Sys_var_villagesql_build_info : public Sys_var_charptr_func {
- public:
-  Sys_var_villagesql_build_info(const char *name_arg, const char *comment_arg)
-      : Sys_var_charptr_func(name_arg, comment_arg, GLOBAL) {}
-  const uchar *global_value_ptr(THD *thd, std::string_view) override;
-};
-
-const uchar *Sys_var_villagesql_build_info::global_value_ptr(THD *thd,
-                                                             std::string_view) {
-  const BuildInfo &info = villagesql::GetBuildInfo();
-
-  rapidjson::StringBuffer sb;
-  rapidjson::Writer<rapidjson::StringBuffer> w(sb);
-  w.StartObject();
-  w.Key("git_sha");
-  w.String(info.git_sha);
-  w.Key("is_dirty");
-  w.Bool(info.is_dirty());
-  w.Key("files_added");
-  w.Int(info.files_added);
-  w.Key("files_deleted");
-  w.Int(info.files_deleted);
-  w.Key("files_modified");
-  w.Int(info.files_modified);
-  w.Key("build_timestamp");
-  w.String(info.build_timestamp);
-  w.Key("build_host");
-  w.String(info.build_host);
-  w.Key("build_os");
-  w.String(info.build_os);
-  w.Key("build_arch");
-  w.String(info.build_arch);
-  w.EndObject();
-
-  size_t buf_size = sb.GetSize() + 1;
-  char *buf = (char *)thd->alloc(buf_size);
-  if (should_assert_if_null(buf))
-    my_error(ER_OUTOFMEMORY, MYF(ME_FATALERROR), buf_size);
-  else
-    std::copy(sb.GetString(), sb.GetString() + sb.GetSize() + 1, buf);
-  return (uchar *)buf;
-}
-
-static Sys_var_villagesql_build_info Sys_villagesql_build_info(
-    "villagesql_build_info",
-    "VillageSQL build metadata (JSON: git SHA, work-tree file counts, build "
-    "timestamp/host/OS/arch).");
 
 static Sys_var_uint Sys_villagesql_vef_server_protocol(
     "villagesql_vef_server_protocol",


### PR DESCRIPTION
Build info changing on every build (because of timestamp) caused many
relinks. Move it higher in the tree, to reduce the number of relinks.

Before: villagesql_common -> sql_main -> libsql_main.a (75 links)
After: mysqld -> 59 links on macOS; 1 on Linux.

Saves 5-10s on no-change build on my mac.

1 wrinkle: sysvar registration. Now our static initialization is via
a file-scope object compiled directly into the executable (so linker
won't drop it.)

Also, tighten build-info test. It redacted every field so would have passed
against a server with no metadata at all.