### PR TITLE
Handle crash TODO

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-sys-vars/r/sys_var_uninstall_race.result
+++ b/mysql-test/suite/villagesql/extension/vsql-sys-vars/r/sys_var_uninstall_race.result
@@ -1,0 +1,27 @@
+SET PERSIST vsql_allow_preview_extensions = ON;
+INSTALL EXTENSION vsql_range_clamp_test;
+# con_set: park SET GLOBAL between the on_change lookup and the callback
+SET DEBUG_SYNC = 'vef_sys_var_before_on_change SIGNAL in_on_change WAIT_FOR release_on_change';
+SET GLOBAL vsql_range_clamp_test.min_setting = 200;
+# default: wait for the callback window to open
+SET DEBUG_SYNC = 'now WAIT_FOR in_on_change';
+# con_uninstall: UNINSTALL EXTENSION with the callback parked
+UNINSTALL EXTENSION vsql_range_clamp_test;
+# default: the UNINSTALL has started
+# default: and it cannot complete while the callback is parked
+SELECT COUNT(*) = 1 AS uninstall_still_running
+FROM performance_schema.threads
+WHERE PROCESSLIST_INFO LIKE 'UNINSTALL EXTENSION vsql_range_clamp_test%';
+uninstall_still_running
+1
+# default: release the callback
+SET DEBUG_SYNC = 'now SIGNAL release_on_change';
+# con_set: SET GLOBAL completes -- the callback ran against a loaded .so
+SET DEBUG_SYNC = 'RESET';
+# con_uninstall: UNINSTALL completes once the callback has returned
+# default: the extension's variables are gone
+SELECT @@global.vsql_range_clamp_test.min_setting;
+ERROR HY000: Unknown system variable 'vsql_range_clamp_test.min_setting'
+SET DEBUG_SYNC = 'RESET';
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/mysql-test/suite/villagesql/extension/vsql-sys-vars/t/sys_var_uninstall_race.test
+++ b/mysql-test/suite/villagesql/extension/vsql-sys-vars/t/sys_var_uninstall_race.test
@@ -1,0 +1,77 @@
+# UNINSTALL EXTENSION must not unload an extension's .so while one of that
+# extension's sys-var on_change callbacks is running.
+#
+# The update trampoline captures the on_change pointer under g_sys_vars_mutex,
+# releases the mutex, then calls into the extension. The
+# vef_sys_var_before_on_change sync point sits in exactly that window. If
+# UNINSTALL EXTENSION could run to completion there, the callback would jump
+# into a dlclosed .so.
+#
+# What prevents that is MySQL's own locking, not anything VillageSQL does: a
+# component variable update holds a read lock on LOCK_system_variables_hash for
+# its whole duration, and the unregister_variable call in on_depopulate_sys_var
+# needs that lock exclusively before the caller dlcloses the .so. The hash lock
+# is the one that matters: LOCK_global_system_variables is held too, but a
+# handler may drop it around blocking work, the way thread_worker's
+# on_enabled_change does. That guarantee lives in vendored MySQL internals, so
+# this test is what notices if a future merge changes them.
+
+--source include/have_debug_sync.inc
+--source include/count_sessions.inc
+
+SET PERSIST vsql_allow_preview_extensions = ON;
+INSTALL EXTENSION vsql_range_clamp_test;
+
+# Both sessions are opened before the SET GLOBAL parks: a parked SET GLOBAL
+# holds LOCK_global_system_variables, which a new connection needs to copy the
+# global variable defaults.
+connect (con_set,localhost,root);
+connect (con_uninstall,localhost,root);
+
+connection con_set;
+--echo # con_set: park SET GLOBAL between the on_change lookup and the callback
+SET DEBUG_SYNC = 'vef_sys_var_before_on_change SIGNAL in_on_change WAIT_FOR release_on_change';
+--send SET GLOBAL vsql_range_clamp_test.min_setting = 200
+
+connection default;
+--echo # default: wait for the callback window to open
+SET DEBUG_SYNC = 'now WAIT_FOR in_on_change';
+
+connection con_uninstall;
+--echo # con_uninstall: UNINSTALL EXTENSION with the callback parked
+--send UNINSTALL EXTENSION vsql_range_clamp_test
+
+connection default;
+--echo # default: the UNINSTALL has started
+--let $wait_condition = SELECT COUNT(*) = 1 FROM performance_schema.threads WHERE PROCESSLIST_INFO LIKE 'UNINSTALL EXTENSION vsql_range_clamp_test%'
+--source include/wait_condition.inc
+
+--echo # default: and it cannot complete while the callback is parked
+SELECT COUNT(*) = 1 AS uninstall_still_running
+FROM performance_schema.threads
+WHERE PROCESSLIST_INFO LIKE 'UNINSTALL EXTENSION vsql_range_clamp_test%';
+
+--echo # default: release the callback
+SET DEBUG_SYNC = 'now SIGNAL release_on_change';
+
+connection con_set;
+--echo # con_set: SET GLOBAL completes -- the callback ran against a loaded .so
+reap;
+SET DEBUG_SYNC = 'RESET';
+
+connection con_uninstall;
+--echo # con_uninstall: UNINSTALL completes once the callback has returned
+reap;
+
+connection default;
+disconnect con_set;
+disconnect con_uninstall;
+
+--echo # default: the extension's variables are gone
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SELECT @@global.vsql_range_clamp_test.min_setting;
+
+SET DEBUG_SYNC = 'RESET';
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;
+--source include/wait_until_count_sessions.inc

--- a/villagesql/services/preview/sys_var.cc
+++ b/villagesql/services/preview/sys_var.cc
@@ -114,13 +114,20 @@ static void vef_sys_var_update_trampoline(MYSQL_THD, SYS_VAR *, void *val_ptr,
   change.var_name = var_name_copy.c_str();
   if (change.type == VEF_VAR_STR && change.str_val != nullptr)
     change.str_val = str_val_copy.c_str();
-  // TODO(villagesql-crash): on_change points into extension code captured under
-  // g_sys_vars_mutex. If UNINSTALL EXTENSION races with a concurrent SET
-  // GLOBAL, on_depopulate_sys_var may erase the entry and return (allowing
-  // dlclose) while this thread holds the captured on_change pointer but has
-  // already released the lock. A drain mechanism analogous to statement_event's
-  // g_inflight counter is needed to close this window.
-  if (on_change != nullptr && change.var_name != nullptr) on_change(&change);
+
+  // on_change runs with g_sys_vars_mutex released (the callback may re-enter
+  // via SYS_VARS.set()). MySQL keeps the .so loaded across the call: a
+  // component variable update holds LOCK_system_variables_hash for read
+  // (visit_component_variable in set_var.cc), which the unregister_variable in
+  // on_depopulate_sys_var needs for write before the caller dlcloses. Hence
+  // there is no drain counter here, unlike other capabilities whose callbacks
+  // dispatch under no such lock. This assumption is validated in
+  // sys_var_uninstall_race.test and should fail if that assumption is ever
+  // broken.
+  if (on_change != nullptr && change.var_name != nullptr) {
+    DEBUG_SYNC_C("vef_sys_var_before_on_change");
+    on_change(&change);
+  }
 }
 
 }  // namespace


### PR DESCRIPTION
The crash doesn't seem to be real, but we add a test case for what it describes in case a  future version of mysql breaks the assumptions about locking.

#1090