### PR TITLE
sys_var: fix lost persisted values and a double free

### DIFF
--- a/mysql-test/suite/villagesql/extension/vsql-sys-vars/r/sys_var_depopulate_set_race.result
+++ b/mysql-test/suite/villagesql/extension/vsql-sys-vars/r/sys_var_depopulate_set_race.result
@@ -1,0 +1,27 @@
+SET PERSIST vsql_allow_preview_extensions = ON;
+INSTALL EXTENSION vsql_range_clamp_test;
+# Give label a heap-allocated value, so there is an old buffer to free
+SET GLOBAL vsql_range_clamp_test.label = 'first';
+SELECT @@global.vsql_range_clamp_test.label;
+@@global.vsql_range_clamp_test.label
+first
+# con_uninstall: park UNINSTALL just after the g_sys_vars entries go
+SET DEBUG_SYNC = 'vef_sys_var_after_depopulate_erase SIGNAL erased WAIT_FOR continue_uninstall';
+UNINSTALL EXTENSION vsql_range_clamp_test;
+SET DEBUG_SYNC = 'now WAIT_FOR erased';
+# con_set: SET GLOBAL with the entry gone but the variable still
+# registered; the trampoline runs and its lookup misses
+SET GLOBAL vsql_range_clamp_test.label = 'second';
+# The new value must have been stored, not dropped
+SELECT @@global.vsql_range_clamp_test.label;
+@@global.vsql_range_clamp_test.label
+second
+# Let UNINSTALL finish: it frees the string the storage points at
+SET DEBUG_SYNC = 'now SIGNAL continue_uninstall';
+SET DEBUG_SYNC = 'RESET';
+# The extension's variables are gone
+SELECT @@global.vsql_range_clamp_test.label;
+ERROR HY000: Unknown system variable 'vsql_range_clamp_test.label'
+SET DEBUG_SYNC = 'RESET';
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/mysql-test/suite/villagesql/extension/vsql-sys-vars/r/sys_var_persist_on_change.result
+++ b/mysql-test/suite/villagesql/extension/vsql-sys-vars/r/sys_var_persist_on_change.result
@@ -1,0 +1,31 @@
+SET PERSIST vsql_allow_preview_extensions = ON;
+INSTALL EXTENSION vsql_range_clamp_test;
+# Defaults
+SELECT @@global.vsql_range_clamp_test.min_setting;
+@@global.vsql_range_clamp_test.min_setting
+0
+SELECT @@global.vsql_range_clamp_test.max_setting;
+@@global.vsql_range_clamp_test.max_setting
+100
+# SET PERSIST applies immediately: min_setting takes 200, on_change
+# raises max_setting to match
+SET PERSIST vsql_range_clamp_test.min_setting = 200;
+SELECT @@global.vsql_range_clamp_test.min_setting;
+@@global.vsql_range_clamp_test.min_setting
+200
+SELECT @@global.vsql_range_clamp_test.max_setting;
+@@global.vsql_range_clamp_test.max_setting
+200
+# Restart with the extension still installed
+# restart: --veb-dir=MYSQLTEST_VARDIR/mysqld.1/veb/
+# The persisted value must be back
+SELECT @@global.vsql_range_clamp_test.min_setting;
+@@global.vsql_range_clamp_test.min_setting
+200
+SELECT @@global.vsql_range_clamp_test.max_setting;
+@@global.vsql_range_clamp_test.max_setting
+200
+RESET PERSIST vsql_range_clamp_test.min_setting;
+UNINSTALL EXTENSION vsql_range_clamp_test;
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/mysql-test/suite/villagesql/extension/vsql-sys-vars/r/sys_var_persist_runtime_install.result
+++ b/mysql-test/suite/villagesql/extension/vsql-sys-vars/r/sys_var_persist_runtime_install.result
@@ -1,0 +1,40 @@
+CALL mtr.add_suppression("Currently unknown variable 'vsql_range_clamp_test.min_setting' was read from the persisted config file.");
+CALL mtr.add_suppression("Currently unknown variable 'vsql_range_clamp_test.label' was read from the persisted config file.");
+SET PERSIST vsql_allow_preview_extensions = ON;
+INSTALL EXTENSION vsql_range_clamp_test;
+# Persist both variables so the server writes them to mysqld-auto.cnf
+SET PERSIST vsql_range_clamp_test.min_setting = 200;
+SET PERSIST vsql_range_clamp_test.label = 'persisted';
+SELECT @@global.vsql_range_clamp_test.min_setting;
+@@global.vsql_range_clamp_test.min_setting
+200
+SELECT @@global.vsql_range_clamp_test.label;
+@@global.vsql_range_clamp_test.label
+persisted
+SELECT vsql_range_clamp_test.last_label();
+vsql_range_clamp_test.last_label()
+persisted
+# UNINSTALL deletes the persisted values; restore the saved file so the
+# entries survive for an extension that is no longer installed
+UNINSTALL EXTENSION vsql_range_clamp_test;
+# Restart: the extension is not installed, so the persisted entries are
+# parked as unknown variables
+# restart: --veb-dir=MYSQLTEST_VARDIR/mysqld.1/veb/
+# Install at runtime: register_variable applies the parked values
+INSTALL EXTENSION vsql_range_clamp_test;
+# The persisted values must have reached the extension
+SELECT @@global.vsql_range_clamp_test.min_setting;
+@@global.vsql_range_clamp_test.min_setting
+200
+SELECT @@global.vsql_range_clamp_test.label;
+@@global.vsql_range_clamp_test.label
+persisted
+# ... and on_change must have fired for them
+SELECT vsql_range_clamp_test.last_label();
+vsql_range_clamp_test.last_label()
+persisted
+RESET PERSIST vsql_range_clamp_test.min_setting;
+RESET PERSIST vsql_range_clamp_test.label;
+UNINSTALL EXTENSION vsql_range_clamp_test;
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/mysql-test/suite/villagesql/extension/vsql-sys-vars/t/sys_var_depopulate_set_race.test
+++ b/mysql-test/suite/villagesql/extension/vsql-sys-vars/t/sys_var_depopulate_set_race.test
@@ -1,0 +1,60 @@
+# A SET GLOBAL that happens between on_depopulate_sys_var erasing the g_sys_vars
+# entries and unregister_variable removing the variable from MySQL is still
+# dispatched to vef_sys_var_update_trampoline, which then finds no entry.
+#
+# The trampoline's typed write does not depend on that lookup, and must not:
+# for a MEMALLOC string, plugin_var_memalloc_global_update frees the old buffer
+# as soon as the update func returns. A skipped write would leave the
+# extension's storage pointing at that freed buffer, and the unregister_variable
+# that follows would free it a second time. This test verifies that this
+# situation can no longer happen (used to crash).
+
+--source include/have_debug_sync.inc
+--source include/count_sessions.inc
+
+SET PERSIST vsql_allow_preview_extensions = ON;
+INSTALL EXTENSION vsql_range_clamp_test;
+
+--echo # Give label a heap-allocated value, so there is an old buffer to free
+SET GLOBAL vsql_range_clamp_test.label = 'first';
+SELECT @@global.vsql_range_clamp_test.label;
+
+connect (con_set,localhost,root);
+connect (con_uninstall,localhost,root);
+
+connection con_uninstall;
+--echo # con_uninstall: park UNINSTALL just after the g_sys_vars entries go
+SET DEBUG_SYNC = 'vef_sys_var_after_depopulate_erase SIGNAL erased WAIT_FOR continue_uninstall';
+--send UNINSTALL EXTENSION vsql_range_clamp_test
+
+connection default;
+SET DEBUG_SYNC = 'now WAIT_FOR erased';
+
+connection con_set;
+--echo # con_set: SET GLOBAL with the entry gone but the variable still
+--echo # registered; the trampoline runs and its lookup misses
+SET GLOBAL vsql_range_clamp_test.label = 'second';
+
+--echo # The new value must have been stored, not dropped
+SELECT @@global.vsql_range_clamp_test.label;
+
+connection default;
+--echo # Let UNINSTALL finish: it frees the string the storage points at
+SET DEBUG_SYNC = 'now SIGNAL continue_uninstall';
+
+connection con_uninstall;
+reap;
+SET DEBUG_SYNC = 'RESET';
+
+connection default;
+disconnect con_set;
+disconnect con_uninstall;
+
+--echo # The extension's variables are gone
+--error ER_UNKNOWN_SYSTEM_VARIABLE
+SELECT @@global.vsql_range_clamp_test.label;
+
+SET DEBUG_SYNC = 'RESET';
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;
+--source include/wait_until_count_sessions.inc

--- a/mysql-test/suite/villagesql/extension/vsql-sys-vars/t/sys_var_persist_on_change.test
+++ b/mysql-test/suite/villagesql/extension/vsql-sys-vars/t/sys_var_persist_on_change.test
@@ -1,0 +1,44 @@
+# A persisted value must reach an extension variable that declares on_change,
+# and its callback must fire, across a restart with the extension installed.
+#
+# At startup, extensions load from init_server_components() before
+# mysqld_server_started is set, so register_variable skips its inline
+# persisted-value apply (component_sys_var_service.cc). The value is applied
+# later by the main startup pass, once on_populate_sys_var has recorded the
+# variable, so the update trampoline finds it.
+# sys_var_persist_runtime_install.test covers the INSTALL EXTENSION path,
+# where that ordering does not hold.
+#
+# min_setting = 200 trips the extension's on_change, which raises max_setting
+# to match, so max_setting is the witness that the callback ran. It survives
+# here because the persisted apply happens after all three variables are
+# registered, unlike the runtime-install case, where max_setting registers
+# afterwards and handle_options writes its own default over it.
+
+SET PERSIST vsql_allow_preview_extensions = ON;
+INSTALL EXTENSION vsql_range_clamp_test;
+
+--echo # Defaults
+SELECT @@global.vsql_range_clamp_test.min_setting;
+SELECT @@global.vsql_range_clamp_test.max_setting;
+
+--echo # SET PERSIST applies immediately: min_setting takes 200, on_change
+--echo # raises max_setting to match
+SET PERSIST vsql_range_clamp_test.min_setting = 200;
+SELECT @@global.vsql_range_clamp_test.min_setting;
+SELECT @@global.vsql_range_clamp_test.max_setting;
+
+--echo # Restart with the extension still installed
+--let $veb_dir = `SELECT @@veb_dir`
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--let $restart_parameters = restart: --veb-dir=$veb_dir
+--source include/restart_mysqld.inc
+
+--echo # The persisted value must be back
+SELECT @@global.vsql_range_clamp_test.min_setting;
+SELECT @@global.vsql_range_clamp_test.max_setting;
+
+RESET PERSIST vsql_range_clamp_test.min_setting;
+UNINSTALL EXTENSION vsql_range_clamp_test;
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/mysql-test/suite/villagesql/extension/vsql-sys-vars/t/sys_var_persist_runtime_install.test
+++ b/mysql-test/suite/villagesql/extension/vsql-sys-vars/t/sys_var_persist_runtime_install.test
@@ -1,0 +1,76 @@
+# A persisted value must reach an extension variable that declares on_change,
+# and its callback must fire, when the extension is installed at runtime.
+#
+# register_variable applies any already-persisted value for the variable inline
+# (component_sys_var_service.cc: set_persisted_options -> sql_set_variables),
+# but only once mysqld_server_started is true, so this is reachable on
+# INSTALL EXTENSION, not at startup. That inline apply calls the variable's
+# update func, which for an on_change variable is
+# vef_sys_var_update_trampoline, and it runs while register_variable is still
+# on the stack. This works because on_populate_sys_var records the variable in
+# g_sys_vars before calling register_variable, so the trampoline can find its
+# on_change, and the trampoline's typed write does not depend on that lookup
+# succeeding. Before either was in place, the persisted value was lost, and for
+# the label string the storage was left pointing at a buffer MySQL had already
+# freed, which UNINSTALL then freed a second time.
+#
+# Getting a persistent entry for an uninstalled extension: UNINSTALL EXTENSION
+# deletes persisted values on the way out, so the file is saved beforehand and
+# restored after, leaving the entry behind for the next INSTALL to apply.
+#
+# Two pieces of data for this test and their meaning:
+#   min_setting  the value reached the extension's storage. A 0 here means the
+#                trampoline's write depended on finding its g_sys_vars entry
+#   last_label   on_change fired. The handler copies into its own buffer,
+#                which no later registration writes over. Empty here means the
+#                variable was recorded after register_variable, not before
+#
+# max_setting is deliberately not checked: on_change raises it when min_setting
+# is applied, but max_setting registers afterwards and handle_options writes
+# its own default over that.
+
+CALL mtr.add_suppression("Currently unknown variable 'vsql_range_clamp_test.min_setting' was read from the persisted config file.");
+CALL mtr.add_suppression("Currently unknown variable 'vsql_range_clamp_test.label' was read from the persisted config file.");
+
+SET PERSIST vsql_allow_preview_extensions = ON;
+INSTALL EXTENSION vsql_range_clamp_test;
+
+--echo # Persist both variables so the server writes them to mysqld-auto.cnf
+SET PERSIST vsql_range_clamp_test.min_setting = 200;
+SET PERSIST vsql_range_clamp_test.label = 'persisted';
+SELECT @@global.vsql_range_clamp_test.min_setting;
+SELECT @@global.vsql_range_clamp_test.label;
+SELECT vsql_range_clamp_test.last_label();
+
+--let $datadir = `SELECT @@datadir`
+--copy_file $datadir/mysqld-auto.cnf $MYSQLTEST_VARDIR/tmp/auto_with_persist.cnf
+
+--echo # UNINSTALL deletes the persisted values; restore the saved file so the
+--echo # entries survive for an extension that is no longer installed
+UNINSTALL EXTENSION vsql_range_clamp_test;
+--remove_file $datadir/mysqld-auto.cnf
+--copy_file $MYSQLTEST_VARDIR/tmp/auto_with_persist.cnf $datadir/mysqld-auto.cnf
+--remove_file $MYSQLTEST_VARDIR/tmp/auto_with_persist.cnf
+
+--echo # Restart: the extension is not installed, so the persisted entries are
+--echo # parked as unknown variables
+--let $veb_dir = `SELECT @@veb_dir`
+--replace_result $MYSQLTEST_VARDIR MYSQLTEST_VARDIR
+--let $restart_parameters = restart: --veb-dir=$veb_dir
+--source include/restart_mysqld.inc
+
+--echo # Install at runtime: register_variable applies the parked values
+INSTALL EXTENSION vsql_range_clamp_test;
+
+--echo # The persisted values must have reached the extension
+SELECT @@global.vsql_range_clamp_test.min_setting;
+SELECT @@global.vsql_range_clamp_test.label;
+
+--echo # ... and on_change must have fired for them
+SELECT vsql_range_clamp_test.last_label();
+
+RESET PERSIST vsql_range_clamp_test.min_setting;
+RESET PERSIST vsql_range_clamp_test.label;
+UNINSTALL EXTENSION vsql_range_clamp_test;
+SET PERSIST vsql_allow_preview_extensions = OFF;
+RESET PERSIST vsql_allow_preview_extensions;

--- a/villagesql/services/preview/sys_var.cc
+++ b/villagesql/services/preview/sys_var.cc
@@ -29,6 +29,7 @@
 #include "mysql/components/services/mysql_system_variable.h"
 #include "mysql/service_plugin_registry.h"
 #include "sql/persisted_variable.h"
+#include "sql/sql_plugin_var.h"
 #include "villagesql/include/error.h"
 #include "villagesql/sdk/include/villagesql/abi/preview/sys_var.h"
 #include "villagesql/services/sys_var_access.h"
@@ -67,53 +68,72 @@ std::vector<RegisteredSysVar> g_sys_vars;
 // Generic update trampoline used when on_change is non-null.
 // Performs the default typed update (mirroring MySQL's update_func_* family)
 // then calls the extension callback.
-static void vef_sys_var_update_trampoline(MYSQL_THD, SYS_VAR *, void *val_ptr,
-                                          const void *save) {
-  vef_sys_var_on_change_func_t on_change = nullptr;
+static void vef_sys_var_update_trampoline(MYSQL_THD, SYS_VAR *var,
+                                          void *val_ptr, const void *save) {
+  // MySQL hands us the new value in save and expects it stored in val_ptr. For
+  // a MEMALLOC string it frees the old buffer as soon as this returns
+  // (plugin_var_memalloc_global_update), so not storing the new one would leave
+  // val_ptr pointing at freed memory for UNINSTALL to free a second time. The
+  // write below is therefore unconditional, and takes its type from MySQL's
+  // descriptor rather than from a g_sys_vars lookup that can miss. Concurrent
+  // global updates are serialized by MySQL on LOCK_global_system_variables.
   vef_sys_var_change_t change{};
-  // These copies own the strings so change.var_name and change.str_val remain
-  // valid after the lock is released. A concurrent on_depopulate_sys_var may
-  // erase the g_sys_vars entry (invalidating var_name), and a concurrent SET
-  // may free the old string value (invalidating str_val).
+  switch (var->flags & PLUGIN_VAR_TYPEMASK) {
+    case PLUGIN_VAR_BOOL:
+      change.type = VEF_VAR_BOOL;
+      change.bool_val = *static_cast<const bool *>(save);
+      *static_cast<bool *>(val_ptr) = change.bool_val;
+      break;
+    case PLUGIN_VAR_LONGLONG:
+      change.type = VEF_VAR_INT;
+      change.int_val = *static_cast<const long long *>(save);
+      *static_cast<long long *>(val_ptr) = change.int_val;
+      break;
+    case PLUGIN_VAR_DOUBLE:
+      change.type = VEF_VAR_DOUBLE;
+      change.dbl_val = *static_cast<const double *>(save);
+      *static_cast<double *>(val_ptr) = change.dbl_val;
+      break;
+    case PLUGIN_VAR_STR:
+      change.type = VEF_VAR_STR;
+      change.str_val = *static_cast<const char *const *>(save);
+      *static_cast<const char **>(val_ptr) = change.str_val;
+      break;
+    default:
+      // on_populate_sys_var registers no other types, and writing val_ptr
+      // would mean guessing its width.
+      LogVSQL(ERROR_LEVEL,
+              "System variable update trampoline: unexpected type 0x%x",
+              var->flags & PLUGIN_VAR_TYPEMASK);
+      return;
+  }
+
+  // on_change and the variable name do come from the registry. A miss means the
+  // variable is still registering or has already been depopulated: the write
+  // above stands either way, there is just no callback to run.
+  vef_sys_var_on_change_func_t on_change = nullptr;
   std::string var_name_copy;
-  std::string str_val_copy;
   {
     std::lock_guard<std::mutex> lock(g_sys_vars_mutex);
     for (const RegisteredSysVar &v : g_sys_vars) {
       if (v.value_ptr == val_ptr) {
         on_change = v.on_change;
         var_name_copy = v.var_name;
-        change.type = v.type;
-        // Perform the typed update (mirroring MySQL's update_func_* family)
-        // and capture the new value for the callback, all under the lock so
-        // a concurrent SET cannot overwrite val_ptr before we finish.
-        switch (v.type) {
-          case VEF_VAR_BOOL:
-            change.bool_val = *static_cast<const bool *>(save);
-            *static_cast<bool *>(val_ptr) = change.bool_val;
-            break;
-          case VEF_VAR_INT:
-            change.int_val = *static_cast<const long long *>(save);
-            *static_cast<long long *>(val_ptr) = change.int_val;
-            break;
-          case VEF_VAR_DOUBLE:
-            change.dbl_val = *static_cast<const double *>(save);
-            *static_cast<double *>(val_ptr) = change.dbl_val;
-            break;
-          case VEF_VAR_STR:
-            change.str_val = *static_cast<const char *const *>(save);
-            *static_cast<const char **>(val_ptr) = change.str_val;
-            if (change.str_val != nullptr) str_val_copy = change.str_val;
-            break;
-        }
         break;
       }
     }
   }
+  if (on_change == nullptr) return;
 
+  // These copies own the strings so change.var_name and change.str_val stay
+  // valid once the lock is released: a concurrent on_depopulate_sys_var may
+  // erase the entry, and the next SET frees this buffer as its old value.
+  std::string str_val_copy;
   change.var_name = var_name_copy.c_str();
-  if (change.type == VEF_VAR_STR && change.str_val != nullptr)
+  if (change.type == VEF_VAR_STR && change.str_val != nullptr) {
+    str_val_copy = change.str_val;
     change.str_val = str_val_copy.c_str();
+  }
 
   // on_change runs with g_sys_vars_mutex released (the callback may re-enter
   // via SYS_VARS.set()). MySQL keeps the .so loaded across the call: a
@@ -124,10 +144,8 @@ static void vef_sys_var_update_trampoline(MYSQL_THD, SYS_VAR *, void *val_ptr,
   // dispatch under no such lock. This assumption is validated in
   // sys_var_uninstall_race.test and should fail if that assumption is ever
   // broken.
-  if (on_change != nullptr && change.var_name != nullptr) {
-    DEBUG_SYNC_C("vef_sys_var_before_on_change");
-    on_change(&change);
-  }
+  DEBUG_SYNC_C("vef_sys_var_before_on_change");
+  on_change(&change);
 }
 
 }  // namespace
@@ -310,9 +328,31 @@ bool on_populate_sys_var(const PopulateContext &ctx,
     mysql_sys_var_update_func update_fn =
         v->on_change != nullptr ? vef_sys_var_update_trampoline : nullptr;
 
+    // Record the variable before registering it: register_variable applies an
+    // already-persisted value inline, and the trampoline looks the variable up
+    // by storage pointer to find its on_change. Registering first would skip
+    // that callback for the persisted value.
+    {
+      std::lock_guard<std::mutex> lock(g_sys_vars_mutex);
+      g_sys_vars.push_back({extension_name, std::string(v->name), v->type,
+                            value_ptr, v->on_change, ctx.capability_config});
+    }
+
     if (reg_svc->register_variable(extension_name.c_str(), v->name, flags,
                                    v->comment ? v->comment : "", nullptr,
                                    update_fn, check_arg, value_ptr)) {
+      // This variable never registered, so drop its entry before the rollback
+      // below, which unregisters by name.
+      {
+        std::lock_guard<std::mutex> lock(g_sys_vars_mutex);
+        auto it = std::remove_if(g_sys_vars.begin(), g_sys_vars.end(),
+                                 [&](const RegisteredSysVar &rv) {
+                                   return rv.capability_config ==
+                                              ctx.capability_config &&
+                                          rv.value_ptr == value_ptr;
+                                 });
+        g_sys_vars.erase(it, g_sys_vars.end());
+      }
       LogVSQL(ERROR_LEVEL,
               "Failed to register system variable '%s' for extension '%s'",
               v->name, extension_name.c_str());
@@ -346,12 +386,6 @@ bool on_populate_sys_var(const PopulateContext &ctx,
       return true;
     }
 
-    {
-      std::lock_guard<std::mutex> lock(g_sys_vars_mutex);
-      g_sys_vars.push_back({extension_name, std::string(v->name), v->type,
-                            value_ptr, v->on_change, ctx.capability_config});
-    }
-
     LogVSQL(INFORMATION_LEVEL,
             "Registered system variable '%s' for extension '%s'", v->name,
             extension_name.c_str());
@@ -377,6 +411,12 @@ void on_depopulate_sys_var(const DepopulateContext &ctx) {
         });
     g_sys_vars.erase(it, g_sys_vars.end());
   }
+
+  // The variables are out of g_sys_vars but stay registered with MySQL until
+  // unregister_variable below, so a concurrent SET still reaches the update
+  // trampoline and finds no entry for them. The sync point lets a test run that
+  // SET here; see sys_var_depopulate_set_race.test.
+  DEBUG_SYNC_C("vef_sys_var_after_depopulate_erase");
 
   if (var_names.empty()) return;
 


### PR DESCRIPTION
vef_sys_var_update_trampoline, the update func we hand MySQL for an extension variable that declares on_change, looked itself up in g_sys_vars by storage pointer and did nothing at all when the lookup missed.

register_variable applies an already-persisted value inline, before on_populate_sys_var has recorded the variable, so the lookup missed there. For an INT the persisted value was silently dropped. For a MEMALLOC string it was worse: plugin_var_memalloc_global_update frees the old buffer as soon as the update func returns, so the storage was left pointing at freed memory and UNINSTALL EXTENSION freed it again (an assert in my_internal_free on debug builds, heap corruption on release).

This commit does two things:

- The typed write is now unconditional, taking its type from MySQL's SYS_VAR descriptor, so a registry miss can no longer skip it. g_sys_vars is consulted only for on_change and var_name, where a miss just means there is no callback to run.

- on_populate_sys_var records the variable before registering it, so on_change fires for a persisted value applied at INSTALL.

sys_var_persist_runtime_install and sys_var_depopulate_set_race both crashed before this change. sys_var_persist_on_change covers the startup path, which was correct.

Fixes #1090
