### PR TITLE
build: fix upstream buffer len error

### DIFF
--- a/plugin/group_replication/libmysqlgcs/src/bindings/xcom/gcs_xcom_networking.cc
+++ b/plugin/group_replication/libmysqlgcs/src/bindings/xcom/gcs_xcom_networking.cc
@@ -1,4 +1,5 @@
 /* Copyright (c) 2016, 2026, Oracle and/or its affiliates.
+   Copyright (c) 2026 VillageSQL Contributors
 
    This program is free software; you can redistribute it and/or modify
    it under the terms of the GNU General Public License, version 2.0,
@@ -422,7 +423,7 @@ static bool sock_descriptor_to_sockaddr(int fd, struct sockaddr_storage *sa) {
   */
 static bool sock_descriptor_to_string(int fd, std::string &out) {
   struct sockaddr_storage sa;
-  socklen_t addr_size = static_cast<socklen_t>(sizeof(struct sockaddr_storage));
+  socklen_t addr_size = static_cast<socklen_t>(INET6_ADDRSTRLEN);
   char saddr[INET6_ADDRSTRLEN];
 
   // get the sockaddr struct


### PR DESCRIPTION
## Description

Fix opt mode build errors that showed up when building on ubuntu 26.04

Upstream mysql has a bug in its call to inet_ntop(); the `size` should be the size of `dst` buffer (the immediately preceding argument) rather than the size of the addr struct.

See https://man7.org/linux/man-pages/man3/inet_ntop.3.html

## Related Issue

n/a

## How was this tested?

[Manually running](https://github.com/villagesql/villagesql-server/actions/runs/33769725697) "Extension SDK Compatibility" on the branch

## Checklist

- [x] I have signed the CLA
- [x] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [x] I have added or updated tests as appropriate
- [x] My changes maintain compatibility with upstream MySQL 8.4
