### PR TITLE
Villagesql I_S tables cols nullability

### DIFF
--- a/Docs/merging/post-merge-checks.md
+++ b/Docs/merging/post-merge-checks.md
@@ -80,3 +80,34 @@ legitimately differs from Oracle's at the same I_S version because of VEF, which
 our rows already diverge from upstream's. Confirm the diff is benign before recording —
 a checksum change with no corresponding upstream I_S change deserves an explanation, not
 a paste.
+
+## The `sys` view metadata repair
+
+`refresh_sys_view_metadata()` in `villagesql/sql/initialize.cc` replays the
+`CREATE OR REPLACE VIEW` statement of a handful of `sys` views on every startup that
+needs it, to undo the column metadata that installing our `INFORMATION_SCHEMA` overrides
+rewrites. It finds those statements by scanning the generated `mysql_sys_schema[]` array
+for `"VIEW <name>"`, using the view names in `kAffectedSysViews`.
+
+That couples us to upstream's sys schema in two ways a merge can break.
+
+**View names.** If upstream renames, splits or drops one of the listed views, the scan
+finds no statement for it. This is caught, not silent: the replay requires exactly one
+match per name and fails startup otherwise, so the `villagesql/information_schema`
+suite's `sys_view_metadata` test will fail loudly. Fix it by updating
+`kAffectedSysViews` to match `scripts/sys_schema/`.
+
+**Statement order.** The replay follows `mysql_sys_schema[]` order, which is the file
+order in `scripts/sys_schema/CMakeLists.txt`. That order is topological today, and
+upstream cannot easily change that — a child view listed before its parent would fail
+every fresh `--initialize` with `ER_NO_SUCH_TABLE`. The repair depends on it, because
+replaying a parent re-rewrites its children's metadata, so children must be replayed
+after their parents. If a merge ever does reorder that list, `sys_view_metadata` is the
+test that notices.
+
+**New sys views.** If upstream adds a `sys` view that reads `INFORMATION_SCHEMA.COLUMNS`
+or `INFORMATION_SCHEMA.STATISTICS`, it needs adding to `kAffectedSysViews`, and so does
+anything that reads *it*. Nothing detects that automatically — the symptom is a
+`sysschema` result diff where nullability flips `YES` to `NO`, and `sysschema` only runs
+in the weekly full suite. `grep -ril "information_schema.\(columns\|statistics\)"
+scripts/sys_schema/` lists the candidates.

--- a/Docs/merging/post-merge-checks.md
+++ b/Docs/merging/post-merge-checks.md
@@ -107,7 +107,18 @@ test that notices.
 
 **New sys views.** If upstream adds a `sys` view that reads `INFORMATION_SCHEMA.COLUMNS`
 or `INFORMATION_SCHEMA.STATISTICS`, it needs adding to `kAffectedSysViews`, and so does
-anything that reads *it*. Nothing detects that automatically — the symptom is a
-`sysschema` result diff where nullability flips `YES` to `NO`, and `sysschema` only runs
-in the weekly full suite. `grep -ril "information_schema.\(columns\|statistics\)"
-scripts/sys_schema/` lists the candidates.
+anything that reads *it*. This is what the `sys_view_metadata_dependents` test is for, and
+it needs no list of its own: it walks `INFORMATION_SCHEMA.VIEW_TABLE_USAGE` with a
+recursive CTE to find the transitive dependent set, then checks each view it finds.
+
+The check is that a view's stored metadata matches what a strict-mode `CREATE` of the
+same body records — which is exactly what the repair restores. It recreates each
+dependent's body in a scratch schema to produce that reference value on the spot.
+The practical consequence at merge time: **a new dependent view needs no action here.**
+If its metadata can be damaged the assert fails and names the offending `view.column`
+pairs, and the fix is to add those views to `kAffectedSysViews` with a sentinel column
+each, ordered after anything they read. If it cannot be damaged the test simply stays
+green — no list to update and no result to re-record. `schema_unused_indexes` is the
+existing example of that second case: it joins `information_schema.statistics` but
+projects all three of its columns from `performance_schema`, so nothing of its own can
+flip.

--- a/mysql-test/suite/sysschema/r/v_schema_auto_increment_columns_ci.result
+++ b/mysql-test/suite/sysschema/r/v_schema_auto_increment_columns_ci.result
@@ -1,12 +1,12 @@
 DESC sys.schema_auto_increment_columns;
 Field	Type	Null	Key	Default	Extra
-table_schema	varchar(64)	NO			
-table_name	varchar(64)	NO			
-column_name	varchar(64)	NO			
-data_type	longtext	NO		NULL	
-column_type	longtext	NO		NULL	
-is_signed	int	NO		0	
-is_unsigned	int	NO		0	
+table_schema	varchar(64)	YES		NULL	
+table_name	varchar(64)	YES		NULL	
+column_name	varchar(64)	YES		NULL	
+data_type	longtext	YES		NULL	
+column_type	longtext	YES		NULL	
+is_signed	int	YES		NULL	
+is_unsigned	int	YES		NULL	
 max_value	bigint unsigned	YES		NULL	
 auto_increment	bigint unsigned	YES		NULL	
 auto_increment_ratio	decimal(25,4) unsigned	YES		NULL	

--- a/mysql-test/suite/sysschema/r/v_schema_auto_increment_columns_cs.result
+++ b/mysql-test/suite/sysschema/r/v_schema_auto_increment_columns_cs.result
@@ -4,9 +4,9 @@ table_schema	varchar(64)	NO		NULL
 table_name	varchar(64)	NO		NULL	
 column_name	varchar(64)	YES		NULL	
 data_type	longtext	YES		NULL	
-column_type	mediumtext	NO		NULL	
-is_signed	int	NO		0	
-is_unsigned	int	NO		0	
+column_type	longtext	YES		NULL	
+is_signed	int	YES		NULL	
+is_unsigned	int	YES		NULL	
 max_value	bigint unsigned	YES		NULL	
 auto_increment	bigint unsigned	YES		NULL	
 auto_increment_ratio	decimal(25,4) unsigned	YES		NULL	

--- a/mysql-test/suite/villagesql/information_schema/r/sys_view_metadata.result
+++ b/mysql-test/suite/villagesql/information_schema/r/sys_view_metadata.result
@@ -1,0 +1,29 @@
+# Sentinel columns, one per overridden I_S view.
+# IS_NULLABLE must be YES, as on a vanilla server.
+SELECT TABLE_NAME, COLUMN_NAME, IS_NULLABLE
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = 'sys'
+     AND ((TABLE_NAME = 'x$schema_flattened_keys' AND COLUMN_NAME = 'index_name')
+OR (TABLE_NAME = 'schema_auto_increment_columns'
+           AND COLUMN_NAME = 'column_name'))
+ORDER BY TABLE_NAME;
+TABLE_NAME	COLUMN_NAME	IS_NULLABLE
+schema_auto_increment_columns	column_name	YES
+x$schema_flattened_keys	index_name	YES
+# The views still resolve and are queryable, not just well-typed.
+SELECT * FROM sys.x$schema_flattened_keys;
+SELECT * FROM sys.schema_redundant_indexes;
+SELECT * FROM sys.schema_object_overview;
+# The repair is idempotent: a restart must neither undo it nor, because
+# the guard short-circuits, redo it.
+# restart
+SELECT TABLE_NAME, COLUMN_NAME, IS_NULLABLE
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = 'sys'
+     AND ((TABLE_NAME = 'x$schema_flattened_keys' AND COLUMN_NAME = 'index_name')
+OR (TABLE_NAME = 'schema_auto_increment_columns'
+           AND COLUMN_NAME = 'column_name'))
+ORDER BY TABLE_NAME;
+TABLE_NAME	COLUMN_NAME	IS_NULLABLE
+schema_auto_increment_columns	column_name	YES
+x$schema_flattened_keys	index_name	YES

--- a/mysql-test/suite/villagesql/information_schema/r/sys_view_metadata.result
+++ b/mysql-test/suite/villagesql/information_schema/r/sys_view_metadata.result
@@ -3,27 +3,45 @@
 SELECT TABLE_NAME, COLUMN_NAME, IS_NULLABLE
 FROM information_schema.COLUMNS
 WHERE TABLE_SCHEMA = 'sys'
-     AND ((TABLE_NAME = 'x$schema_flattened_keys' AND COLUMN_NAME = 'index_name')
+     AND ((TABLE_NAME = 'schema_object_overview' AND COLUMN_NAME = 'object_type')
+OR (TABLE_NAME = 'x$schema_flattened_keys' AND COLUMN_NAME = 'index_name')
 OR (TABLE_NAME = 'schema_auto_increment_columns'
-           AND COLUMN_NAME = 'column_name'))
+           AND COLUMN_NAME = 'column_name')
+OR (TABLE_NAME = 'schema_redundant_indexes'
+           AND COLUMN_NAME = 'redundant_index_name'))
 ORDER BY TABLE_NAME;
 TABLE_NAME	COLUMN_NAME	IS_NULLABLE
 schema_auto_increment_columns	column_name	YES
+schema_object_overview	object_type	YES
+schema_redundant_indexes	redundant_index_name	YES
 x$schema_flattened_keys	index_name	YES
-# The views still resolve and are queryable, not just well-typed.
+# Check that all the sys views in I_S use the same charset and collation.
+# If they don't either the upstream changed some view(s) to different
+# charset/collation (highly unlikely), or we broke something (more
+# likely).
+SET @contexts = (SELECT COUNT(*) FROM
+(SELECT DISTINCT CHARACTER_SET_CLIENT, COLLATION_CONNECTION
+FROM information_schema.VIEWS WHERE TABLE_SCHEMA = 'sys') distinct_contexts);
+include/assert.inc [Every sys view records one client charset and connection collation, so the replay matched the sys schema DDL context]
 SELECT * FROM sys.x$schema_flattened_keys;
 SELECT * FROM sys.schema_redundant_indexes;
 SELECT * FROM sys.schema_object_overview;
+SELECT * FROM sys.schema_auto_increment_columns;
 # The repair is idempotent: a restart must neither undo it nor, because
 # the guard short-circuits, redo it.
 # restart
 SELECT TABLE_NAME, COLUMN_NAME, IS_NULLABLE
 FROM information_schema.COLUMNS
 WHERE TABLE_SCHEMA = 'sys'
-     AND ((TABLE_NAME = 'x$schema_flattened_keys' AND COLUMN_NAME = 'index_name')
+     AND ((TABLE_NAME = 'schema_object_overview' AND COLUMN_NAME = 'object_type')
+OR (TABLE_NAME = 'x$schema_flattened_keys' AND COLUMN_NAME = 'index_name')
 OR (TABLE_NAME = 'schema_auto_increment_columns'
-           AND COLUMN_NAME = 'column_name'))
+           AND COLUMN_NAME = 'column_name')
+OR (TABLE_NAME = 'schema_redundant_indexes'
+           AND COLUMN_NAME = 'redundant_index_name'))
 ORDER BY TABLE_NAME;
 TABLE_NAME	COLUMN_NAME	IS_NULLABLE
 schema_auto_increment_columns	column_name	YES
+schema_object_overview	object_type	YES
+schema_redundant_indexes	redundant_index_name	YES
 x$schema_flattened_keys	index_name	YES

--- a/mysql-test/suite/villagesql/information_schema/r/sys_view_metadata_dependents.result
+++ b/mysql-test/suite/villagesql/information_schema/r/sys_view_metadata_dependents.result
@@ -1,0 +1,52 @@
+CREATE DATABASE sys_view_probe;
+# Every view that reads INFORMATION_SCHEMA.COLUMNS or .STATISTICS,
+# directly or through another view.
+#
+# Matching is case folded on purpose as the sys scripts spell
+# the reference both "statistics" and "STATISTICS".
+CREATE TEMPORARY TABLE test.sys_view_dependents (view_name VARCHAR(64));
+INSERT INTO test.sys_view_dependents (view_name)
+WITH RECURSIVE dependents (view_schema, view_name) AS (
+SELECT VIEW_SCHEMA, VIEW_NAME
+FROM information_schema.VIEW_TABLE_USAGE
+WHERE LOWER(TABLE_SCHEMA) = 'information_schema'
+     AND LOWER(TABLE_NAME) IN ('columns', 'statistics')
+UNION
+SELECT u.VIEW_SCHEMA, u.VIEW_NAME
+FROM information_schema.VIEW_TABLE_USAGE u
+JOIN dependents d
+ON LOWER(u.TABLE_SCHEMA) = LOWER(d.view_schema)
+AND LOWER(u.TABLE_NAME) = LOWER(d.view_name)
+)
+SELECT view_name FROM dependents WHERE LOWER(view_schema) = 'sys';
+# Copy each one into a scratch schema, under the server default sql_mode.
+# That is deliberate and load bearing, not inherited: run_bootstrap_thread
+# gives the repair the server default, and the strict mode in it is what
+# makes Item_str_func columns nullable (THD::is_strict_mode() tests
+# STRICT_TRANS_TABLES | STRICT_ALL_TABLES). Created under a relaxed
+# sql_mode the copies would record the damaged form, match the damaged
+# original, and the check below would pass without testing anything.
+SET @saved_sql_mode = @@SESSION.sql_mode;
+SET SESSION sql_mode = DEFAULT;
+include/assert.inc [The copies are created in strict mode, so a match below means repaired rather than equally damaged]
+SET SESSION sql_mode = @saved_sql_mode;
+# Guard against a vacuous pass: every dependent must have been copied,
+# and there must be at least one record in this table.
+include/assert.inc [Every dependent sys view was copied, and there is at least one]
+# On failure the interpolated condition names the offending view.column
+# pairs: add those views to kAffectedSysViews, with a sentinel column
+# each, ordered after anything they read.
+SET @damaged = (
+SELECT IFNULL(GROUP_CONCAT(CONCAT(o.TABLE_NAME, '.', o.COLUMN_NAME)
+ORDER BY o.TABLE_NAME, o.ORDINAL_POSITION
+SEPARATOR ' '), 'none')
+FROM information_schema.COLUMNS o
+JOIN information_schema.COLUMNS p
+ON p.TABLE_SCHEMA = 'sys_view_probe'
+     AND p.TABLE_NAME = o.TABLE_NAME
+AND p.ORDINAL_POSITION = o.ORDINAL_POSITION
+WHERE o.TABLE_SCHEMA = 'sys'
+     AND o.IS_NULLABLE <> p.IS_NULLABLE);
+include/assert.inc [Every sys view reading an overridden INFORMATION_SCHEMA view stores the nullability a strict-mode CREATE records]
+DROP TEMPORARY TABLE test.sys_view_dependents;
+DROP DATABASE sys_view_probe;

--- a/mysql-test/suite/villagesql/information_schema/r/sys_view_metadata_dependents.result
+++ b/mysql-test/suite/villagesql/information_schema/r/sys_view_metadata_dependents.result
@@ -19,13 +19,9 @@ ON LOWER(u.TABLE_SCHEMA) = LOWER(d.view_schema)
 AND LOWER(u.TABLE_NAME) = LOWER(d.view_name)
 )
 SELECT view_name FROM dependents WHERE LOWER(view_schema) = 'sys';
-# Copy each one into a scratch schema, under the server default sql_mode.
-# That is deliberate and load bearing, not inherited: run_bootstrap_thread
-# gives the repair the server default, and the strict mode in it is what
-# makes Item_str_func columns nullable (THD::is_strict_mode() tests
-# STRICT_TRANS_TABLES | STRICT_ALL_TABLES). Created under a relaxed
-# sql_mode the copies would record the damaged form, match the damaged
-# original, and the check below would pass without testing anything.
+# Copy each one into a scratch schema, under the server's default
+# sql_mode, which is strict mode. The bootstrap thread runs in strict mode,
+# and that is what makes Item_str_func columns nullable.
 SET @saved_sql_mode = @@SESSION.sql_mode;
 SET SESSION sql_mode = DEFAULT;
 include/assert.inc [The copies are created in strict mode, so a match below means repaired rather than equally damaged]

--- a/mysql-test/suite/villagesql/information_schema/r/sys_view_metadata_no_sys.result
+++ b/mysql-test/suite/villagesql/information_schema/r/sys_view_metadata_no_sys.result
@@ -1,0 +1,8 @@
+DROP DATABASE sys;
+# Startup must survive the missing schema, not abort on it.
+# restart
+# And it must not have resurrected a partial sys schema on the way past.
+SELECT COUNT(*) AS sys_schemata FROM information_schema.SCHEMATA
+WHERE SCHEMA_NAME = 'sys';
+sys_schemata
+0

--- a/mysql-test/suite/villagesql/information_schema/t/sys_view_metadata.test
+++ b/mysql-test/suite/villagesql/information_schema/t/sys_view_metadata.test
@@ -1,0 +1,26 @@
+# Test that the sys views reading the VillageSQL INFORMATION_SCHEMA overrides
+# keep the column metadata a vanilla MySQL records.
+
+--echo # Sentinel columns, one per overridden I_S view.
+--echo # IS_NULLABLE must be YES, as on a vanilla server.
+let $sentinels =
+  SELECT TABLE_NAME, COLUMN_NAME, IS_NULLABLE
+    FROM information_schema.COLUMNS
+   WHERE TABLE_SCHEMA = 'sys'
+     AND ((TABLE_NAME = 'x\$schema_flattened_keys' AND COLUMN_NAME = 'index_name')
+       OR (TABLE_NAME = 'schema_auto_increment_columns'
+           AND COLUMN_NAME = 'column_name'))
+   ORDER BY TABLE_NAME;
+eval $sentinels;
+
+--echo # The views still resolve and are queryable, not just well-typed.
+--disable_result_log
+SELECT * FROM sys.x$schema_flattened_keys;
+SELECT * FROM sys.schema_redundant_indexes;
+SELECT * FROM sys.schema_object_overview;
+--enable_result_log
+
+--echo # The repair is idempotent: a restart must neither undo it nor, because
+--echo # the guard short-circuits, redo it.
+--source include/restart_mysqld.inc
+eval $sentinels;

--- a/mysql-test/suite/villagesql/information_schema/t/sys_view_metadata.test
+++ b/mysql-test/suite/villagesql/information_schema/t/sys_view_metadata.test
@@ -7,17 +7,31 @@ let $sentinels =
   SELECT TABLE_NAME, COLUMN_NAME, IS_NULLABLE
     FROM information_schema.COLUMNS
    WHERE TABLE_SCHEMA = 'sys'
-     AND ((TABLE_NAME = 'x\$schema_flattened_keys' AND COLUMN_NAME = 'index_name')
+     AND ((TABLE_NAME = 'schema_object_overview' AND COLUMN_NAME = 'object_type')
+       OR (TABLE_NAME = 'x\$schema_flattened_keys' AND COLUMN_NAME = 'index_name')
        OR (TABLE_NAME = 'schema_auto_increment_columns'
-           AND COLUMN_NAME = 'column_name'))
+           AND COLUMN_NAME = 'column_name')
+       OR (TABLE_NAME = 'schema_redundant_indexes'
+           AND COLUMN_NAME = 'redundant_index_name'))
    ORDER BY TABLE_NAME;
 eval $sentinels;
 
---echo # The views still resolve and are queryable, not just well-typed.
+--echo # Check that all the sys views in I_S use the same charset and collation.
+--echo # If they don't either the upstream changed some view(s) to different
+--echo # charset/collation (highly unlikely), or we broke something (more
+--echo # likely).
+SET @contexts = (SELECT COUNT(*) FROM
+  (SELECT DISTINCT CHARACTER_SET_CLIENT, COLLATION_CONNECTION
+     FROM information_schema.VIEWS WHERE TABLE_SCHEMA = 'sys') distinct_contexts);
+--let $assert_text = Every sys view records one client charset and connection collation, so the replay matched the sys schema DDL context
+--let $assert_cond = [SELECT @contexts AS c, c, 1] = 1
+--source include/assert.inc
+
 --disable_result_log
 SELECT * FROM sys.x$schema_flattened_keys;
 SELECT * FROM sys.schema_redundant_indexes;
 SELECT * FROM sys.schema_object_overview;
+SELECT * FROM sys.schema_auto_increment_columns;
 --enable_result_log
 
 --echo # The repair is idempotent: a restart must neither undo it nor, because

--- a/mysql-test/suite/villagesql/information_schema/t/sys_view_metadata_dependents.test
+++ b/mysql-test/suite/villagesql/information_schema/t/sys_view_metadata_dependents.test
@@ -37,13 +37,9 @@ WITH RECURSIVE dependents (view_schema, view_name) AS (
 )
 SELECT view_name FROM dependents WHERE LOWER(view_schema) = 'sys';
 
---echo # Copy each one into a scratch schema, under the server default sql_mode.
---echo # That is deliberate and load bearing, not inherited: run_bootstrap_thread
---echo # gives the repair the server default, and the strict mode in it is what
---echo # makes Item_str_func columns nullable (THD::is_strict_mode() tests
---echo # STRICT_TRANS_TABLES | STRICT_ALL_TABLES). Created under a relaxed
---echo # sql_mode the copies would record the damaged form, match the damaged
---echo # original, and the check below would pass without testing anything.
+--echo # Copy each one into a scratch schema, under the server's default
+--echo # sql_mode, which is strict mode. The bootstrap thread runs in strict mode,
+--echo # and that is what makes Item_str_func columns nullable.
 SET @saved_sql_mode = @@SESSION.sql_mode;
 SET SESSION sql_mode = DEFAULT;
 

--- a/mysql-test/suite/villagesql/information_schema/t/sys_view_metadata_dependents.test
+++ b/mysql-test/suite/villagesql/information_schema/t/sys_view_metadata_dependents.test
@@ -1,0 +1,96 @@
+# Guard against kAffectedSysViews in villagesql/sql/sys_view_metadata.cc going
+# stale when upstream adds a sys view.
+#
+# That list is hand maintained and nothing in the build ties it to the sys
+# schema scripts, so a sys view added upstream later would be damaged by
+# installing the VillageSQL INFORMATION_SCHEMA overrides and then silently
+# skipped by the repair. This test keeps no list of its own: it derives the
+# dependent set from the data dictionary and checks every view it finds.
+#
+# The check is "the stored metadata is what a strict-mode CREATE would record",
+# which is exactly what the repair restores. Recreating each dependent's body in
+# a scratch schema produces that reference value on the spot.
+# Because the reference value is derived rather than recorded, a failure cannot
+# be cleared by re-recording; kAffectedSysViews has to actually be fixed. That
+# is the point.
+
+CREATE DATABASE sys_view_probe;
+
+--echo # Every view that reads INFORMATION_SCHEMA.COLUMNS or .STATISTICS,
+--echo # directly or through another view.
+--echo #
+--echo # Matching is case folded on purpose as the sys scripts spell
+--echo # the reference both "statistics" and "STATISTICS".
+CREATE TEMPORARY TABLE test.sys_view_dependents (view_name VARCHAR(64));
+INSERT INTO test.sys_view_dependents (view_name)
+WITH RECURSIVE dependents (view_schema, view_name) AS (
+  SELECT VIEW_SCHEMA, VIEW_NAME
+    FROM information_schema.VIEW_TABLE_USAGE
+   WHERE LOWER(TABLE_SCHEMA) = 'information_schema'
+     AND LOWER(TABLE_NAME) IN ('columns', 'statistics')
+  UNION
+  SELECT u.VIEW_SCHEMA, u.VIEW_NAME
+    FROM information_schema.VIEW_TABLE_USAGE u
+    JOIN dependents d
+      ON LOWER(u.TABLE_SCHEMA) = LOWER(d.view_schema)
+     AND LOWER(u.TABLE_NAME) = LOWER(d.view_name)
+)
+SELECT view_name FROM dependents WHERE LOWER(view_schema) = 'sys';
+
+--echo # Copy each one into a scratch schema, under the server default sql_mode.
+--echo # That is deliberate and load bearing, not inherited: run_bootstrap_thread
+--echo # gives the repair the server default, and the strict mode in it is what
+--echo # makes Item_str_func columns nullable (THD::is_strict_mode() tests
+--echo # STRICT_TRANS_TABLES | STRICT_ALL_TABLES). Created under a relaxed
+--echo # sql_mode the copies would record the damaged form, match the damaged
+--echo # original, and the check below would pass without testing anything.
+SET @saved_sql_mode = @@SESSION.sql_mode;
+SET SESSION sql_mode = DEFAULT;
+
+--let $assert_text = The copies are created in strict mode, so a match below means repaired rather than equally damaged
+--let $assert_cond = [SELECT @@SESSION.sql_mode REGEXP "STRICT_TRANS_TABLES|STRICT_ALL_TABLES" AS s, s, 1] = 1
+--source include/assert.inc
+
+--let $count = query_get_value(SELECT COUNT(*) AS c FROM test.sys_view_dependents, c, 1)
+--let $i = 1
+--disable_query_log
+while ($i <= $count) {
+  --let $v = query_get_value(SELECT view_name AS v FROM test.sys_view_dependents ORDER BY view_name, v, $i)
+  --eval SET @body = (SELECT VIEW_DEFINITION FROM information_schema.VIEWS WHERE TABLE_SCHEMA = 'sys' AND TABLE_NAME = '$v')
+  --eval SET @stmt = CONCAT('CREATE VIEW sys_view_probe.`$v` AS ', @body)
+  PREPARE st FROM @stmt;
+  EXECUTE st;
+  DEALLOCATE PREPARE st;
+  --inc $i
+}
+--enable_query_log
+SET SESSION sql_mode = @saved_sql_mode;
+
+--echo # Guard against a vacuous pass: every dependent must have been copied,
+--echo # and there must be at least one record in this table.
+--let $copies = query_get_value(SELECT COUNT(*) AS c FROM information_schema.VIEWS WHERE TABLE_SCHEMA = 'sys_view_probe', c, 1)
+--let $assert_text = Every dependent sys view was copied, and there is at least one
+--let $assert_cond = $count = $copies AND $copies > 0
+--source include/assert.inc
+
+--echo # On failure the interpolated condition names the offending view.column
+--echo # pairs: add those views to kAffectedSysViews, with a sentinel column
+--echo # each, ordered after anything they read.
+SET @damaged = (
+  SELECT IFNULL(GROUP_CONCAT(CONCAT(o.TABLE_NAME, '.', o.COLUMN_NAME)
+                             ORDER BY o.TABLE_NAME, o.ORDINAL_POSITION
+                             SEPARATOR ' '), 'none')
+    FROM information_schema.COLUMNS o
+    JOIN information_schema.COLUMNS p
+      ON p.TABLE_SCHEMA = 'sys_view_probe'
+     AND p.TABLE_NAME = o.TABLE_NAME
+     AND p.ORDINAL_POSITION = o.ORDINAL_POSITION
+   WHERE o.TABLE_SCHEMA = 'sys'
+     AND o.IS_NULLABLE <> p.IS_NULLABLE);
+
+--let $assert_text = Every sys view reading an overridden INFORMATION_SCHEMA view stores the nullability a strict-mode CREATE records
+--let $assert_cond = "[SELECT @damaged AS d, d, 1]" = "none"
+--source include/assert.inc
+
+DROP TEMPORARY TABLE test.sys_view_dependents;
+DROP DATABASE sys_view_probe;

--- a/mysql-test/suite/villagesql/information_schema/t/sys_view_metadata_no_sys.test
+++ b/mysql-test/suite/villagesql/information_schema/t/sys_view_metadata_no_sys.test
@@ -1,0 +1,26 @@
+# Test that the server still starts when the sys schema does not exist.
+#
+# refresh_sys_view_metadata() repairs the sys views that installing the
+# VillageSQL INFORMATION_SCHEMA overrides re-derives the metadata of. sys is an
+# ordinary schema though, and an administrator is free to drop it -- at which
+# point there is nothing to repair, and replaying the sys DDL would fail on the
+# missing schema and take startup down with it.
+#
+# The check for that cannot be folded into the sentinel columns: a dropped
+# schema and a view upstream has renamed look identical from a sentinel's point
+# of view, and those opposite cases want opposite handling. A renamed view has
+# to be loud, because a repair that quietly stops repairing is how this class
+# of bug went unnoticed through two releases. A dropped schema has to be silent.
+
+# The dropped schema cannot be put back from SQL, so hand mtr a fresh datadir
+# for whatever runs next.
+--source include/force_restart.inc
+
+DROP DATABASE sys;
+
+--echo # Startup must survive the missing schema, not abort on it.
+--source include/restart_mysqld.inc
+
+--echo # And it must not have resurrected a partial sys schema on the way past.
+SELECT COUNT(*) AS sys_schemata FROM information_schema.SCHEMATA
+ WHERE SCHEMA_NAME = 'sys';

--- a/villagesql/sql/CMakeLists.txt
+++ b/villagesql/sql/CMakeLists.txt
@@ -19,6 +19,7 @@ SET(VILLAGESQL_SQL_SOURCES
   initialize.cc
   metadata_modifier.cc
   parse_tree_items.cc
+  sys_view_metadata.cc
   util.cc
 )
 

--- a/villagesql/sql/initialize.cc
+++ b/villagesql/sql/initialize.cc
@@ -28,6 +28,7 @@
 #include "sql/bootstrap.h"
 #include "sql/dd/cache/dictionary_client.h"
 #include "sql/mysqld.h"
+#include "sql/opt_costconstantcache.h"
 #include "sql/sd_notify.h"
 #include "sql/sys_vars.h"
 #include "sql/thd_raii.h"
@@ -39,6 +40,7 @@
 #include "villagesql/schema/schema_manager.h"
 #include "villagesql/schema/victionary_client.h"
 #include "villagesql/services/capability_registry.h"
+#include "villagesql/sql/sys_view_metadata.h"
 #include "villagesql/veb/veb_file.h"
 
 namespace villagesql {
@@ -245,6 +247,14 @@ static bool do_init_extension_infrastructure(THD *thd) {
     return true;
   }
 
+  // Repair the sys view metadata that installing the VillageSQL
+  // INFORMATION_SCHEMA overrides rewrote.
+  if (refresh_sys_view_metadata(thd)) {
+    trans_rollback_stmt(thd);
+    trans_rollback(thd);
+    return true;
+  }
+
   // Load installed extensions from villagesql.extensions table
   // This validates manifests and cleans up orphaned expansion directories
   if (villagesql::veb::load_installed_extensions(thd)) {
@@ -288,9 +298,19 @@ bool init_extension_infrastructure() {
   // The initialization code may update table settings, in order to avoid
   // locking and avoid asserts in the locking code, run on a bootstrap dd system
   // thread.
-  if (bootstrap::run_bootstrap_thread(nullptr, nullptr,
-                                      &do_init_extension_infrastructure,
-                                      SYSTEM_THREAD_DD_INITIALIZE)) {
+  //
+  // The optimizer cost model is not initialized at this point in startup --
+  // init_server_components() tears it down after each bootstrap DDL phase and
+  // only brings it up for good later. refresh_sys_view_metadata() re-creates
+  // ALGORITHM=TEMPTABLE sys views, and create_tmp_table() reaches into the cost
+  // model, so bracket the thread the same way init_server_components().
+  init_optimizer_cost_module(true);
+  const bool init_failed = bootstrap::run_bootstrap_thread(
+      nullptr, nullptr, &do_init_extension_infrastructure,
+      SYSTEM_THREAD_DD_INITIALIZE);
+  delete_optimizer_cost_module();
+
+  if (init_failed) {
     LogVSQL(ERROR_LEVEL, "Failed to initialize");
     sysd::notify("STATUS=VillageSQL initialization unsuccessful\n");
     return true;

--- a/villagesql/sql/initialize.cc
+++ b/villagesql/sql/initialize.cc
@@ -248,12 +248,11 @@ static bool do_init_extension_infrastructure(THD *thd) {
   }
 
   // Repair the sys view metadata that installing the VillageSQL
-  // INFORMATION_SCHEMA overrides rewrote.
-  if (refresh_sys_view_metadata(thd)) {
-    trans_rollback_stmt(thd);
-    trans_rollback(thd);
-    return true;
-  }
+  // INFORMATION_SCHEMA overrides rewrote. Best effort by design: it logs its
+  // own failures and never fails startup, because the metadata is display only
+  // and the likeliest failure is upstream drift rather than a broken
+  // dictionary.
+  refresh_sys_view_metadata(thd);
 
   // Load installed extensions from villagesql.extensions table
   // This validates manifests and cleans up orphaned expansion directories
@@ -303,7 +302,7 @@ bool init_extension_infrastructure() {
   // init_server_components() tears it down after each bootstrap DDL phase and
   // only brings it up for good later. refresh_sys_view_metadata() re-creates
   // ALGORITHM=TEMPTABLE sys views, and create_tmp_table() reaches into the cost
-  // model, so bracket the thread the same way init_server_components().
+  // model, so bracket the thread the same way init_server_components() does.
   init_optimizer_cost_module(true);
   const bool init_failed = bootstrap::run_bootstrap_thread(
       nullptr, nullptr, &do_init_extension_infrastructure,

--- a/villagesql/sql/sys_view_metadata.cc
+++ b/villagesql/sql/sys_view_metadata.cc
@@ -1,0 +1,224 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+#include "villagesql/sql/sys_view_metadata.h"
+
+#include <array>
+#include <cctype>
+#include <cstring>
+#include <string>
+
+#include "my_sys.h"
+#include "sql/dd/cache/dictionary_client.h"
+#include "sql/dd/dd_schema.h"
+#include "sql/dd/types/abstract_table.h"
+#include "sql/dd/types/column.h"
+#include "sql/dd/types/view.h"
+#include "sql/mysqld.h"
+#include "sql/sql_class.h"
+#include "sql/thd_raii.h"
+#include "villagesql/include/error.h"
+#include "villagesql/schema/systable/helpers.h"
+
+// Declared the same way sql/dd/impl/upgrade/server.cc does for
+// fix_sys_schema().
+extern const char *mysql_sys_schema[];
+
+namespace villagesql {
+
+namespace {
+
+constexpr const char *kSysSchemaName = "sys";
+
+// This is a membership set, not an execution order: the replay follows
+// mysql_sys_schema[] order, which lists every view after the ones it reads.
+// It has to be this order as recreating a view implicitly recreates the
+// metadata of whatever reads it.
+constexpr auto kAffectedSysViews = std::to_array<const char *>({
+    "schema_object_overview",
+    "x$schema_flattened_keys",
+    "schema_auto_increment_columns",
+    "schema_redundant_indexes",
+});
+
+struct SysViewSentinel {
+  const char *view_name;
+  const char *column_name;
+};
+
+// One sentinel column per overridden INFORMATION_SCHEMA view, used to tell
+// whether the metadata still looks the way a vanilla server records it. A
+// healthy sentinel is nullable; a rewritten one is NOT NULL.
+constexpr auto kSysViewSentinels = std::to_array<SysViewSentinel>({
+    {"x$schema_flattened_keys", "index_name"},
+    {"schema_auto_increment_columns", "column_name"},
+});
+
+// True when query is the CREATE OR REPLACE VIEW statement for view_name.
+bool statement_creates_view(const char *query, const char *view_name) {
+  const std::string needle = std::string("VIEW ") + view_name;
+  const char *hit = strstr(query, needle.c_str());
+  if (hit == nullptr) return false;
+
+  // hit[needle.length()] is the character just after the match, which must
+  // not be alphanumeric or '_' or '$' to be a whole-identifier match.
+  // hit[needle.length()] is safe - it's null character in the worst case.
+  const unsigned char after = static_cast<unsigned char>(hit[needle.length()]);
+  return !(std::isalnum(after) || after == '_' || after == '$');
+}
+
+// True when every sentinel column is still nullable, meaning nothing needs
+// repairing.
+bool sys_view_metadata_is_vanilla(THD *thd) {
+  for (const SysViewSentinel &sentinel : kSysViewSentinels) {
+    const dd::Abstract_table *table = nullptr;
+    if (thd->dd_client()->acquire(kSysSchemaName, sentinel.view_name, &table)) {
+      LogVSQL(WARNING_LEVEL,
+              "Could not read sys.%s from the data dictionary; refreshing sys "
+              "view metadata anyway",
+              sentinel.view_name);
+      return false;
+    }
+
+    const dd::View *view = dynamic_cast<const dd::View *>(table);
+    if (view == nullptr) {
+      // TODO(villagesql-rebase): upstream renamed or dropped this sys view.
+      // Update kSysViewSentinels and kAffectedSysViews to match
+      // scripts/sys_schema/.
+      LogVSQL(WARNING_LEVEL,
+              "sys.%s is not a view; refreshing sys view metadata anyway",
+              sentinel.view_name);
+      return false;
+    }
+
+    const dd::Column *column = nullptr;
+    for (const dd::Column *candidate : view->columns()) {
+      if (my_strcasecmp(system_charset_info, candidate->name().c_str(),
+                        sentinel.column_name) == 0) {
+        column = candidate;
+        break;
+      }
+    }
+    if (column == nullptr) {
+      // TODO(villagesql-rebase): upstream renamed or dropped this column.
+      LogVSQL(WARNING_LEVEL,
+              "sys.%s has no column %s; refreshing sys view metadata anyway",
+              sentinel.view_name, sentinel.column_name);
+      return false;
+    }
+
+    if (!column->is_nullable()) return false;
+  }
+
+  return true;
+}
+
+// SET NAMES utf8mb4 is recorded as the view's character_set_client and
+// collation_connection, and it also fixes the collation of the string literals
+// in bodies like CONCAT('ALTER TABLE `', ...).
+class Sys_schema_ddl_context {
+ public:
+  explicit Sys_schema_ddl_context(THD *thd)
+      : m_thd(thd),
+        m_saved_client_cs(thd->variables.character_set_client),
+        m_saved_connection_cl(thd->variables.collation_connection),
+        m_saved_db(thd->db()) {
+    const CHARSET_INFO *client_cs = nullptr;
+    const CHARSET_INFO *connection_cl = nullptr;
+    if (resolve_charset("utf8mb4", system_charset_info, &client_cs) ||
+        resolve_collation("utf8mb4_0900_ai_ci", system_charset_info,
+                          &connection_cl)) {
+      LogVSQL(ERROR_LEVEL, "Could not resolve the utf8mb4 charset");
+      m_error = true;
+      return;
+    }
+
+    m_thd->variables.character_set_client = client_cs;
+    m_thd->variables.collation_connection = connection_cl;
+    m_thd->update_charset();
+    m_thd->reset_db({kSysSchemaName, strlen(kSysSchemaName)});
+  }
+
+  ~Sys_schema_ddl_context() {
+    m_thd->reset_db(m_saved_db);
+    m_thd->variables.character_set_client = m_saved_client_cs;
+    m_thd->variables.collation_connection = m_saved_connection_cl;
+    m_thd->update_charset();
+  }
+
+  Sys_schema_ddl_context(const Sys_schema_ddl_context &) = delete;
+  Sys_schema_ddl_context &operator=(const Sys_schema_ddl_context &) = delete;
+
+  bool error() const { return m_error; }
+
+ private:
+  THD *m_thd;
+  const CHARSET_INFO *m_saved_client_cs;
+  const CHARSET_INFO *m_saved_connection_cl;
+  LEX_CSTRING m_saved_db;
+  bool m_error{false};
+};
+
+}  // namespace
+
+// Restores the stored column metadata of the sys views listed in
+// kAffectedSysViews, by replaying their CREATE OR REPLACE VIEW statements out
+// of the generated mysql_sys_schema[] array.
+//
+// Must run on a bootstrap thread. run_bootstrap_thread() sets the server
+// default sql_mode (strict_mode).
+bool refresh_sys_view_metadata(THD *thd) {
+  bool sys_schema_exists = false;
+  if (dd::schema_exists(thd, kSysSchemaName, &sys_schema_exists)) return true;
+  if (!sys_schema_exists) return false;
+
+  if (sys_view_metadata_is_vanilla(thd)) return false;
+
+  const Disable_binlog_guard binlog_guard(thd);
+  const Disable_sql_log_bin_guard sql_log_bin_guard(thd);
+  const Sys_schema_ddl_context ddl_context(thd);
+  if (ddl_context.error()) return true;
+
+  std::array<size_t, kAffectedSysViews.size()> replayed{};
+  for (const char **query = &mysql_sys_schema[0]; *query != nullptr; query++) {
+    for (size_t i = 0; i < kAffectedSysViews.size(); i++) {
+      if (!statement_creates_view(*query, kAffectedSysViews[i])) continue;
+      replayed[i]++;
+      // A CREATE OR REPLACE VIEW implicitly commits, which is why this runs
+      // between two statements rather than mid-transaction. Disabling
+      // autocommit does not suppress that: SQLCOM_CREATE_VIEW carries
+      // CF_AUTO_COMMIT_TRANS.
+      if (villagesql::execute_statement(thd, *query)) return true;
+      break;
+    }
+  }
+
+  for (size_t i = 0; i < kAffectedSysViews.size(); i++) {
+    if (replayed[i] == 1) continue;
+    // TODO(villagesql-rebase): upstream renamed, split or dropped this sys
+    // view. Update kAffectedSysViews to match scripts/sys_schema/.
+    LogVSQL(ERROR_LEVEL,
+            "Expected exactly one CREATE VIEW statement for sys.%s in the sys "
+            "schema script, found %zu",
+            kAffectedSysViews[i], replayed[i]);
+    return true;
+  }
+
+  LogVSQL(INFORMATION_LEVEL, "Refreshed stored metadata of %zu sys views",
+          kAffectedSysViews.size());
+  return false;
+}
+
+}  // namespace villagesql

--- a/villagesql/sql/sys_view_metadata.cc
+++ b/villagesql/sql/sys_view_metadata.cc
@@ -19,13 +19,16 @@
 #include <cctype>
 #include <cstring>
 #include <string>
+#include <string_view>
 
+#include "m_string.h"
 #include "my_sys.h"
 #include "sql/dd/cache/dictionary_client.h"
 #include "sql/dd/dd_schema.h"
 #include "sql/dd/types/abstract_table.h"
 #include "sql/dd/types/column.h"
 #include "sql/dd/types/view.h"
+#include "sql/dd_table_share.h"
 #include "sql/mysqld.h"
 #include "sql/sql_class.h"
 #include "sql/thd_raii.h"
@@ -42,71 +45,163 @@ namespace {
 
 constexpr const char *kSysSchemaName = "sys";
 
+struct AffectedSysView {
+  const char *view_name;
+  // A column whose nullability reveals whether this view's metadata was
+  // rewritten: any column the body renders through an Item_str_func, i.e. a
+  // COLLATE or CONCAT expression. Nullable means vanilla, NOT NULL means
+  // rewritten.
+  const char *sentinel_column;
+};
+
+// TODO(villagesql-rebase): upstream may add, rename or drop a sys view that
+// reads one of the overridden INFORMATION_SCHEMA views, in which case this list
+// needs updating. Docs/merging/post-merge-checks.md has the procedure, under
+// "The sys view metadata repair".
+//
+// Tests in villagesql/information_schema back that up. sys_view_metadata
+// catches a rename or drop. sys_view_metadata_dependents catches an addition,
+// because it derives the dependent set from VIEW_TABLE_USAGE instead of a fixed
+// list.
+//
 // This is a membership set, not an execution order: the replay follows
 // mysql_sys_schema[] order, which lists every view after the ones it reads.
 // It has to be this order as recreating a view implicitly recreates the
 // metadata of whatever reads it.
-constexpr auto kAffectedSysViews = std::to_array<const char *>({
-    "schema_object_overview",
-    "x$schema_flattened_keys",
-    "schema_auto_increment_columns",
-    "schema_redundant_indexes",
-});
-
-struct SysViewSentinel {
-  const char *view_name;
-  const char *column_name;
-};
-
-// One sentinel column per overridden INFORMATION_SCHEMA view, used to tell
-// whether the metadata still looks the way a vanilla server records it. A
-// healthy sentinel is nullable; a rewritten one is NOT NULL.
-constexpr auto kSysViewSentinels = std::to_array<SysViewSentinel>({
+//
+// Every entry carries its own sentinel so the detection and the repair cannot
+// drift apart.
+constexpr auto kAffectedSysViews = std::to_array<AffectedSysView>({
+    {"schema_object_overview", "object_type"},
     {"x$schema_flattened_keys", "index_name"},
     {"schema_auto_increment_columns", "column_name"},
+    {"schema_redundant_indexes", "redundant_index_name"},
 });
 
-// True when query is the CREATE OR REPLACE VIEW statement for view_name.
-bool statement_creates_view(const char *query, const char *view_name) {
-  const std::string needle = std::string("VIEW ") + view_name;
-  const char *hit = strstr(query, needle.c_str());
-  if (hit == nullptr) return false;
+// Returns query advanced past leading blank and "--" comment lines, so the
+// result points at the statement's first real token. Needed because
+// mysql_sys_schema keeps each statement's comment block -- GPL header included
+// -- in the same mysql_sys_schema[] element as the statement, so an element
+// begins
+// "-- Copyright (c) ..." rather than at its CREATE.
+//
+// Only "--" and blank lines are skipped. MySQL also accepts "#" and "/* */",
+// but no statement opens with either. Returned string_view will not be a
+// valid SQL statement.
+// Returning an empty view means "nothing left that could be a statement".
+std::string_view skip_leading_dash_comments(std::string_view query) {
+  for (;;) {
+    const size_t token = query.find_first_not_of(" \t\n\r");
+    if (token == std::string_view::npos) return {};
+    query.remove_prefix(token);
 
-  // hit[needle.length()] is the character just after the match, which must
-  // not be alphanumeric or '_' or '$' to be a whole-identifier match.
-  // hit[needle.length()] is safe - it's null character in the worst case.
-  const unsigned char after = static_cast<unsigned char>(hit[needle.length()]);
+    if (!query.starts_with("--")) return query;
+
+    const size_t eol = query.find('\n');
+    if (eol == std::string_view::npos) return {};
+    query.remove_prefix(eol + 1);
+  }
+}
+
+size_t find_case_insensitive(std::string_view haystack,
+                             std::string_view needle) {
+  if (needle.size() > haystack.size()) return std::string_view::npos;
+
+  const size_t last_start = haystack.size() - needle.size();
+  for (size_t i = 0; i <= last_start; i++) {
+    if (native_strncasecmp(haystack.data() + i, needle.data(), needle.size()) ==
+        0)
+      return i;
+  }
+  return std::string_view::npos;
+}
+
+// True when query is the CREATE OR REPLACE VIEW statement for view_name.
+//
+// The statement must *be* a CREATE OR REPLACE, not merely contain one: sample
+// SQL quoted in a comment block would satisfy containment, and
+// procedures/statement_performance_analyzer.sql already documents a
+// "mysql> CREATE OR REPLACE VIEW mydb.my_statements AS" example.
+//
+// The name is still searched for rather than expected adjacently, because the
+// sys views are written as
+//
+//   CREATE OR REPLACE
+//     ALGORITHM = TEMPTABLE
+//     DEFINER = 'mysql.sys'@'localhost'
+//     SQL SECURITY INVOKER
+//   VIEW x$schema_flattened_keys (
+//
+// so "CREATE OR REPLACE VIEW" may not appear contiguously. Matching is case
+// insensitive and byte-wise; sys view names are ASCII.
+bool statement_creates_view(std::string_view query,
+                            std::string_view view_name) {
+  static constexpr std::string_view kCreateOrReplace = "CREATE OR REPLACE";
+
+  const std::string_view stmt = skip_leading_dash_comments(query);
+  if (stmt.size() < kCreateOrReplace.size() ||
+      native_strncasecmp(stmt.data(), kCreateOrReplace.data(),
+                         kCreateOrReplace.size()) != 0)
+    return false;
+
+  const std::string needle = std::string("VIEW ").append(view_name);
+  const size_t pos = find_case_insensitive(stmt, needle);
+  if (pos == std::string_view::npos) return false;
+
+  // The character just after the name must not be alphanumeric or
+  // '_' or '$' to be a whole-identifier match.
+  const size_t after_pos = pos + needle.size();
+  if (after_pos == stmt.size()) return true;
+  const unsigned char after = static_cast<unsigned char>(stmt[after_pos]);
   return !(std::isalnum(after) || after == '_' || after == '$');
 }
 
-// True when every sentinel column is still nullable, meaning nothing needs
-// repairing.
-bool sys_view_metadata_is_vanilla(THD *thd) {
-  for (const SysViewSentinel &sentinel : kSysViewSentinels) {
+// Text of the error a failed data dictionary read raised, for logging before
+// clear_dd_error() discards it.
+const char *dd_error_text(THD *thd) {
+  return thd->is_error() ? thd->get_stmt_da()->message_text()
+                         : "no error reported";
+}
+
+// Consumes the error a failed data dictionary read left on the THD.
+void clear_dd_error(THD *thd) { thd->clear_error(); }
+
+// True when the sentinel columns no longer hold the metadata a vanilla server
+// records, so replaying is worth doing.
+//
+// There are three outcomes underneath, and two of them return false. Vanilla
+// metadata needs no replay. An unreadable dictionary also returns false, but
+// for the opposite reason -- we learned nothing, so there is no basis to act
+// on -- and it logs and clears the error before returning.
+bool sys_view_metadata_needs_refresh(THD *thd) {
+  for (const AffectedSysView &affected : kAffectedSysViews) {
     const dd::Abstract_table *table = nullptr;
-    if (thd->dd_client()->acquire(kSysSchemaName, sentinel.view_name, &table)) {
-      LogVSQL(WARNING_LEVEL,
-              "Could not read sys.%s from the data dictionary; refreshing sys "
-              "view metadata anyway",
-              sentinel.view_name);
+    // A missing view is not an error and does not land here: acquire() reports
+    // that as success with a null table. Reaching this branch means the
+    // dictionary itself could not be read.
+    if (thd->dd_client()->acquire(kSysSchemaName, affected.view_name, &table)) {
+      LogVSQL(ERROR_LEVEL,
+              "Could not read sys.%s from the data dictionary: %s; leaving sys "
+              "view metadata as it is until the next restart",
+              affected.view_name, dd_error_text(thd));
+      clear_dd_error(thd);
       return false;
     }
 
     const dd::View *view = dynamic_cast<const dd::View *>(table);
     if (view == nullptr) {
       // TODO(villagesql-rebase): upstream renamed or dropped this sys view.
-      // Update kSysViewSentinels and kAffectedSysViews to match
-      // scripts/sys_schema/.
+      // Update kAffectedSysViews to match scripts/sys_schema/.
       LogVSQL(WARNING_LEVEL,
               "sys.%s is not a view; refreshing sys view metadata anyway",
-              sentinel.view_name);
-      return false;
+              affected.view_name);
+      return true;
     }
 
     const dd::Column *column = nullptr;
     for (const dd::Column *candidate : view->columns()) {
       if (my_strcasecmp(system_charset_info, candidate->name().c_str(),
-                        sentinel.column_name) == 0) {
+                        affected.sentinel_column) == 0) {
         column = candidate;
         break;
       }
@@ -115,61 +210,83 @@ bool sys_view_metadata_is_vanilla(THD *thd) {
       // TODO(villagesql-rebase): upstream renamed or dropped this column.
       LogVSQL(WARNING_LEVEL,
               "sys.%s has no column %s; refreshing sys view metadata anyway",
-              sentinel.view_name, sentinel.column_name);
-      return false;
+              affected.view_name, affected.sentinel_column);
+      return true;
     }
 
-    if (!column->is_nullable()) return false;
+    if (!column->is_nullable()) return true;
   }
 
-  return true;
+  return false;
 }
 
-// SET NAMES utf8mb4 is recorded as the view's character_set_client and
-// collation_connection, and it also fixes the collation of the string literals
-// in bodies like CONCAT('ALTER TABLE `', ...).
-class Sys_schema_ddl_context {
+class Sys_schema_db_context {
  public:
-  explicit Sys_schema_ddl_context(THD *thd)
-      : m_thd(thd),
-        m_saved_client_cs(thd->variables.character_set_client),
-        m_saved_connection_cl(thd->variables.collation_connection),
-        m_saved_db(thd->db()) {
-    const CHARSET_INFO *client_cs = nullptr;
-    const CHARSET_INFO *connection_cl = nullptr;
-    if (resolve_charset("utf8mb4", system_charset_info, &client_cs) ||
-        resolve_collation("utf8mb4_0900_ai_ci", system_charset_info,
-                          &connection_cl)) {
-      LogVSQL(ERROR_LEVEL, "Could not resolve the utf8mb4 charset");
-      m_error = true;
-      return;
-    }
-
-    m_thd->variables.character_set_client = client_cs;
-    m_thd->variables.collation_connection = connection_cl;
-    m_thd->update_charset();
+  explicit Sys_schema_db_context(THD *thd) : m_thd(thd), m_saved_db(thd->db()) {
     m_thd->reset_db({kSysSchemaName, strlen(kSysSchemaName)});
   }
 
-  ~Sys_schema_ddl_context() {
-    m_thd->reset_db(m_saved_db);
+  ~Sys_schema_db_context() { m_thd->reset_db(m_saved_db); }
+
+  Sys_schema_db_context(const Sys_schema_db_context &) = delete;
+  Sys_schema_db_context &operator=(const Sys_schema_db_context &) = delete;
+
+ private:
+  THD *m_thd;
+  LEX_CSTRING m_saved_db;
+};
+
+// Recreates a view under the character set and collation it already carries.
+class View_charset_context {
+ public:
+  View_charset_context(THD *thd, const CHARSET_INFO *client_cs,
+                       const CHARSET_INFO *connection_cl)
+      : m_thd(thd),
+        m_saved_client_cs(thd->variables.character_set_client),
+        m_saved_connection_cl(thd->variables.collation_connection) {
+    m_thd->variables.character_set_client = client_cs;
+    m_thd->variables.collation_connection = connection_cl;
+    m_thd->update_charset();
+  }
+
+  ~View_charset_context() {
     m_thd->variables.character_set_client = m_saved_client_cs;
     m_thd->variables.collation_connection = m_saved_connection_cl;
     m_thd->update_charset();
   }
 
-  Sys_schema_ddl_context(const Sys_schema_ddl_context &) = delete;
-  Sys_schema_ddl_context &operator=(const Sys_schema_ddl_context &) = delete;
-
-  bool error() const { return m_error; }
+  View_charset_context(const View_charset_context &) = delete;
+  View_charset_context &operator=(const View_charset_context &) = delete;
 
  private:
   THD *m_thd;
   const CHARSET_INFO *m_saved_client_cs;
   const CHARSET_INFO *m_saved_connection_cl;
-  LEX_CSTRING m_saved_db;
-  bool m_error{false};
 };
+
+// Reads the character set and collation sys.view_name currently records, the
+// pair a CREATE OR REPLACE has to reproduce. False means they could not be
+// determined, and the caller leaves that view alone rather than guessing: a
+// wrong character set would be written into the view silently, with nothing in
+// the column metadata to show for it.
+bool view_ddl_charset(THD *thd, const char *view_name,
+                      const CHARSET_INFO **client_cs,
+                      const CHARSET_INFO **connection_cl) {
+  const dd::Abstract_table *table = nullptr;
+  if (thd->dd_client()->acquire(kSysSchemaName, view_name, &table)) {
+    LogVSQL(ERROR_LEVEL, "Could not read sys.%s from the data dictionary: %s",
+            view_name, dd_error_text(thd));
+    clear_dd_error(thd);
+    return false;
+  }
+
+  const dd::View *view = dynamic_cast<const dd::View *>(table);
+  if (view == nullptr) return false;
+
+  *client_cs = dd_get_mysql_charset(view->client_collation_id());
+  *connection_cl = dd_get_mysql_charset(view->connection_collation_id());
+  return *client_cs != nullptr && *connection_cl != nullptr;
+}
 
 }  // namespace
 
@@ -179,28 +296,78 @@ class Sys_schema_ddl_context {
 //
 // Must run on a bootstrap thread. run_bootstrap_thread() sets the server
 // default sql_mode (strict_mode).
-bool refresh_sys_view_metadata(THD *thd) {
+// Every failure path below logs and returns without repairing the rest. The
+// metadata is display only, so a partial or skipped repair is not worth failing
+// startup over, and nothing records that the attempt was made: the next startup
+// inspects the dictionary again and repairs then if it can.
+void refresh_sys_view_metadata(THD *thd) {
   bool sys_schema_exists = false;
-  if (dd::schema_exists(thd, kSysSchemaName, &sys_schema_exists)) return true;
-  if (!sys_schema_exists) return false;
+  if (dd::schema_exists(thd, kSysSchemaName, &sys_schema_exists)) {
+    LogVSQL(
+        ERROR_LEVEL,
+        "Could not determine whether the sys schema exists: %s; leaving sys "
+        "view metadata as it is until the next restart",
+        dd_error_text(thd));
+    clear_dd_error(thd);
+    return;
+  }
+  if (!sys_schema_exists) return;
 
-  if (sys_view_metadata_is_vanilla(thd)) return false;
+  // A false here can mean the metadata is fine or that the dictionary could not
+  // be read, which has logged and cleared its own error. Nothing is persisted
+  // either way, so the next startup re-inspects and repairs if it can.
+  if (!sys_view_metadata_needs_refresh(thd)) {
+    assert(false == thd->is_error());
+    // sys_view_metadata_needs_refresh should've cleared the error if it failed.
+    // Just to be safe, log and clear the error here as well.
+    if (thd->is_error()) {
+      LogVSQL(
+          ERROR_LEVEL,
+          "Could not determine whether sys view metadata needs refresh: %s; "
+          "leaving sys view metadata as it is until the next restart",
+          dd_error_text(thd));
+      clear_dd_error(thd);
+    }
+    return;
+  }
 
   const Disable_binlog_guard binlog_guard(thd);
   const Disable_sql_log_bin_guard sql_log_bin_guard(thd);
-  const Sys_schema_ddl_context ddl_context(thd);
-  if (ddl_context.error()) return true;
+  const Sys_schema_db_context db_context(thd);
 
   std::array<size_t, kAffectedSysViews.size()> replayed{};
   for (const char **query = &mysql_sys_schema[0]; *query != nullptr; query++) {
     for (size_t i = 0; i < kAffectedSysViews.size(); i++) {
-      if (!statement_creates_view(*query, kAffectedSysViews[i])) continue;
+      const char *view_name = kAffectedSysViews[i].view_name;
+      if (!statement_creates_view(*query, view_name)) continue;
+      // Counted as found even when the replay below is skipped: this covers
+      // what the sys schema script contains
       replayed[i]++;
+
+      const CHARSET_INFO *client_cs = nullptr;
+      const CHARSET_INFO *connection_cl = nullptr;
+      if (!view_ddl_charset(thd, view_name, &client_cs, &connection_cl)) {
+        LogVSQL(WARNING_LEVEL,
+                "Could not read the character set sys.%s was created with; "
+                "leaving that view as it is",
+                view_name);
+        break;
+      }
+      const View_charset_context charset_context(thd, client_cs, connection_cl);
+
       // A CREATE OR REPLACE VIEW implicitly commits, which is why this runs
       // between two statements rather than mid-transaction. Disabling
       // autocommit does not suppress that: SQLCOM_CREATE_VIEW carries
       // CF_AUTO_COMMIT_TRANS.
-      if (villagesql::execute_statement(thd, *query)) return true;
+      // So nothing may be pending here, or the implicit commit would commit it
+      // on behalf of whoever opened it. Asserted every iteration rather than
+      // once before the loop, because that same implicit commit is what has to
+      // leave the state clean for the next view.
+      assert(thd->get_transaction()->is_empty(Transaction_ctx::STMT));
+      assert(thd->get_transaction()->is_empty(Transaction_ctx::SESSION));
+
+      // execute_statement() has already logged the failure.
+      if (villagesql::execute_statement(thd, *query)) return;
       break;
     }
   }
@@ -209,16 +376,15 @@ bool refresh_sys_view_metadata(THD *thd) {
     if (replayed[i] == 1) continue;
     // TODO(villagesql-rebase): upstream renamed, split or dropped this sys
     // view. Update kAffectedSysViews to match scripts/sys_schema/.
-    LogVSQL(ERROR_LEVEL,
+    LogVSQL(WARNING_LEVEL,
             "Expected exactly one CREATE VIEW statement for sys.%s in the sys "
-            "schema script, found %zu",
-            kAffectedSysViews[i], replayed[i]);
-    return true;
+            "schema script, found %zu; sys view metadata left as it is",
+            kAffectedSysViews[i].view_name, replayed[i]);
+    return;
   }
 
   LogVSQL(INFORMATION_LEVEL, "Refreshed stored metadata of %zu sys views",
           kAffectedSysViews.size());
-  return false;
 }
 
 }  // namespace villagesql

--- a/villagesql/sql/sys_view_metadata.h
+++ b/villagesql/sql/sys_view_metadata.h
@@ -1,0 +1,54 @@
+/* Copyright (c) 2026 VillageSQL Contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef VILLAGESQL_SQL_SYS_VIEW_METADATA_H_
+#define VILLAGESQL_SQL_SYS_VIEW_METADATA_H_
+
+class THD;
+
+namespace villagesql {
+
+// Restores the stored column metadata of the sys views that installing the
+// VillageSQL INFORMATION_SCHEMA overrides re-derives.
+//
+// When INFORMATION_SCHEMA is first created - it's created in strict sql_mode.
+// When INFORMATION_SCHEMA (NON_DD_BASED) are created with CREATE OR REPLACE
+// VIEW, they are created with sql_mode = 0. This makes columns defined with
+// COLLATE and CONCAT to be marked as NOT NULL, which is not the case when they
+// are created in strict sql_mode. This function replays the CREATE OR REPLACE
+// VIEW statements for these views under strict sql_mode to restore the original
+// column metadata.
+//
+// Two requirements on the caller:
+//
+//   - Run it on a bootstrap thread. run_bootstrap_thread() installs the server
+//     default sql_mode, and the strict mode in it is precisely what makes the
+//     replay record the vanilla values. Under a relaxed sql_mode this
+//     re-records the rewritten form and achieves nothing.
+//
+//   - Have the optimizer cost model initialized. Some of the sys views are
+//     ALGORITHM = TEMPTABLE, and create_tmp_table() reaches into it. Startup
+//     tears the cost model down between bootstrap DDL phases, so the caller
+//     generally needs an init_optimizer_cost_module() / delete pair around it.
+//
+// Returns true on failure. Callers during startup should treat that as fatal:
+// it runs single-threaded with no concurrent DDL, so this replay should not
+// failed.
+bool refresh_sys_view_metadata(THD *thd);
+
+}  // namespace villagesql
+
+#endif  // VILLAGESQL_SQL_SYS_VIEW_METADATA_H_

--- a/villagesql/sql/sys_view_metadata.h
+++ b/villagesql/sql/sys_view_metadata.h
@@ -44,10 +44,9 @@ namespace villagesql {
 //     tears the cost model down between bootstrap DDL phases, so the caller
 //     generally needs an init_optimizer_cost_module() / delete pair around it.
 //
-// Returns true on failure. Callers during startup should treat that as fatal:
-// it runs single-threaded with no concurrent DDL, so this replay should not
-// failed.
-bool refresh_sys_view_metadata(THD *thd);
+// The repair is best effort and never reports failure to the caller, which is
+// why this returns nothing.
+void refresh_sys_view_metadata(THD *thd);
 
 }  // namespace villagesql
 


### PR DESCRIPTION
In villagesql we create our version of COLUMNS and STATISTICS. It turns out they are not exactly the same as the tables in upstream MySQL. The difference is nullability. Our tables show NO, while upstream shows YES. The difference is due to the fact that during bootstrap the CREATEs are run in strict mode. Some of the columns are marked with COLLATE. In strict mode COLLATE marks the columns as NULLable. However, when our overrides are created - mysql runs CREATE OR REPLACE VIEW with sql_mode = 0 - which makes the COLLATE columns not nullable. Here ours I_S tables differ from upstream.

refresh_sys_view_metadata() replays the four affected views' DDL at startup.

This also reverts the same drift for sys.schema_auto_increment_columns, introduced by the I_S.COLUMNS override in 0.0.1.

Closes #1109