### PR TITLE
Backport reader service from 9.7

### DIFF
--- a/include/mysql/components/services/mysql_system_variable.h
+++ b/include/mysql/components/services/mysql_system_variable.h
@@ -1,4 +1,5 @@
 /* Copyright (c) 2021, 2026, Oracle and/or its affiliates.
+   Copyright (c) 2026 VillageSQL Contributors
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License, version 2.0,
@@ -280,5 +281,85 @@ DECLARE_BOOL_METHOD(set,
                     (MYSQL_THD thd, const char *variable_type,
                      my_h_string variable_base, my_h_string variable_name));
 END_SERVICE_DEFINITION(mysql_system_variable_update_default)
+
+// TODO(villagesql-rebase): this file was edited to add the
+// mysql_system_variable_reader service definition backported from 9.7 -- only
+// this block was added, the rest of the file is unchanged. On the 8.4->9.x
+// rebase upstream already declares this service, so drop this block and restore
+// verbatim 9.7.
+/**
+  @ingroup group_components_services_inventory
+
+  Fetches the session/global/persist value of a system variable
+
+  This is an example of using the service:
+
+  Call this to get the session/global/persist value of a variable.
+  You can access both the component variables
+  (SELECT ["@@"][scope "."]component_name "." variable_name;
+   where scope ::= SESSION | LOCAL | GLOBAL)
+  and the "legacy" system variables
+  (SELECT ["@@"][scope "."].variable_name;
+   where scope ::= SESSION | LOCAL | GLOBAL) that are registered
+  by the server component.
+  To access the latter you need to pass "mysql_server" (lowercase) as a
+  component name.
+
+  A pointer to the value is returned into the val input/output argument. And the
+  length of the value (as applicable) is returned into the out_length_of_val
+  argument.
+
+  In case when the user buffer was too small to copy the value, the call fails
+  and needed buffer size is returned by 'out_length_of_val'.
+
+  Decide on a variable storage type among one of "GLOBAL" or "SESSION"
+
+  Typical use (char * variable):
+  @code
+
+  char *value, buffer_for_value[160];
+  size_t value_length;
+  const char *type = "GLOBAL";
+
+  value= &buffer_for_value[0];
+  value_length= sizeof(buffer_for_value) - 1;
+  mysql_service_mysql_system_variable_reader->get(nullptr, type, "foo", "bar",
+           &value, &value_length);
+  printf("%.*s", (int) value_length, value);
+
+  To get the "SESSION" value the "hthd" should be passed :
+  MYSQL_THD hthd;
+  if (mysql_service_mysql_current_thread_reader->get(&hthd)) {
+    my_error("%s\n", "mysql_current_thread_reader get() api failed");
+  }
+  mysql_service_mysql_system_variable_reader->get(
+          hthd, "SESSION", "foo", "bar",
+          &value, &value_length);
+
+  @endcode
+*/
+BEGIN_SERVICE_DEFINITION(mysql_system_variable_reader)
+/**
+  Gets the value of a system variable.
+
+  @param hthd thread session handle. if NULL, the GLOBAL value of the variable
+  is returned.
+  @param variable_type one of [GLOBAL, SESSION].
+  @param component_name Name of the component or "mysql_server" for the legacy
+  ones.
+  @param variable_name Name of the variable
+  @param[in,out] val On input: a buffer to hold the value. On output a pointer
+  to the value.
+  @param[in,out] out_length_of_val On input: the buffer size. On output the
+  length of the data copied.
+
+  @retval true    failure
+  @retval false   success
+*/
+DECLARE_BOOL_METHOD(get, (MYSQL_THD hthd, const char *variable_type,
+                          const char *component_name, const char *variable_name,
+                          void **val, size_t *out_length_of_val));
+
+END_SERVICE_DEFINITION(mysql_system_variable_reader)
 
 #endif /* MYSQL_SYSTEM_VARIABLES_H */

--- a/sql/server_component/CMakeLists.txt
+++ b/sql/server_component/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2020, 2026, Oracle and/or its affiliates.
+#    Copyright (c) 2026 VillageSQL Contributors
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,
@@ -61,6 +62,7 @@ SET(MYSQL_SERVER_COMPONENT_SOURCES
   audit_api_connection_service_imp.cc
   mysql_query_attributes_imp.cc
   mysql_server_keyring_lockable_imp.cc
+  mysql_system_variable_reader_imp.cc
   mysql_system_variable_update_imp.cc
   mysql_thd_attributes_imp.cc
   transaction_delegate_control_imp.cc

--- a/sql/server_component/mysql_system_variable_bits.h
+++ b/sql/server_component/mysql_system_variable_bits.h
@@ -1,0 +1,38 @@
+/* Copyright (c) 2024, 2026, Oracle and/or its affiliates.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License, version 2.0,
+as published by the Free Software Foundation.
+
+This program is designed to work with certain software (including
+but not limited to OpenSSL) that is licensed under separate terms,
+as designated in a particular file or component or in included license
+documentation.  The authors of MySQL hereby grant you an additional
+permission to link the program and your derivative works with the
+separately licensed software that they have either included with
+the program or referenced in the documentation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License, version 2.0, for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+
+#ifndef MYSQL_SYSTEM_VARIABLE_BITS_H
+#define MYSQL_SYSTEM_VARIABLE_BITS_H
+
+#include <sql/set_var.h>    // enum_var_type, sys_var
+#include "sql/sql_class.h"  // THD
+
+/**
+  Return the system variable type given a type name.
+*/
+enum_var_type sysvar_type(const char *type_name);
+
+const char *get_variable_value(THD *thd, sys_var *system_var, char *val_buf,
+                               enum_var_type var_type, size_t *val_length);
+
+#endif /* MYSQL_SYSTEM_VARIABLE_BITS_H */

--- a/sql/server_component/mysql_system_variable_reader_imp.cc
+++ b/sql/server_component/mysql_system_variable_reader_imp.cc
@@ -1,0 +1,90 @@
+/* Copyright (c) 2024, 2026, Oracle and/or its affiliates.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License, version 2.0,
+as published by the Free Software Foundation.
+
+This program is designed to work with certain software (including
+but not limited to OpenSSL) that is licensed under separate terms,
+as designated in a particular file or component or in included license
+documentation.  The authors of MySQL hereby grant you an additional
+permission to link the program and your derivative works with the
+separately licensed software that they have either included with
+the program or referenced in the documentation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License, version 2.0, for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+
+#include "sql/server_component/mysql_system_variable_reader_imp.h"
+#include "sql/server_component/mysql_system_variable_bits.h"
+
+#include <mysql/components/minimal_chassis.h>
+#include <mysql/components/services/log_builtins.h>
+#include <mysql/components/services/mysql_current_thread_reader.h>
+#include <sql/set_var.h>
+
+/**
+   Gets the value of a system variable.
+
+   Works only for system variables taking integer or compatible values.
+   Passing non-NULL THD means that the operation will be executed within the
+   scope of existing transaction, thus any operation side effects impacting
+   transaction itself (for example it may generate an SQL error that it stores
+   into the current THD). If using existing THD, security context of the thread
+   is checked to make sure that required privileges exist. Passing NULL makes a
+   call to current_thd and gets the GLOBAL value of the variable.
+   Passing NULL with SESSION type will gives error and returns.
+
+   @param hthd thread session handle. if NULL, the GLOBAL value of the variable
+   is returned.
+   @param variable_type one of [GLOBAL, SESSION].
+   @param component_name Name of the component or "mysql_server" for the legacy
+   ones.
+   @param variable_name Name of the variable
+   @param[in,out] val On input: a buffer to hold the value. On output a pointer
+   to the value.
+   @param[in,out] out_length_of_val On input: the buffer size. On output the
+   length of the data copied.
+
+   @retval false   success
+   @retval TRUE failure, error set. For error info, see THD if supplied.
+*/
+DEFINE_BOOL_METHOD(mysql_system_variable_reader_imp::get,
+                   (MYSQL_THD hthd, const char *variable_type,
+                    const char *component_name, const char *variable_name,
+                    void **val, size_t *out_length_of_val)) {
+  try {
+    enum_var_type var_type;
+
+    var_type = sysvar_type(variable_type);
+    if ((var_type == OPT_SESSION) && (hthd == nullptr)) {
+      LogErr(ERROR_LEVEL, ER_TMP_SESSION_FOR_VAR, variable_name);
+      return true;
+    }
+    if (var_type == OPT_DEFAULT) var_type = OPT_GLOBAL;
+    if (hthd == nullptr) {
+      hthd = current_thd;
+    }
+    // all of the non-prefixed variables are treated as part of the server
+    // component
+    const char *prefix =
+        strcmp(component_name, "mysql_server") == 0 ? "" : component_name;
+    auto f = [val, out_length_of_val, var_type, hthd](
+                 const System_variable_tracker &, sys_var *var) -> bool {
+      return get_variable_value(hthd, var, (char *)*val, var_type,
+                                out_length_of_val) == nullptr;
+    };
+    return System_variable_tracker::make_tracker(prefix, variable_name)
+        .access_system_variable<bool>(hthd, f, Suppress_not_found_error::YES)
+        .value_or(true);
+  } catch (...) {
+    mysql_components_handle_std_exception(__func__);
+  }
+  return true;
+}

--- a/sql/server_component/mysql_system_variable_reader_imp.h
+++ b/sql/server_component/mysql_system_variable_reader_imp.h
@@ -1,0 +1,42 @@
+/* Copyright (c) 2021, 2026, Oracle and/or its affiliates.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License, version 2.0,
+as published by the Free Software Foundation.
+
+This program is designed to work with certain software (including
+but not limited to OpenSSL) that is licensed under separate terms,
+as designated in a particular file or component or in included license
+documentation.  The authors of MySQL hereby grant you an additional
+permission to link the program and your derivative works with the
+separately licensed software that they have either included with
+the program or referenced in the documentation.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License, version 2.0, for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+
+#ifndef MYSQL_SYSTEM_VARIABLE_READER_IMP_H
+#define MYSQL_SYSTEM_VARIABLE_READER_IMP_H
+
+#include <mysql/components/service_implementation.h>
+#include <mysql/components/services/mysql_system_variable.h>
+
+/**
+  An implementation of mysql system_variable_reader for
+  the mysql server component.
+*/
+class mysql_system_variable_reader_imp {
+ public:
+  static DEFINE_BOOL_METHOD(get, (MYSQL_THD hthd, const char *variable_type,
+                                  const char *component_name,
+                                  const char *variable_name, void **val,
+                                  size_t *out_length_of_val));
+};
+
+#endif /* MYSQL_SYSTEM_VARIABLE_READER_IMP_H */

--- a/sql/server_component/mysql_system_variable_update_imp.cc
+++ b/sql/server_component/mysql_system_variable_update_imp.cc
@@ -47,7 +47,7 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 /**
   Return the system variable type given a type name.
 */
-static enum_var_type sysvar_type(const char *type_name) {
+enum_var_type sysvar_type(const char *type_name) {
   if (type_name) {
     if (!strcmp(type_name, "GLOBAL"))
       return OPT_GLOBAL;

--- a/sql/server_component/server_component.cc
+++ b/sql/server_component/server_component.cc
@@ -1,4 +1,5 @@
 /* Copyright (c) 2016, 2026, Oracle and/or its affiliates.
+   Copyright (c) 2026 VillageSQL Contributors
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License, version 2.0,
@@ -91,6 +92,8 @@ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 #include "mysql_status_variable_reader_imp.h"
 #include "mysql_stored_program_imp.h"
 #include "mysql_string_service_imp.h"
+// TODO(villagesql-rebase): drop on rebase, verbatim 9.7 has it
+#include "mysql_system_variable_reader_imp.h"
 #include "mysql_system_variable_update_imp.h"
 #include "mysql_thd_attributes_imp.h"
 #include "mysql_thd_store_imp.h"
@@ -468,6 +471,14 @@ Keyring_load_service_impl::load END_SERVICE_IMPLEMENTATION();
 BEGIN_SERVICE_IMPLEMENTATION(mysql_server, keyring_writer)
 Keyring_writer_service_impl::store,
     Keyring_writer_service_impl::remove END_SERVICE_IMPLEMENTATION();
+
+// TODO(villagesql-rebase): this file was edited to register the
+// mysql_system_variable_reader service backported from 9.7 -- only these lines
+// were added, the rest of the file is unchanged. On the 8.4->9.x rebase
+// upstream already registers this service, so drop this hunk (and the include
+// and PROVIDES_SERVICE entries added for it) and restore verbatim 9.7.
+BEGIN_SERVICE_IMPLEMENTATION(mysql_server, mysql_system_variable_reader)
+mysql_system_variable_reader_imp::get END_SERVICE_IMPLEMENTATION();
 
 BEGIN_SERVICE_IMPLEMENTATION(mysql_server, mysql_system_variable_update_string)
 mysql_system_variable_update_imp::set_string END_SERVICE_IMPLEMENTATION();
@@ -1000,6 +1011,8 @@ PROVIDES_SERVICE(mysql_server_path_filter, dynamic_loader_scheme_file),
     PROVIDES_SERVICE(mysql_server, keyring_reader_with_status),
     PROVIDES_SERVICE(mysql_server, keyring_load),
     PROVIDES_SERVICE(mysql_server, keyring_writer),
+    // TODO(villagesql-rebase): drop on rebase, verbatim 9.7 has it
+    PROVIDES_SERVICE(mysql_server, mysql_system_variable_reader),
     PROVIDES_SERVICE(mysql_server, mysql_system_variable_update_string),
     PROVIDES_SERVICE(mysql_server, mysql_system_variable_update_integer),
     PROVIDES_SERVICE(mysql_server, mysql_system_variable_update_default),


### PR DESCRIPTION
The session variable service (#1057) backported register/set/unregister and THD-local storage for component system variables, but not the companion mysql_system_variable_reader service that trunk pairs with it. That reader is the only component service that takes a scope (GLOBAL or SESSION) plus a THD, so without it there is no supported service call to read a session-scoped value; component_sys_variable_register::get_variable reads GLOBAL only.

sql/server_component/mysql_system_variable_reader_imp.h, sql/server_component/mysql_system_variable_reader_imp.cc, and sql/server_component/mysql_system_variable_bits.h are copied verbatim from MySQL 9.7 (the target rebase base). sysvar_type() in mysql_system_variable_update_imp.cc is un-static'd so the reader can link to it, which restores that file to verbatim 9.7 as well. These four files are kept byte-for-byte identical -- no VillageSQL copyright line, no reformatting -- so the eventual 8.4->9.x rebase merges them with zero conflict. villint is told to skip them below.

server_component.cc and mysql_system_variable.h receive only the reader hunks (include, service implementation, PROVIDES_SERVICE, service definition); they are not copied wholesale because 9.7-with-721 carries newer worklogs that are not on this baseline. get_variable_value() is already non-static.

villint-ignore: sql/server_component/mysql_system_variable_reader_imp.h, sql/server_component/mysql_system_variable_reader_imp.cc, sql/server_component/mysql_system_variable_bits.h, sql/server_component/mysql_system_variable_update_imp.cc
