### PR TITLE
Bump label checker version

### DIFF
--- a/.github/workflows/validate-labels.yml
+++ b/.github/workflows/validate-labels.yml
@@ -14,14 +14,14 @@ jobs:
 
         # Requires area and kind labels
         - name: Validate Area
-          uses: agilepathway/label-checker@c3d16ad512e7cea5961df85ff2486bb774caf3c5
+          uses: agilepathway/label-checker@c324842522fbd012e4f590afe3b4e591301322ed
           with:
             prefix_mode: true
             any_of: "area"
             repo_token: ${{ secrets.GITHUB_TOKEN }}
 
         - name: Validate Kind
-          uses: agilepathway/label-checker@c3d16ad512e7cea5961df85ff2486bb774caf3c5
+          uses: agilepathway/label-checker@c324842522fbd012e4f590afe3b4e591301322ed
           with:
             prefix_mode: true
             any_of: "kind"


### PR DESCRIPTION
## Description

Bumps the version of agile/label-checker to address failure caused by Debian security update (expired Bullseye). Will require manual merge since this is a fix for a failing status check.

## Related Issue

N/A

## How was this tested?

N/A, version bump

## Checklist

- [X] I have signed the CLA
- [X] I have read [CONTRIBUTING.md](https://github.com/villagesql/villagesql-server/blob/main/CONTRIBUTING.md)
- [X] I have added or updated tests as appropriate
- [X] My changes maintain compatibility with upstream MySQL 8.4
