### PR TITLE
More time for slow max_parts tests

### DIFF
--- a/mysql-test/suite/max_parts/t/partition_max_parts_hash_innodb-master.opt
+++ b/mysql-test/suite/max_parts/t/partition_max_parts_hash_innodb-master.opt
@@ -1,3 +1,4 @@
 --open-files-limit=65535
 --local-infile=ON
 --secure-file-priv=$MYSQL_TMP_DIR
+--testcase-timeout=45

--- a/mysql-test/suite/max_parts/t/partition_max_parts_key_innodb-master.opt
+++ b/mysql-test/suite/max_parts/t/partition_max_parts_key_innodb-master.opt
@@ -1,3 +1,4 @@
 --open-files-limit=65535
 --local-infile=ON
 --secure-file-priv=$MYSQL_TMP_DIR
+--testcase-timeout=45

--- a/mysql-test/suite/max_parts/t/partition_max_parts_list_innodb-master.opt
+++ b/mysql-test/suite/max_parts/t/partition_max_parts_list_innodb-master.opt
@@ -1,3 +1,4 @@
 --open-files-limit=65535
 --local-infile=ON
 --secure-file-priv=$MYSQL_TMP_DIR
+--testcase-timeout=45

--- a/mysql-test/suite/max_parts/t/partition_max_parts_range_innodb-master.opt
+++ b/mysql-test/suite/max_parts/t/partition_max_parts_range_innodb-master.opt
@@ -1,3 +1,4 @@
 --open-files-limit=65535
 --local-infile=ON
 --secure-file-priv=$MYSQL_TMP_DIR
+--testcase-timeout=45

--- a/mysql-test/suite/max_parts/t/partition_max_sub_parts_key_list_innodb-master.opt
+++ b/mysql-test/suite/max_parts/t/partition_max_sub_parts_key_list_innodb-master.opt
@@ -1,3 +1,4 @@
 --open-files-limit=65535
 --local-infile=ON
 --secure-file-priv=$MYSQL_TMP_DIR
+--testcase-timeout=45

--- a/mysql-test/suite/max_parts/t/partition_max_sub_parts_key_range_innodb-master.opt
+++ b/mysql-test/suite/max_parts/t/partition_max_sub_parts_key_range_innodb-master.opt
@@ -1,3 +1,4 @@
 --open-files-limit=65535
 --local-infile=ON
 --secure-file-priv=$MYSQL_TMP_DIR
+--testcase-timeout=45

--- a/mysql-test/suite/max_parts/t/partition_max_sub_parts_list_innodb-master.opt
+++ b/mysql-test/suite/max_parts/t/partition_max_sub_parts_list_innodb-master.opt
@@ -1,3 +1,4 @@
 --open-files-limit=65535
 --local-infile=ON
 --secure-file-priv=$MYSQL_TMP_DIR
+--testcase-timeout=45

--- a/mysql-test/suite/max_parts/t/partition_max_sub_parts_range_innodb-master.opt
+++ b/mysql-test/suite/max_parts/t/partition_max_sub_parts_range_innodb-master.opt
@@ -1,3 +1,4 @@
 --open-files-limit=65535
 --local-infile=ON
 --secure-file-priv=$MYSQL_TMP_DIR
+--testcase-timeout=45


### PR DESCRIPTION
## Description

Bumps the time limit for several max_parts tests to 45 minutes.

These tests pass in a release build, taking roughly 60 seconds.  They seem to be much slower
in debug builds.  In debug builds, they time out at 900 seconds / 15 minutes.

## Related Issue

Part of the Notify #eng-health when nightly build and test fails #771 effort.
