### PR TITLE
Allow multiple labels

### DIFF
--- a/.github/workflows/validate-labels.yml
+++ b/.github/workflows/validate-labels.yml
@@ -17,12 +17,12 @@ jobs:
           uses: agilepathway/label-checker@c3d16ad512e7cea5961df85ff2486bb774caf3c5
           with:
             prefix_mode: true
-            one_of: "area"
+            any_of: "area"
             repo_token: ${{ secrets.GITHUB_TOKEN }}
 
         - name: Validate Kind
           uses: agilepathway/label-checker@c3d16ad512e7cea5961df85ff2486bb774caf3c5
           with:
             prefix_mode: true
-            one_of: "kind"
+            any_of: "kind"
             repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

The label check test fails if more than one kind label is applied. This allows for multiple.

## Related Issue

N/A

## How was this tested?

Test in personal private repo.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [ ] I have added or updated tests as appropriate
- [ ] My changes maintain compatibility with upstream MySQL 8.4
