### PR TITLE
TODOs: reclassify todos

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,7 +173,7 @@ For additional options, see `./scripts/villint.sh --help`.
 
 ## Architecture Overview
 
-TODO(villagesql-ga): Add VillageSQL-specific architecture documentation covering:
+TODO(villagesql-general): Add VillageSQL-specific architecture documentation covering:
 - Extension framework architecture
 - Custom type system design
 - Victionary caching layer
@@ -212,16 +212,19 @@ When adding VillageSQL features:
 - For header guards, use `// HEADER_GUARD_NAME_H` at the `#endif`
 - All todos in the code that we add should look like `// TODO(villagesql): <thing to do>`
   - Use subareas for categorization:
+    - `TODO(villagesql-back-to-mysql):` - Required for downgrade safety / vanilla MySQL
     - `TODO(villagesql-beta):` - Must handle before Beta Release (0.1.0)
-    - `TODO(villagesql-preview):` - Related to preview capability system
-    - `TODO(villagesql-ga):` - Must handle before General Availability (1.0.0)
-    - `TODO(villagesql-performance):` - Performance optimization possibility
-    - `TODO(villagesql-rebase):` - Check during MySQL version rebases
+    - `TODO(villagesql-blob):` - Needed to support blobs as underlying storage for custom types
+    - `TODO(villagesql-charset):` - Potential CHARSET_INFO issues/inconsistencies
     - `TODO(villagesql-crash):` - Known crash
-    - `TODO(villagesql-windows):` - Known problems with supporting Windows
-    - `TODO(villagesql-indexing):` - Related to indexing work
-    - `TODO(villagesql-back-to-mysql):` - Required for downgrade safety / vanilla MySQL compatibility
+    - `TODO(villagesql-general):` - Must handle before General Availability (1.0.0)
+    - `TODO(villagesql-indexing):` - Related to custom indexing work
+    - `TODO(villagesql-performance):` - Performance optimization possibility
+    - `TODO(villagesql-preview):` - Related to preview capability system
+    - `TODO(villagesql-production):` - Must handle for "production readiness"
+    - `TODO(villagesql-rebase):` - Check during MySQL version rebases
     - `TODO(villagesql-rust):` - Related to the Rust SDK / Rust extension support
+    - `TODO(villagesql-windows):` - Known problems with supporting Windows
 - Avoid `/* */` style comments except for copyright headers
 - Do NOT use section separator comments (e.g., `// ===== Serialization =====`) - they're hard to maintain and add little value
 - Do NOT add explanatory comments on #include lines (e.g., `#include "my_sys.h" // my_ok, my_printf_error`) - they're hard to maintain

--- a/cmake/mysql_version.cmake
+++ b/cmake/mysql_version.cmake
@@ -80,7 +80,7 @@ MACRO(GET_MYSQL_VERSION)
     MESSAGE(FATAL_ERROR "MYSQL_VERSION_MATURITY can be set to INNOVATION or LTS.")
   ENDIF()
 
-  # TODO(villagesql-ga): figure out our strategy for LTS and numbering.
+  # TODO(villagesql-production): figure out our strategy for LTS and numbering.
   ## Versions like 8.0.x, 8.4.x, and x.7.y (x > 8) should be LTS
   # IF ((MAJOR_VERSION EQUAL "8" AND MINOR_VERSION EQUAL "0" AND PATCH_VERSION GREATER "34") OR
   #     (MAJOR_VERSION EQUAL "8" AND MINOR_VERSION EQUAL "4") OR

--- a/mysql-test/suite/villagesql/load_data/t/load_data_complex_bad_value_modes.test
+++ b/mysql-test/suite/villagesql/load_data/t/load_data_complex_bad_value_modes.test
@@ -37,8 +37,7 @@ let $null_notnull_strict_error = 1263; # ER_WARN_NULL_TO_NOTNULL
 
 # --- with DEFAULT ---
 # Note: VillageSQL (like MySQL for builtins) currently ignores the user-defined
-# DEFAULT for bad values and stores the intrinsic default (0,0) instead.
-# TODO(villagesql-beta): fix to use user-defined DEFAULT.
+# DEFAULT for bad values and stores the intrinsic default instead.
 let $col_def = COMPLEX DEFAULT '(100,100)';
 let $type_default = (100,100);
 let $bad_value_strict_error = 1366; # ER_TRUNCATED_WRONG_VALUE_FOR_FIELD

--- a/scripts/villint.sh
+++ b/scripts/villint.sh
@@ -185,17 +185,19 @@ get_clang_format_version() {
 # Whitelist of allowed TODO tags for VillageSQL code
 ALLOWED_TODO_TAGS=(
   "villagesql"
-  "villagesql-beta"
-  "villagesql-preview"
-  "villagesql-crash"
-  "villagesql-ga"
-  "villagesql-performance"
-  "villagesql-rebase"
-  "villagesql-windows"
-  "villagesql-blob"
-  "villagesql-indexing"
   "villagesql-back-to-mysql"
+  "villagesql-beta"
+  "villagesql-blob"
+  "villagesql-charset"
+  "villagesql-crash"
+  "villagesql-general"
+  "villagesql-indexing"
+  "villagesql-performance"
+  "villagesql-preview"
+  "villagesql-production"
+  "villagesql-rebase"
   "villagesql-rust"
+  "villagesql-windows"
 )
 
 INVALID_TODO_TAGS_FOUND=0

--- a/sql/create_field.h
+++ b/sql/create_field.h
@@ -134,7 +134,8 @@ class Create_field {
   Field *field;  // For alter table
 
   // VillageSQL: Custom type context if this column uses a custom type.
-  // TODO(villagesql-ga): add a proper accessor instead of direct field access.
+  // TODO(villagesql-general): add a proper accessor instead of direct field
+  // access.
   const villagesql::TypeContext *custom_type_context{nullptr};
 
   uint offset;

--- a/sql/item.cc
+++ b/sql/item.cc
@@ -3621,7 +3621,8 @@ void Item_string::print(const THD *, String *str,
     String decoded;
     if (!villagesql::DecodeStringUncached(*get_type_context(), str_value,
                                           &decoded)) {
-      // TODO(villagesql-beta): Should we print a placeholder in case of error?
+      // TODO(villagesql-general): Should we print a placeholder in case of
+      // error?
       str->append(decoded);
     }
     str->append('\'');
@@ -7104,7 +7105,7 @@ type_conversion_status Item_string::save_in_field_inner(Field *field, bool) {
     }
 
     // Now re-cache the new version.
-    // TODO(villagesql-beta): check on the collation settings.
+    // TODO(villagesql-charset): check on the collation settings.
     fixed = false;
     init(encoded->ptr(), encoded->length(), &my_charset_bin,
          collation.derivation, collation.repertoire);

--- a/sql/item.h
+++ b/sql/item.h
@@ -3928,14 +3928,14 @@ class Item_sp_variable : public Item {
     return this_item()->get_type_context();
   }
   bool has_type_context() const override {
-    // TODO(villagesql-beta): Investigate if we have some latent issues here.
+    // TODO(villagesql-general): Investigate if we have some latent issues here.
     return this_item()->has_type_context();
   }
-  // TODO(villagesql-ga): Delegate set_type_context() (and the encode/decode
-  // methods) to this_item() so Item_sp_variable is fully symmetric with its
-  // underlying Item. Currently set_type_context() writes to the Item base
-  // cache while get_type_context() reads from the delegated item, which is
-  // inconsistent.
+  // TODO(villagesql-general): Delegate set_type_context() (and the
+  // encode/decode methods) to this_item() so Item_sp_variable is fully
+  // symmetric with its underlying Item. Currently set_type_context() writes to
+  // the Item base cache while get_type_context() reads from the delegated item,
+  // which is inconsistent.
 
  protected:
   inline type_conversion_status save_in_field_inner(

--- a/sql/parse_tree_items.cc
+++ b/sql/parse_tree_items.cc
@@ -270,7 +270,7 @@ bool PTI_function_call_generic_ident_sys::do_itemize(Parse_context *pc,
       *res = Create_udf_func::s_singleton.create(thd, udf, opt_udf_expr_list);
     } else {
       // Try unqualified VDF lookup before stored functions
-      // TODO(villagesql-general): Move VDF resolution after stored functions?
+      // TODO(villagesql-beta): Move VDF resolution after stored functions?
       bool vdf_error = false;
       if (try_itemize_unqualified_vdf(pc, ident, opt_udf_expr_list, res,
                                       &vdf_error)) {
@@ -300,7 +300,7 @@ bool PTI_function_call_generic_2d::do_itemize(Parse_context *pc, Item **res) {
   if (super::do_itemize(pc, res)) return true;
 
   // First, try to resolve as a custom VDF (extension.function)
-  // TODO(villagesql-general): Move VDF resolution after stored functions?
+  // TODO(villagesql-beta): Move VDF resolution after stored functions?
   bool vdf_error;
   if (try_itemize_custom_vdf(pc, db, func, opt_expr_list, res, &vdf_error)) {
     return vdf_error;  // Handled as VDF

--- a/sql/parse_tree_items.cc
+++ b/sql/parse_tree_items.cc
@@ -270,7 +270,7 @@ bool PTI_function_call_generic_ident_sys::do_itemize(Parse_context *pc,
       *res = Create_udf_func::s_singleton.create(thd, udf, opt_udf_expr_list);
     } else {
       // Try unqualified VDF lookup before stored functions
-      // TODO(villagesql-beta): Move VDF resolution after Stored functions
+      // TODO(villagesql-general): Move VDF resolution after stored functions?
       bool vdf_error = false;
       if (try_itemize_unqualified_vdf(pc, ident, opt_udf_expr_list, res,
                                       &vdf_error)) {
@@ -300,7 +300,7 @@ bool PTI_function_call_generic_2d::do_itemize(Parse_context *pc, Item **res) {
   if (super::do_itemize(pc, res)) return true;
 
   // First, try to resolve as a custom VDF (extension.function)
-  // TODO(villagesql-beta): Move VDF resolution after Stored functions
+  // TODO(villagesql-general): Move VDF resolution after stored functions?
   bool vdf_error;
   if (try_itemize_custom_vdf(pc, db, func, opt_expr_list, res, &vdf_error)) {
     return vdf_error;  // Handled as VDF

--- a/sql/sql_lex.cc
+++ b/sql/sql_lex.cc
@@ -542,7 +542,7 @@ void lex_end(LEX *lex) {
   lex->sphead = nullptr;
 
   // Free custom-routine tracking; a view's transient LEX never runs ~LEX.
-  // TODO(villagesql-beta): merge view croutines_list into the parent in
+  // TODO(villagesql-general): merge view croutines_list into the parent in
   // handle_view() like sroutines, so view-referenced VDFs get extension MDLs.
   lex->croutines.reset();
   lex->croutines_list.clear();

--- a/storage/innobase/handler/handler0alter.cc
+++ b/storage/innobase/handler/handler0alter.cc
@@ -1106,8 +1106,8 @@ enum_alter_inplace_result ha_innobase::check_if_supported_inplace_alter(
         } else if (villagesql::innodb::Custom_column::
                        alter_add_drop_with_extended_storage(ha_alter_info,
                                                             table)) {
-          // TODO(villagesql-ga): Support INSTANT ALTER for custom columns with
-          // extended storage.
+          // TODO(villagesql-general): Support INSTANT ALTER for custom columns
+          // with extended storage.
           if (is_instant_requested) {
             villagesql_error(
                 "ALGORITHM=INSTANT is not supported for columns "

--- a/testclients/mysql_client_test.cc
+++ b/testclients/mysql_client_test.cc
@@ -7482,7 +7482,7 @@ static void test_explain_bug() {
                            : MYSQL_TYPE_VAR_STRING,
                        nullptr, nullptr, "", 64);
 
-  // TODO(villagesql-ga): database name is no longer 'information_schema
+  // TODO(villagesql-general): database name is no longer 'information_schema
   // on the type field because it is a derived field.
   verify_prepare_field(result, 1, "Type", "Type", MYSQL_TYPE_BLOB, nullptr,
                        nullptr, "", 0);

--- a/unittest/gunit/villagesql/type_context-t.cc
+++ b/unittest/gunit/villagesql/type_context-t.cc
@@ -510,9 +510,10 @@ TEST_F(TypeContextTest, VariableLengthTypeEncodesIntrinsicDefault) {
 // fatal: init reports an error and stores no buffer. Such a type must supply a
 // non-empty intrinsic_default_str/fn to be usable.
 
-// TODO(villagesql-beta): try to validate on install whether encode("") produces
-// valid default - in case no intrinsic_default_str/fn is provided. Or even
-// check if encode(instrinsic_default_str) produces a valid default.
+// TODO(villagesql-general): try to validate on install whether encode("")
+// produces valid default - in case no intrinsic_default_str/fn is provided. Or
+// even check if encode(instrinsic_default_str) produces a valid default. Note:
+// this can only be a valid install-time check for non-parameterized types.
 TEST_F(TypeContextTest, VariableLengthEmptyEncodeIsFatal) {
   villagesql::TypeDescriptor desc(
       villagesql::TypeDescriptorKey("EMPTYVAR", "test_ext", "1.0.0"),

--- a/villagesql/dev_server/bundled_extensions.txt
+++ b/villagesql/dev_server/bundled_extensions.txt
@@ -1,7 +1,7 @@
 # Bundled extensions included in the dev server release tarball.
 # Also tested against the HEAD SDK in extension-compat-suite.yml.
 #
-# TODO(villagesql-ga): In the future, move this per-extension configuration into the
+# TODO(villagesql-general): In the future, move this per-extension configuration into the
 # extension repos themselves (each declaring its own build/abi/path).
 #
 # Format: <url> <branch-or-tag> [key=value ...]

--- a/villagesql/schema/descriptor/type_context.cc
+++ b/villagesql/schema/descriptor/type_context.cc
@@ -127,7 +127,7 @@ bool TypeContext::init_intrinsic_default(std::string &error_out) {
     return true;
   }
 
-  // TODO(villagesql-beta): consolidate this encode call with TypeEncoder to
+  // TODO(villagesql-general): consolidate this encode call with TypeEncoder to
   // avoid duplicating the vdf/fn dispatch logic.
   const EncodeOp &op = encode_op_.value();
   if (op.vdf() != nullptr) {
@@ -245,7 +245,7 @@ void TypeContext::resolve_cached_values() {
       // This can happen if parameters stored on disk no longer validate
       // (e.g., extension upgraded). The type will be unusable until the
       // column is altered, but we won't crash.
-      // TODO(villagesql-beta): how should we actually handle this error?
+      // TODO(villagesql-production): how should we actually handle this error?
       LogVSQL(WARNING_LEVEL,
               "resolve_params failed for type '%s' (params: %s): %s. "
               "Falling back to descriptor defaults.",
@@ -303,7 +303,6 @@ TypeParameters TypeParameters::from_raw(const std::string_view raw) {
 
   // Parse "k=v,k=v,..." into pairs, sort by lowercased key, lowercase values,
   // re-serialize. Use the same charset for both lowercasing and sort order.
-  // TODO(villagesql-beta): refactor parsing to use std::string_view.
   const CHARSET_INFO *cs = type_parameter_collation();
   std::vector<std::pair<std::string, std::string>> pairs;
   size_t start = 0;

--- a/villagesql/schema/schema_manager.cc
+++ b/villagesql/schema/schema_manager.cc
@@ -727,7 +727,8 @@ bool SchemaManager::upgrade_villagesql_schema(THD *thd) {
   // maybe_install_villagesql_schema_on_first_run(), which runs after this, so
   // there is nothing to check or upgrade here.
   //
-  // TODO(villagesql-ga): support upgrading a data directory across code bases.
+  // TODO(villagesql-production): support upgrading a data directory across code
+  // bases.
   if (current_villagesql_version.is_valid() &&
       current_villagesql_version.code_base() !=
           target_villagesql_version.code_base()) {

--- a/villagesql/schema/systable/custom_sp_params.h
+++ b/villagesql/schema/systable/custom_sp_params.h
@@ -47,9 +47,9 @@ struct SpParamKeyPrefix {
                                  canonical_table_name(sp_name_)}) +
             ".") {}
 
-  // TODO(villagesql-beta): Add a db-only constructor (no sp_name) to support
-  // bulk deletion of all sp params for a given database, needed for DROP
-  // DATABASE cleanup.
+  // TODO(villagesql-production): Add a db-only constructor (no sp_name) to
+  // support bulk deletion of all sp params for a given database, needed for
+  // DROP DATABASE cleanup.
   const std::string &str() const { return normalized_prefix_; }
 
   const std::string &db() const { return db_; }

--- a/villagesql/schema/systable/extensions.cc
+++ b/villagesql/schema/systable/extensions.cc
@@ -47,8 +47,8 @@ constexpr const char kPendingActionColumn[] = "pending_action";
 // Format the current UTC time as ISO-8601 with microseconds:
 // "YYYY-MM-DDTHH:MM:SS.uuuuuuZ".
 //
-// TODO(villagesql-ga): move to a shared time-formatting utility once a
-// second caller wants it.
+// TODO(villagesql): move to a shared time-formatting utility once a second
+// caller wants it.
 std::string CurrentTimestampUtc() {
   using clock = std::chrono::system_clock;
   const auto now = clock::now();

--- a/villagesql/schema/victionary_client.h
+++ b/villagesql/schema/victionary_client.h
@@ -396,11 +396,12 @@ class SystemTableMap {
            op_type == OperationType::UPDATE);
 
     // Create shared_ptr for the entry
-    // TODO(villagesql-ga): what happens if the underlying allocation fails? It
-    // probably throws an exception and crashes, but we should validate that. If
-    // that's the behavior, we either need to wrap make_shared<> or else come up
-    // with a nothrow alternative that achieves the same result. This would help
-    // us more consistently handle OOM conditions.
+    // TODO(villagesql-production): what happens if the underlying allocation
+    // fails? It probably throws an exception and crashes, but we should
+    // validate that. If that's the behavior, we either need to wrap
+    // make_shared<> or else come up with a nothrow alternative that achieves
+    // the same result. This would help us more consistently handle OOM
+    // conditions.
     auto entry_ptr = std::make_shared<EntryType>(std::move(entry));
     if (should_assert_if_null(entry_ptr)) {
       my_error(ER_OUTOFMEMORY, MYF(ME_FATALERROR), sizeof(EntryType));

--- a/villagesql/sdk/include/villagesql/abi/types.h
+++ b/villagesql/sdk/include/villagesql/abi/types.h
@@ -280,7 +280,7 @@ typedef enum : int {
   VEF_TYPE_INT = 2,
   VEF_TYPE_CUSTOM = 3
 
-  // TODO(villagesql-ga): Do we want to support DECIMAL?
+  // TODO(villagesql-production): Do we want to support DECIMAL?
 } vef_type_id;
 
 // Snapshot of vef_invalue_t as of VEF_PROTOCOL_1. Used as the element type of

--- a/villagesql/sdk/include/villagesql/detail/func_builder.h
+++ b/villagesql/sdk/include/villagesql/detail/func_builder.h
@@ -914,7 +914,7 @@ struct IntrinsicDefaultWithCacheWrapper {
 inline bool serialize_type_params(
     const std::map<std::string, std::string> &params, const char *op_name,
     std::string &out, char *error_msg) {
-  // TODO(villagesql-beta): decide on a broader character set policy.
+  // TODO(villagesql-charset): decide on a broader character set policy.
   out.clear();
   for (const auto &[key, value] : params) {
     if (key.empty() || key.find_first_of(",=") != std::string::npos) {

--- a/villagesql/sdk/include/villagesql/vsql/pre_post_run.h
+++ b/villagesql/sdk/include/villagesql/vsql/pre_post_run.h
@@ -38,7 +38,7 @@
 // need to reach for prerun or postrun, please come talk to us so we can
 // understand your use case.
 //
-// TODO(villagesql-beta): add a typed-state mechanism (working name
+// TODO(villagesql-general): add a typed-state mechanism (working name
 // `.state<T>()` on FuncBuilder) so extensions can declare a per-statement
 // state type and have the SDK manage its lifetime automatically — no
 // matched prerun/postrun pair required just to free state. Implementable
@@ -90,7 +90,7 @@ class PrerunArgs {
     return PrerunArgType(&a_->arg_types[i]);
   }
 
-  // TODO(villagesql-beta): expose const_at(i) returning the serialized
+  // TODO(villagesql-general): expose const_at(i) returning the serialized
   // literal bytes for constant arguments. Blocked on vdf_handler.cc
   // populating vef_prerun_args_t::const_values / const_lengths; today both
   // are unconditionally nullptr at the prerun call site.

--- a/villagesql/services/preview/mysql_services.cc
+++ b/villagesql/services/preview/mysql_services.cc
@@ -43,7 +43,7 @@ std::unordered_map<const vef_preview_mysql_services_t *, ServiceState> g_states;
 // Acquire every consumed service and write its pointer back into the extension.
 // On any failure, roll back what this call already did.
 //
-// TODO(villagesql-beta): consider whether to enforce a manifest allow-list —
+// TODO(villagesql-general): consider whether to enforce a manifest allow-list —
 // refusing any service the code consumes that is not listed in the extension's
 // manifest "required_mysql_services". This is an open design decision, not a
 // pending task: it's one way to constrain which services an extension may

--- a/villagesql/services/preview/sys_var.cc
+++ b/villagesql/services/preview/sys_var.cc
@@ -278,7 +278,7 @@ bool on_populate_sys_var(const PopulateContext &ctx,
         value_ptr = v->integer.value_ptr;
         break;
       case VEF_VAR_DOUBLE:
-        // TODO(villagesql-beta): component_sys_variable_register does not
+        // TODO(villagesql-general): component_sys_variable_register does not
         // support PLUGIN_VAR_DOUBLE; register_variable will fail with
         // "Unknown variable type code 0x8". Until MySQL adds support,
         // extensions should use VEF_VAR_INT (milliseconds) instead.

--- a/villagesql/sql/metadata_modifier.cc
+++ b/villagesql/sql/metadata_modifier.cc
@@ -1435,7 +1435,7 @@ bool PersistCustomSpParams(THD *thd, sp_head *sp) {
   // table's uncommitted map for this THD before touching any open TABLE*, so
   // other system tables (columns, properties, extensions) are skipped safely
   // because no entries were marked for them on this code path.
-  // TODO(villagesql-beta) Evaluate change the API in the future to allow
+  // TODO(villagesql-general) Evaluate change the API in the future to allow
   // committing only from a subset of tables and asserting the others have
   // nothing pending.
   Table_ref sp_params_table(SchemaManager::VILLAGESQL_SCHEMA_NAME,

--- a/villagesql/system_views/extension_registration.cc
+++ b/villagesql/system_views/extension_registration.cc
@@ -174,7 +174,7 @@ static std::string registration_to_json(const vef_registration_t *r) {
   }
   w.EndArray();
 
-  // TODO(villagesql-beta): Serialize per-capability data (sys_vars,
+  // TODO(villagesql-preview): Serialize per-capability data (sys_vars,
   // status_vars, etc.) into the JSON by adding a to_json callback to
   // CapabilityRegistration. Each capability provides its own serializer;
   // extension_registration.cc iterates required_capabilities, looks up the

--- a/villagesql/types/from_string_inference.cc
+++ b/villagesql/types/from_string_inference.cc
@@ -85,7 +85,7 @@ bool InferFromStringConstant(THD * /*thd*/, int64_t max_persisted_length,
   inferred_workspace.max_buf_len = sizeof(stack_params_buf);
 
   // Build the single STRING input arg holding the constant literal.
-  // TODO(villagesql-beta): change this to use the encoding wrapper.
+  // TODO(villagesql): change this to use the encoding wrapper.
   vef_invalue_t arg{};
   arg.type = VEF_TYPE_STRING;
   arg.is_null = false;

--- a/villagesql/types/type_decoder.cc
+++ b/villagesql/types/type_decoder.cc
@@ -64,7 +64,7 @@ DecodeResult TypeDecoder::decode(const uchar *data, size_t len, String *out) {
     }
 
     if (vdf_call_->alt_str_buf() != nullptr) {
-      // TODO(villagesql-beta): support caller supplied buffers.
+      // TODO(villagesql-general): support caller supplied buffers.
       last_error_msg_ = "VDF provided unsupported alternate output buffer";
       return DecodeResult::kExtensionError;
     }

--- a/villagesql/types/type_encoder.cc
+++ b/villagesql/types/type_encoder.cc
@@ -65,7 +65,7 @@ String *TypeEncoder::encode(const String &from, bool &is_valid) {
     auto r =
         vdf_call_->invoke(from, pointer_cast<uchar *>(buffer_), buffer_size_);
     if (!r) {
-      // TODO(villagesql-beta): log warnings for errors
+      // TODO(villagesql-general): log warnings for errors
       is_valid = false;
       return nullptr;
     }

--- a/villagesql/types/util.cc
+++ b/villagesql/types/util.cc
@@ -1833,8 +1833,9 @@ bool InjectCustomSpParams(
       // The Item_field delegates has_type_context() to its field pointer, but
       // set_type_context() on the Item base caches it for non-field items
       // (Item_sp_variable) that call get_type_context() on this_item().
-      // TODO(villagesql-ga): Once Item_field delegates set_type_context() to
-      // its underlying Field, this call can be dropped for field-backed items.
+      // TODO(villagesql-general): Once Item_field delegates set_type_context()
+      // to its underlying Field, this call can be dropped for field-backed
+      // items.
       if (var_items.array() && var_items[m.field_idx]) {
         var_items[m.field_idx]->set_type_context(tc_ref.get());
       }

--- a/villagesql/veb/sql_extension.h
+++ b/villagesql/veb/sql_extension.h
@@ -35,7 +35,7 @@ extern char opt_veb_dir[FN_REFLEN];
 // the setup work (VEB resolution, MDL acquisition, victionary access); the
 // dispatch flags below select which path runs.
 //
-// TODO(villagesql-beta): evaluate giving `ALTER EXTENSION` its own
+// TODO(villagesql-general): evaluate giving `ALTER EXTENSION` its own
 // `enum_sql_command` value. Today both INSTALL and ALTER report as
 // `SQLCOM_INSTALL_EXTENSION` in the slow query log, audit log, and
 // performance_schema statement events; they should be distinguishable.

--- a/villagesql/veb/sql_extension_update_precheck.cc
+++ b/villagesql/veb/sql_extension_update_precheck.cc
@@ -157,7 +157,7 @@ UpdatePreCheckResult RunUpdatePreCheck(const UpdatePreCheckInput &input) {
 // NOTE: when adding a new extension-owned systable that participates in an
 // UPDATE (i.e. its rows carry an extension_name + extension_version), both
 // this function and the UNINSTALL EXTENSION code in sql_extension.cc need to
-// be updated to walk the new map. See the TODO(villagesql-ga) in
+// be updated to walk the new map. See the TODO in
 // veb_file.cc::load_installed_extensions for the planned centralization of
 // this enumeration on VictionaryClient.
 //

--- a/villagesql/veb/sql_extension_update_precheck.h
+++ b/villagesql/veb/sql_extension_update_precheck.h
@@ -53,7 +53,7 @@ namespace veb {
 // Docs/EXTENSION_UPDATE_AT_RESTART.md "Pre-Check API Shape" for the planned
 // hook contract.
 //
-// TODO(villagesql-beta): relocate the precheck out of the live server
+// TODO(villagesql-general): relocate the precheck out of the live server
 // process. Phase 1 (this file) runs the dlopen + vef_register harvest
 // in-process, which exposes the live server to static initializers and
 // any side effects in the target .so. Phase 2 is a subprocess: the parent
@@ -106,7 +106,7 @@ struct UpdatePreCheckInput {
   std::vector<DependentColumnSnapshot> dependent_columns;
   std::vector<DependentSpParamSnapshot> dependent_sp_params;
 
-  // TODO(villagesql-beta): the apply path rewrites custom_indexes rows
+  // TODO(villagesql-general): the apply path rewrites custom_indexes rows
   // to the target version unconditionally, but this precheck does not
   // verify that every in-use index_type / index_profile survives in the
   // target registration (analogous to the dropped-type check for

--- a/villagesql/veb/veb_file.cc
+++ b/villagesql/veb/veb_file.cc
@@ -389,7 +389,7 @@ bool load_veb_manifest(const std::string &name, std::string &version) {
 
   std::string manifest_name = name_value.GetString();
 
-  // TODO(villagesql-beta): Consider relaxing this requirement to allow VEB
+  // TODO(villagesql-general): Consider relaxing this requirement to allow VEB
   // filename to differ from manifest name.
   // Validate manifest name matches expected extension name (VEB basename)
   if (manifest_name != name) {
@@ -935,11 +935,12 @@ bool load_installed_extensions(THD *thd) {
         // parent DA is never touched. This is MySQL's designed-for-purpose
         // mechanism for exactly this pattern.
         //
-        // TODO(villagesql-ga): consolidate internal helpers on structured
+        // TODO(villagesql-general): consolidate internal helpers on structured
         // error-string out-params and translate to villagesql_error only at
         // the SQL boundary (ALTER call site). That would remove the need
         // for this scratch DA entirely and align the internal call surface
-        // with the subprocess-precheck story.
+        // with the subprocess-precheck story. Remove the NOTE in
+        // sql_extension_update_precheck.cc mentioning this TODO.
         //
         // TODO(villagesql): load_installed_extensions has grown large;
         // break the per-extension work into a purpose-driven helper.
@@ -1159,7 +1160,7 @@ bool load_installed_extensions(THD *thd) {
           const std::string &from_version = pending.current_version;
           const std::string &to_version = pending.target_version;
 
-          // TODO(villagesql-ga): the set of extension-owned systables
+          // TODO(villagesql-general): the set of extension-owned systables
           // (columns, sp_params, custom_indexes, ...) is enumerated by
           // name at every caller that operates on an extension's rows:
           // UNINSTALL EXTENSION (delete sweep + use-count check),
@@ -1432,8 +1433,9 @@ bool open_vef_extension(const std::string &so_path, vef_protocol_t max_protocol,
     return true;
   }
 
-  // TODO(villagesql-beta): Add more validation of the returned registration
-  // object (e.g. func/type descriptors, protocol version, null pointers).
+  // TODO(villagesql-production): Add more validation of the returned
+  // registration object (e.g. func/type descriptors, protocol version, null
+  // pointers).
 
   LogVSQL(INFORMATION_LEVEL,
           "Successfully loaded VEF extension '%s' (protocol %d, %d funcs, %d "

--- a/villagesql/villint/regtest_villint_test_cases/todo_tag_invalid_edit.sh
+++ b/villagesql/villint/regtest_villint_test_cases/todo_tag_invalid_edit.sh
@@ -17,7 +17,7 @@ cat > "$FILE" << 'EOF'
  * of the License, or (at your option) any later version.
  */
 
-// TODO(villagesql-gaaaa): This is a typo - should be villagesql-ga
+// TODO(villagesql-generaltesttypo): This is a typo - should be villagesql-general
 void test_function() {}
 EOF
 

--- a/villagesql/villint/regtest_villint_test_cases/todo_tag_invalid_verify.sh
+++ b/villagesql/villint/regtest_villint_test_cases/todo_tag_invalid_verify.sh
@@ -13,8 +13,8 @@ if [ ! -f "$FILE" ]; then
 fi
 
 # Check if file contains the invalid tag
-if grep -q "TODO(villagesql-gaaaa)" "$FILE"; then
-    echo "FAIL: $FILE contains invalid TODO tag 'villagesql-gaaaa'"
+if grep -q "TODO(villagesql-generaltesttypo)" "$FILE"; then
+    echo "FAIL: $FILE contains invalid TODO tag 'villagesql-generaltesttypo'"
     exit 1
 fi
 

--- a/villagesql/villint/regtest_villint_test_cases/todo_tag_valid_edit.sh
+++ b/villagesql/villint/regtest_villint_test_cases/todo_tag_valid_edit.sh
@@ -17,7 +17,7 @@ cat > "$FILE" << 'EOF'
  * of the License, or (at your option) any later version.
  */
 
-// TODO(villagesql-ga): Must handle before initial release
+// TODO(villagesql-general): Must handle before initial release
 // TODO(villagesql-performance): Performance optimization
 // TODO(villagesql-rebase): Check during MySQL rebases
 // TODO(villagesql-windows): Work to support Windows

--- a/villagesql/villint/regtest_villint_test_cases/todo_tag_valid_verify.sh
+++ b/villagesql/villint/regtest_villint_test_cases/todo_tag_valid_verify.sh
@@ -12,8 +12,8 @@ if [ ! -f "$FILE" ]; then
 fi
 
 # Verify the file contains our expected valid tags
-if ! grep -q "TODO(villagesql-ga):" "$FILE"; then
-    echo "FAIL: $FILE missing expected TODO(villagesql-ga) tag"
+if ! grep -q "TODO(villagesql-general):" "$FILE"; then
+    echo "FAIL: $FILE missing expected TODO(villagesql-general) tag"
     exit 1
 fi
 


### PR DESCRIPTION
Reclassify beta and ga TODOs. If required for:
- beta -> villagesql-beta
- production-readiness -> villagesql-production
- otherwise, villagesql or villagesql-general

We still need an audit for villagesql-indexing.

Clear out some done TODOs as well:
- string_view usage in type_context.cc
- DEFAULT work that no longer makes sense

villint-ignore: villagesql/villint/regtest_villint_test_cases/todo_tag_invalid_edit.sh
villint-ignore: villagesql/villint/regtest_villint_test_cases/todo_tag_invalid_verify.sh

Closes #832
