### PR TITLE
Recorded v_schema_object_overview

### DIFF
--- a/mysql-test/suite/sysschema/r/v_schema_object_overview.result
+++ b/mysql-test/suite/sysschema/r/v_schema_object_overview.result
@@ -1,6 +1,6 @@
 DESC sys.schema_object_overview;
 Field	Type	Null	Key	Default	Extra
 db	varchar(64)	#		#	
-object_type	varchar(19)	#		#	
+object_type	varchar(72)	#		#	
 count	bigint	#		#	
 SELECT * FROM sys.schema_object_overview;


### PR DESCRIPTION
During implementation of SHOW INDEX, the INDEX_TYPE column was widened from varchar(11) utf8mb3_bin to varchar(64) utf8mb4_bin, since the value now comes from a villagesql column.

The v_schema_object_overview didn't record this value and failed.
