### PR TITLE
sdk: use version from build

### DIFF
--- a/mysql-test/suite/villagesql/sdk/r/sdk_version.result
+++ b/mysql-test/suite/villagesql/sdk/r/sdk_version.result
@@ -1,0 +1,18 @@
+# SDK Version Test
+Found SDK tarball
+# Extract SDK tarball
+# === Stable ABI (SDK include/) ===
+# Build the template against the stable ABI
+INSTALL EXTENSION my_extension;
+SELECT JSON_UNQUOTE(JSON_EXTRACT(REGISTRATION_JSON, '$.sdk_version')) INTO @reported_sdk_version
+FROM INFORMATION_SCHEMA.EXTENSION_REGISTRATION WHERE EXTENSION_NAME = 'my_extension';
+# OK (stable ABI): extension sdk_version matches the server release version
+UNINSTALL EXTENSION my_extension;
+# === Dev ABI (SDK include-dev/) ===
+# Build the template against the dev ABI
+INSTALL EXTENSION my_extension;
+SELECT JSON_UNQUOTE(JSON_EXTRACT(REGISTRATION_JSON, '$.sdk_version')) INTO @reported_sdk_version
+FROM INFORMATION_SCHEMA.EXTENSION_REGISTRATION WHERE EXTENSION_NAME = 'my_extension';
+# OK (dev ABI): extension sdk_version matches the server release version
+UNINSTALL EXTENSION my_extension;
+# Cleanup

--- a/mysql-test/suite/villagesql/sdk/t/sdk_version.inc
+++ b/mysql-test/suite/villagesql/sdk/t/sdk_version.inc
@@ -1,0 +1,49 @@
+# Per-ABI helper for sdk_version.test.
+#
+# Builds the shipped SDK template against one ABI of the extracted SDK, installs
+# it, asserts the extension's reported sdk_version matches the server release
+# version, then uninstalls and removes the VEB.
+#
+# Caller sets before sourcing:
+#   $sdk_dir       - extracted SDK root (contains template/, include/, ...)
+#   $veb_dir       - server VEB directory
+#   $abi_label     - human label for output ("stable" / "dev")
+#   $abi_build_dir - build subdirectory name (distinct per ABI)
+#   $abi_cmake_arg - extra cmake args ("" for stable, -DVSQL_USE_DEV_ABI=ON for dev)
+
+--echo # Build the template against the $abi_label ABI
+--exec rm -rf $sdk_dir/template/$abi_build_dir
+--exec mkdir -p $sdk_dir/template/$abi_build_dir
+# unset LD_PRELOAD so the toolchain sub-build does not run under the LD_PRELOAD'd
+# ASan runtime on sanitizer builds; otherwise the uninstrumented system gcc trips
+# LeakSanitizer on its own allocations and fails the build (see
+# include/villagesql/create_extension_sdk.inc for the full explanation).
+--exec cd $sdk_dir/template/$abi_build_dir && unset LD_PRELOAD && cmake $abi_cmake_arg .. > cmake_output.txt 2>&1
+--exec cd $sdk_dir/template/$abi_build_dir && unset LD_PRELOAD && make > make_output.txt 2>&1
+
+--file_exists $sdk_dir/template/$abi_build_dir/my_extension.veb
+--exec cp $sdk_dir/template/$abi_build_dir/my_extension.veb $veb_dir/
+
+INSTALL EXTENSION my_extension;
+
+# The template is built from this same server build's SDK, so it must report
+# this build's exact version (including any -dev pre-release) as its sdk_version.
+# The only representational difference is the code-base prefix that
+# villagesql_server_version carries (e.g. "mysql-8.4_"), which the SDK's
+# vef_version_t has no field for, so we strip just that prefix and compare the
+# remainder exactly.
+SELECT JSON_UNQUOTE(JSON_EXTRACT(REGISTRATION_JSON, '$.sdk_version')) INTO @reported_sdk_version
+FROM INFORMATION_SCHEMA.EXTENSION_REGISTRATION WHERE EXTENSION_NAME = 'my_extension';
+--let $reported_sdk_version = `SELECT @reported_sdk_version`
+--let $release_version = `SELECT SUBSTRING_INDEX(@@GLOBAL.villagesql_server_version, '_', -1)`
+if ($release_version != $reported_sdk_version)
+{
+  # --die does not interpolate mysqltest variables, so surface the mismatched
+  # values with --echo (which does) before failing with a static message.
+  --echo # FAIL ($abi_label ABI): extension reported sdk_version '$reported_sdk_version' but the server release version is '$release_version'
+  --die Extension sdk_version does not match the server release version it was built from
+}
+--echo # OK ($abi_label ABI): extension sdk_version matches the server release version
+
+UNINSTALL EXTENSION my_extension;
+--exec rm -f $veb_dir/my_extension.veb

--- a/mysql-test/suite/villagesql/sdk/t/sdk_version.test
+++ b/mysql-test/suite/villagesql/sdk/t/sdk_version.test
@@ -1,0 +1,50 @@
+# SDK Version Test
+#
+# Builds the shipped SDK template against the freshly-built SDK — once for each
+# ABI (stable include/ and dev include-dev/) — and verifies that the extension
+# reports this build's version as its sdk_version.
+#
+# The SDK is built from the same server build, so an extension compiled against
+# it must report the server's release version. This catches a stale/frozen
+# sdk_version being shipped in either ABI of the SDK package.
+#
+# This test requires the SDK tarball to be built first (make sdk).
+# Requires: cmake in PATH, C++ compiler in PATH
+
+--echo # SDK Version Test
+
+# @@villagesql_server_version includes the code base as a prefix, separated from
+# the abbreviated version by an underscore (e.g. "mysql-8.4_0.0.5"); the SDK
+# directory name uses the abbreviated version.
+--let $veb_dir = `SELECT @@veb_dir`
+--let $build_dir = `SELECT @@basedir`
+--let $sdk_abbr = `SELECT SUBSTRING_INDEX(@@villagesql_server_version, '_', -1)`
+--let $test_dir = $MYSQLTEST_VARDIR/tmp/sdk_version_test
+--let $sdk_dir_name = villagesql-extension-sdk-$sdk_abbr
+--let $sdk_tarball = $build_dir/$sdk_dir_name.tar.gz
+--let $sdk_dir = $test_dir/$sdk_dir_name
+
+--exec test -f "$sdk_tarball" || (echo "SDK tarball not found. Run 'make sdk' first." && echo "Looked for: $sdk_tarball" && exit 1)
+--echo Found SDK tarball
+
+--exec rm -rf $test_dir
+--exec mkdir -p $test_dir
+--echo # Extract SDK tarball
+# unset LD_PRELOAD so tar does not run under the LD_PRELOAD'd ASan runtime on
+# sanitizer builds (see include/villagesql/create_extension_sdk.inc).
+--exec unset LD_PRELOAD && tar -xzf $sdk_tarball -C $test_dir
+
+--echo # === Stable ABI (SDK include/) ===
+--let $abi_label = stable
+--let $abi_build_dir = build_stable
+--let $abi_cmake_arg =
+--source sdk_version.inc
+
+--echo # === Dev ABI (SDK include-dev/) ===
+--let $abi_label = dev
+--let $abi_build_dir = build_dev
+--let $abi_cmake_arg = -DVSQL_USE_DEV_ABI=ON
+--source sdk_version.inc
+
+--echo # Cleanup
+--exec rm -rf $test_dir

--- a/villagesql/CMakeLists.txt
+++ b/villagesql/CMakeLists.txt
@@ -107,6 +107,16 @@ add_custom_command(
     "${STABLE_SDK_DIR}/include/villagesql"
     "${SDK_STAGING_DIR}/include/villagesql"
 
+  # Overwrite the snapshot's frozen sdk_version.h with one generated from the
+  # release version (like villagesql_config's @SDK_VERSION@), so an extension
+  # built against the shipped SDK reports the version it was actually built from
+  # rather than the value pinned in the frozen v3 snapshot. (The frozen value is
+  # only seen when building directly against stable_sdk/v3, as the abi_v3 tests
+  # do.)
+  COMMAND ${CMAKE_COMMAND} -E copy
+    "${CMAKE_BINARY_DIR}/sdk/include/villagesql/sdk_version.h"
+    "${SDK_STAGING_DIR}/include/villagesql/"
+
   # Copy dev (unstable) SDK headers (all subdirectories picked up automatically)
   COMMAND ${CMAKE_COMMAND} -E copy_directory
     "${CMAKE_CURRENT_SOURCE_DIR}/sdk/include/villagesql"

--- a/villagesql/cmake/VsqlExtension.cmake
+++ b/villagesql/cmake/VsqlExtension.cmake
@@ -108,6 +108,10 @@ endfunction()
 macro(vsql_add_test_extension DIR_NAME VEB_NAME)
   cmake_parse_arguments(_ext "MYSQL_HEADERS" "ABI;VERSION" "" ${ARGN})
 
+  # v3 fixtures build against the frozen v3 ABI snapshot directly (its headers
+  # plus its frozen sdk_version.h), so they exercise the v3 ABI as a pinned
+  # extension sees it. Everything else builds against the current dev ABI
+  # (include-dev/ from the built SDK).
   if(_ext_ABI STREQUAL "v3")
     set(_vsql_test_ext_include "${CMAKE_SOURCE_DIR}/villagesql/stable_sdk/v3/include")
   else()

--- a/villagesql/sdk/README.md
+++ b/villagesql/sdk/README.md
@@ -93,6 +93,20 @@ diff as the reference for the full set of edit sites.
 **1. Freeze the snapshot.** Stop changing `villagesql/sdk/` and copy its current
    contents to `villagesql/stable_sdk/v{M+1}/` (the new odd/stable snapshot).
    Even versions are never snapshotted, which is why there is no `stable_sdk/v2`.
+   Give the snapshot a frozen `sdk_version.h` pinned to the version at which the
+   protocol was stabilized (the same way `stable_sdk/v1` hard-codes its version
+   in the `VEF_GENERATE_ENTRY_POINTS` macro). This is the value an extension
+   sees when it builds directly against the frozen snapshot — which is exactly
+   what the `abi_v{N}` compliance tests do, so they exercise the ABI as a pinned
+   extension would. Do **not** copy the dev `sdk_version.h.in` template into the
+   snapshot.
+
+   The shipped SDK does not use that frozen value: when the SDK package is
+   built, packaging overwrites `sdk_version.h` in both `include/` and
+   `include-dev/` with one generated from the current release version (like
+   `villagesql_config`'s `@SDK_VERSION@`), so an extension built against the SDK
+   reports the release it was actually built from. The `sdk` test suite verifies
+   this by building against the freshly-built SDK package.
 
 **2. Add both enum values** to `vef_protocol_t` in
    `villagesql/sdk/include/villagesql/abi/types.h`: `VEF_PROTOCOL_{M+1}` (now

--- a/villagesql/stable_sdk/v3/include/villagesql/sdk_version.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/sdk_version.h
@@ -14,7 +14,15 @@
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
 // Frozen SDK version for the stable v3 ABI snapshot.
-//
+
+#ifndef VILLAGESQL_SDK_SDK_VERSION_H
+#define VILLAGESQL_SDK_SDK_VERSION_H
+
+#include <villagesql/abi/types.h>
+
+namespace villagesql {
+namespace detail {
+
 // This is the version reported by an extension built directly against the
 // frozen v3 headers (as the abi_v3 compatibility tests do), pinned to the
 // VillageSQL version at which protocol v3 was stabilized. It intentionally
@@ -25,18 +33,7 @@
 // header is overwritten with one generated from the current release version
 // (see villagesql/sdk/include/villagesql/sdk_version.h.in and the packaging in
 // villagesql/CMakeLists.txt), so extensions built against the SDK report the
-// release they were built from. See villagesql/sdk/COMPATIBILITY_TESTING.md.
-
-#ifndef VILLAGESQL_SDK_SDK_VERSION_H
-#define VILLAGESQL_SDK_SDK_VERSION_H
-
-#include <villagesql/abi/types.h>
-
-namespace villagesql {
-namespace detail {
-
-// SDK version reported to the server during vef_register(). Frozen at the
-// VillageSQL version when protocol v3 was stabilized.
+// release they were built from.
 constexpr vef_version_t kSdkVersion = {0, 0, 4, "only-for-tests"};
 
 }  // namespace detail

--- a/villagesql/stable_sdk/v3/include/villagesql/sdk_version.h
+++ b/villagesql/stable_sdk/v3/include/villagesql/sdk_version.h
@@ -13,8 +13,19 @@
 // You should have received a copy of the GNU General Public License
 // along with this program; if not, see <https://www.gnu.org/licenses/>.
 
-// Frozen SDK version for the stable v3 SDK snapshot.
-// Generated at stabilization time; do not edit.
+// Frozen SDK version for the stable v3 ABI snapshot.
+//
+// This is the version reported by an extension built directly against the
+// frozen v3 headers (as the abi_v3 compatibility tests do), pinned to the
+// VillageSQL version at which protocol v3 was stabilized. It intentionally
+// stays fixed with the snapshot, the same way stable_sdk/v1 hard-codes its
+// version in the VEF_GENERATE_ENTRY_POINTS macro.
+//
+// The shipped SDK does NOT use this value: when the SDK package is built, this
+// header is overwritten with one generated from the current release version
+// (see villagesql/sdk/include/villagesql/sdk_version.h.in and the packaging in
+// villagesql/CMakeLists.txt), so extensions built against the SDK report the
+// release they were built from. See villagesql/sdk/COMPATIBILITY_TESTING.md.
 
 #ifndef VILLAGESQL_SDK_SDK_VERSION_H
 #define VILLAGESQL_SDK_SDK_VERSION_H
@@ -24,9 +35,9 @@
 namespace villagesql {
 namespace detail {
 
-// SDK version reported to the server during vef_register(). Frozen at
-// the VillageSQL version when protocol v3 was stabilized.
-constexpr vef_version_t kSdkVersion = {0, 0, 4, nullptr};
+// SDK version reported to the server during vef_register(). Frozen at the
+// VillageSQL version when protocol v3 was stabilized.
+constexpr vef_version_t kSdkVersion = {0, 0, 4, "only-for-tests"};
 
 }  // namespace detail
 }  // namespace villagesql


### PR DESCRIPTION
## Description

Use the server build version to generate the sdk version when building the SDK, add a test to validate that this works.

## Related Issue

Closes: #1094 

## How was this tested?

This PR is two commits:
"sdk: add test of SDK version string" - this fails but lets us see the error message
"sdk: fix the version" - fixes it.

These will be squashes as part of this commit.

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
